### PR TITLE
Adjust sync KPI behaviour and default port

### DIFF
--- a/custom_components/AK_Access_ctrl/__init__.py
+++ b/custom_components/AK_Access_ctrl/__init__.py
@@ -959,7 +959,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     api = AkuvoxAPI(
         host=cfg.get(CONF_HOST),
-        port=cfg.get(CONF_PORT, 443),
+        port=cfg.get(CONF_PORT, 80),
         username=cfg.get(CONF_USERNAME) or None,
         password=cfg.get(CONF_PASSWORD) or None,
         use_https=cfg.get("use_https", DEFAULT_USE_HTTPS),

--- a/custom_components/AK_Access_ctrl/config_flow.py
+++ b/custom_components/AK_Access_ctrl/config_flow.py
@@ -28,7 +28,7 @@ class AkuvoxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # unique_id as host:port to avoid dup
-            uniq = f"{user_input[CONF_HOST]}:{user_input.get(CONF_PORT, 443)}"
+            uniq = f"{user_input[CONF_HOST]}:{user_input.get(CONF_PORT, 80)}"
             await self.async_set_unique_id(uniq)
             self._abort_if_unique_id_configured()
             return self.async_create_entry(title=user_input[CONF_DEVICE_NAME], data=user_input)
@@ -36,7 +36,7 @@ class AkuvoxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema({
             vol.Required(CONF_DEVICE_NAME): str,
             vol.Required(CONF_HOST): str,
-            vol.Optional(CONF_PORT, default=443): int,
+            vol.Optional(CONF_PORT, default=80): int,
             vol.Required(CONF_DEVICE_TYPE, default="Intercom"): vol.In(DEVICE_TYPES),
             vol.Optional(CONF_USERNAME, default=""): str,
             vol.Optional(CONF_PASSWORD, default=""): str,

--- a/custom_components/AK_Access_ctrl/http.py
+++ b/custom_components/AK_Access_ctrl/http.py
@@ -329,7 +329,11 @@ class AkuvoxUIView(HomeAssistantView):
             devices.append(dev)
 
         kpis["devices"] = len(devices)
-        kpis["pending"] = sum(1 for d in devices if d.get("sync_status") != "in_sync")
+        kpis["pending"] = sum(
+            1
+            for d in devices
+            if d.get("sync_status") != "in_sync" and d.get("online", True)
+        )
 
         # Users KPI (only HA### ids)
         try:

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -225,8 +225,14 @@ function renderKPIs(k){
   if (k.next_sync_eta) startNextSyncCountdown(k.next_sync_eta, k.auto_sync_time);
   $('#kpiDevices').textContent = k.devices ?? '0';
   $('#kpiUsers').textContent   = k.users ?? '0';
-  $('#kpiPending').textContent = k.pending ?? '0';
+  const pendingRaw = Number(k?.pending ?? 0);
+  const pendingCount = Number.isFinite(pendingRaw) ? pendingRaw : 0;
+  $('#kpiPending').textContent = String(pendingCount);
   $('#kpiNext').textContent    = (k.next_sync || '—');
+  const syncNowBox = document.getElementById('kpiSyncNowBox');
+  if (syncNowBox) {
+    syncNowBox.style.display = pendingCount > 1 ? '' : 'none';
+  }
   const auto = k.auto_sync_time;
   if (auto) {
     const el = document.getElementById('autoSyncInput');
@@ -520,6 +526,16 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btnForceFull')?.addEventListener('click', forceFullSync);
   document.getElementById('btnRebootAll')?.addEventListener('click', rebootAll);
 
+  const addUserBtn = document.getElementById('btnAddUser');
+  if (addUserBtn) {
+    addUserBtn.href = buildHref('users');
+    addUserBtn.removeAttribute('target');
+    addUserBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      openInApp('users');
+    });
+  }
+
   const autoEl = document.getElementById('autoSyncInput');
   autoEl?.addEventListener('focus', resetAutoSyncIndicator);
   autoEl?.addEventListener('change', async () => {
@@ -547,19 +563,6 @@ document.addEventListener('DOMContentLoaded', () => {
   refresh();
   setInterval(refresh, 5000);
 });
-
-/* Add User link */
-(() => {
-  const a = document.getElementById('btnAddUser');
-  if (!a) return;
-  const href = buildHref('users');
-  a.href = href;
-  a.removeAttribute('target');
-  a.addEventListener('click', (e) => {
-    e.preventDefault();
-    openInApp('users');
-  });
-})();
 
 /* ===== Countdown + watchdog ===== */
 let nextSyncTimer = null;
@@ -612,7 +615,7 @@ setInterval(refresh, 5000);
         <div class="box text-end"><div>Devices</div><div id="kpiDevices">—</div></div>
         <div class="box text-end"><div>Pending Sync</div><div id="kpiPending">—</div></div>
         <div class="box text-end"><div>Next Sync</div><div id="kpiNext">—</div></div>
-        <div class="box2"><button id="btnSyncNowEta" class="btn btn-sm btn-primary"><i class="bi bi-lightning-fill"></i> Sync Now </button></div>
+        <div class="box2" id="kpiSyncNowBox" style="display:none;"><button id="btnSyncNowEta" class="btn btn-sm btn-primary"><i class="bi bi-lightning-fill"></i> Sync Now </button></div>
         <div class="box text-end">
           <div>Auto Sync</div>
           <input id="autoSyncInput" class="form-control form-control-sm" placeholder="HH:MM" style="width:6rem;display:inline-block">


### PR DESCRIPTION
## Summary
- default new device setups to port 80 again and ensure backend pending counts ignore offline hardware
- hide the top-level Sync Now shortcut unless multiple devices need syncing and keep the Add User link working when embedded

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68cf8053cfec832cbcd2b67eb14a7707