### PR TITLE
Fix UI state endpoint when panel registered

### DIFF
--- a/custom_components/AK_Access_ctrl/http.py
+++ b/custom_components/AK_Access_ctrl/http.py
@@ -258,8 +258,14 @@ class AkuvoxUIView(HomeAssistantView):
                 "sync_manager",
                 "sync_queue",
                 "_ui_registered",
+                "_panel_registered",
             ):
                 continue
+
+            if not isinstance(data, dict):
+                # Guard against sentinel values (e.g. booleans) stored in hass.data.
+                continue
+
             coord = data.get("coordinator")
             if not coord:
                 continue


### PR DESCRIPTION
## Summary
- ignore hass.data sentinel keys when building UI state so the Akuvox dashboard no longer 500s once the panel is registered

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68ceb97feab8832c826357ece7260844