### PR TITLE
Sanitize Akuvox UI state payload

### DIFF
--- a/custom_components/AK_Access_ctrl/const.py
+++ b/custom_components/AK_Access_ctrl/const.py
@@ -36,3 +36,7 @@ DEFAULT_VERIFY_SSL    = False
 DEFAULT_POLL_INTERVAL = 30  # seconds
 
 EVENT_NON_KEY_ACCESS_GRANTED = "akuvox_non_key_access_granted"
+
+ADMIN_DASHBOARD_URL_PATH = "akuvox-access-control"
+ADMIN_DASHBOARD_TITLE = "Akuvox Access Control"
+ADMIN_DASHBOARD_ICON = "mdi:door-closed-lock"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,49 @@ homeassistant.core.callback = _callback
 helpers = types.ModuleType("homeassistant.helpers")
 helpers.update_coordinator = types.ModuleType("homeassistant.helpers.update_coordinator")
 helpers.update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
+helpers.storage = types.ModuleType("homeassistant.helpers.storage")
+
+
+class _Store:  # pragma: no cover - minimal stub
+    def __init__(self, hass, version, key):
+        self.hass = hass
+        self.version = version
+        self.key = key
+
+    async def async_load(self):
+        return None
+
+    async def async_save(self, data):
+        return None
+
+
+helpers.storage.Store = _Store
+helpers.event = types.ModuleType("homeassistant.helpers.event")
+
+
+async def _event_stub(*args, **kwargs):  # pragma: no cover - simple coroutine stub
+    return None
+
+
+helpers.event.async_call_later = _event_stub
+helpers.event.async_track_time_change = _event_stub
+helpers.event.async_track_time_interval = _event_stub
+helpers.aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+
+
+async def _async_get_clientsession(hass):  # pragma: no cover - simple stub
+    return ClientSession()
+
+
+helpers.aiohttp_client.async_get_clientsession = _async_get_clientsession
+helpers.network = types.ModuleType("homeassistant.helpers.network")
+
+
+def _get_url(*args, **kwargs):  # pragma: no cover - simple stub
+    return "http://example.com"
+
+
+helpers.network.get_url = _get_url
 
 util = types.ModuleType("homeassistant.util")
 util.dt = types.ModuleType("homeassistant.util.dt")
@@ -103,6 +146,117 @@ class BasicAuth:  # pragma: no cover - simple stub
 
 aiohttp.ClientSession = ClientSession
 aiohttp.BasicAuth = BasicAuth
+aiohttp.web = types.ModuleType("aiohttp.web")
+
+
+class _WebRequest:  # pragma: no cover - minimal stub
+    def __init__(self):
+        self.app = {}
+        self.headers = {}
+        self.query = {}
+
+
+class _WebResponse:  # pragma: no cover - minimal stub
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def _json_response(data=None, status=200):  # pragma: no cover - simple stub
+    return {"data": data, "status": status}
+
+
+class _HTTPException(Exception):  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        self.status = kwargs.get("status")
+
+
+class _HTTPFound(_HTTPException):
+    pass
+
+
+class _HTTPNotFound(_HTTPException):
+    pass
+
+
+class _HTTPForbidden(_HTTPException):
+    pass
+
+
+aiohttp.web.Request = _WebRequest
+aiohttp.web.FileResponse = _WebResponse
+aiohttp.web.Response = _WebResponse
+aiohttp.web.json_response = _json_response
+aiohttp.web.HTTPFound = _HTTPFound
+aiohttp.web.HTTPNotFound = _HTTPNotFound
+aiohttp.web.HTTPForbidden = _HTTPForbidden
+
+components = types.ModuleType("homeassistant.components")
+
+
+class _FrontendModule(types.ModuleType):
+    def __init__(self) -> None:
+        super().__init__("homeassistant.components.frontend")
+        self.registered: list[dict] = []
+        self.removed: list[str] = []
+
+    def async_register_built_in_panel(
+        self,
+        hass,
+        component_name,
+        sidebar_title=None,
+        sidebar_icon=None,
+        frontend_url_path=None,
+        config=None,
+        require_admin=False,
+        *,
+        update=False,
+        config_panel_domain=None,
+    ):
+        self.registered.append(
+            {
+                "component_name": component_name,
+                "sidebar_title": sidebar_title,
+                "sidebar_icon": sidebar_icon,
+                "frontend_url_path": frontend_url_path,
+                "config": config,
+                "require_admin": require_admin,
+                "update": update,
+            }
+        )
+        hass.data.setdefault("frontend_panels", {})[
+            frontend_url_path or component_name
+        ] = {
+            "component_name": component_name,
+            "config": config,
+            "require_admin": require_admin,
+        }
+
+    def async_remove_panel(self, hass, frontend_url_path):
+        self.removed.append(frontend_url_path)
+        hass.data.setdefault("frontend_panels", {}).pop(frontend_url_path, None)
+
+
+frontend = _FrontendModule()
+components.frontend = frontend
+components.http = types.ModuleType("homeassistant.components.http")
+components.http.view = types.ModuleType("homeassistant.components.http.view")
+components.http.view.HomeAssistantView = type(
+    "HomeAssistantView",
+    (),
+    {"__module__": "homeassistant.components.http.view"},
+)
+components.persistent_notification = types.ModuleType(
+    "homeassistant.components.persistent_notification"
+)
+
+
+async def _notify_stub(*args, **kwargs):  # pragma: no cover - simple stub
+    return None
+
+
+components.persistent_notification.async_create = _notify_stub
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -118,10 +272,21 @@ sys.modules.setdefault("homeassistant", homeassistant)
 sys.modules.setdefault("homeassistant.core", homeassistant.core)
 sys.modules.setdefault("homeassistant.helpers", helpers)
 sys.modules.setdefault("homeassistant.helpers.update_coordinator", helpers.update_coordinator)
+sys.modules.setdefault("homeassistant.helpers.storage", helpers.storage)
+sys.modules.setdefault("homeassistant.helpers.event", helpers.event)
+sys.modules.setdefault("homeassistant.helpers.aiohttp_client", helpers.aiohttp_client)
+sys.modules.setdefault("homeassistant.helpers.network", helpers.network)
 sys.modules.setdefault("homeassistant.const", const)
 sys.modules.setdefault("homeassistant.config_entries", config_entries)
 sys.modules.setdefault("homeassistant.util", util)
 sys.modules.setdefault("homeassistant.util.dt", util.dt)
+sys.modules.setdefault("homeassistant.components", components)
+sys.modules.setdefault("homeassistant.components.http", components.http)
+sys.modules.setdefault("homeassistant.components.http.view", components.http.view)
+sys.modules.setdefault(
+    "homeassistant.components.persistent_notification", components.persistent_notification
+)
+sys.modules.setdefault("homeassistant.components.frontend", frontend)
 sys.modules.setdefault("custom_components", custom_components)
 sys.modules.setdefault("custom_components.AK_Access_ctrl", akuvox_pkg)
 sys.modules.setdefault("aiohttp", aiohttp)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,127 @@
+import importlib
+import json
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+from aiohttp import web
+
+from custom_components.AK_Access_ctrl.const import (
+    ADMIN_DASHBOARD_ICON,
+    ADMIN_DASHBOARD_TITLE,
+    ADMIN_DASHBOARD_URL_PATH,
+    DOMAIN,
+)
+
+from custom_components.AK_Access_ctrl.http import AkuvoxUIView
+
+akuvox_init = importlib.import_module("custom_components.AK_Access_ctrl.__init__")
+
+
+def test_register_admin_dashboard_creates_panel(hass):
+    frontend = sys.modules["homeassistant.components.frontend"]
+    frontend.registered.clear()
+    frontend.removed.clear()
+    hass.data.clear()
+
+    assert akuvox_init._register_admin_dashboard(hass) is True
+
+    assert frontend.registered
+    panel = frontend.registered[-1]
+    assert panel["component_name"] == "iframe"
+    assert panel["sidebar_title"] == ADMIN_DASHBOARD_TITLE
+    assert panel["sidebar_icon"] == ADMIN_DASHBOARD_ICON
+    assert panel["frontend_url_path"] == ADMIN_DASHBOARD_URL_PATH
+    assert panel["config"] == {"url": "/akuvox-ac/"}
+    assert panel["require_admin"] is True
+
+    stored = hass.data["frontend_panels"][ADMIN_DASHBOARD_URL_PATH]
+    assert stored["require_admin"] is True
+
+    akuvox_init._remove_admin_dashboard(hass)
+    assert ADMIN_DASHBOARD_URL_PATH in frontend.removed
+    assert ADMIN_DASHBOARD_URL_PATH not in hass.data.get("frontend_panels", {})
+
+
+class _DummyUsersStore:
+    def __init__(self):
+        self.data = {
+            "users": {
+                "HA001": {
+                    "name": "Stored User",
+                    "groups": {"Default", "VIP"},
+                    "pin": "1234",
+                    "status": "active",
+                }
+            }
+        }
+
+    def all(self):
+        return dict(self.data.get("users") or {})
+
+    async def async_save(self):
+        return None
+
+
+def test_ui_state_sanitizes_sets_and_datetimes(hass):
+    hass.data.setdefault(DOMAIN, {})
+
+    coord = SimpleNamespace(
+        device_name="Panel A",
+        friendly_name="Panel A",
+        health={
+            "name": "Panel A",
+            "device_type": "Door",
+            "ip": "1.2.3.4",
+            "online": True,
+            "sync_status": "pending",
+            "last_sync": datetime(2024, 5, 1, 12, 30),
+        },
+        events=[{"timestamp": datetime(2024, 5, 1, 12, 0), "Event": "Sync"}],
+        users=[
+            {
+                "ID": "HA001",
+                "Name": "Door User",
+                "Groups": {"Default", "VIP"},
+                "LastAccess": datetime(2024, 5, 1, 11, 0),
+            }
+        ],
+    )
+
+    hass.data[DOMAIN].update(
+        {
+            "entry-1": {
+                "coordinator": coord,
+                "options": {"exit_device": False},
+            },
+            "users_store": _DummyUsersStore(),
+            "schedules_store": SimpleNamespace(all=lambda: {"24/7 Access": {"mon": [["00:00", "24:00"]]}}),
+            "sync_manager": SimpleNamespace(get_next_sync_text=lambda: datetime(2024, 5, 1, 15, 0)),
+            "sync_queue": SimpleNamespace(next_sync_eta=datetime(2024, 5, 1, 16, 0)),
+            "settings_store": SimpleNamespace(
+                get_auto_sync_time=lambda: None,
+                get_auto_reboot=lambda: {"time": datetime(2024, 5, 2, 1, 0), "days": {"mon", "tue"}},
+            ),
+        }
+    )
+
+    request = web.Request()
+    request.app["hass"] = hass
+
+    view = AkuvoxUIView()
+    response = hass.loop.run_until_complete(view.get(request))
+    payload = response["data"]
+
+    assert payload["devices"][0]["last_sync"].startswith("2024-05-01T12:30")
+    event = payload["devices"][0]["events"][0]
+    assert isinstance(event["timestamp"], str)
+    user = payload["devices"][0]["users"][0]
+    assert sorted(user["Groups"]) == ["Default", "VIP"]
+
+    registry = payload["registry_users"][0]
+    assert sorted(registry["groups"]) == ["Default", "VIP"]
+
+    auto_reboot = payload["kpis"].get("auto_reboot")
+    assert isinstance(auto_reboot["days"], list)
+
+    json.dumps(payload)  # should not raise for any nested structures


### PR DESCRIPTION
## Summary
- add a JSON-safe helper so the Akuvox dashboard state endpoint converts sets and datetimes into serializable values
- sanitize device, registry user, KPI, and schedule payloads before returning them to the frontend
- add a regression test covering a stored user with set-based groups and datetime fields to ensure serialization remains stable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdf7f35248832c8ec3638d4ecbbf51