### PR TITLE
Defer device communication to sync cycles

### DIFF
--- a/custom_components/AK_Access_ctrl/__init__.py
+++ b/custom_components/AK_Access_ctrl/__init__.py
@@ -1220,7 +1220,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         enabled = bool(call.data.get("enabled", True))
         if entry_id in hass.data[DOMAIN]:
             hass.data[DOMAIN][entry_id]["options"]["exit_device"] = enabled
-            await hass.data[DOMAIN]["sync_queue"].sync_now(entry_id)
+            queue: SyncQueue = hass.data[DOMAIN].get("sync_queue")  # type: ignore[assignment]
+            if queue:
+                queue.mark_change(entry_id)
 
     async def svc_set_auto_reboot(call):
         time_hhmm = call.data.get("time")


### PR DESCRIPTION
## Summary
- queue syncs when toggling exit device participation so changes are pushed during the next sync
- update UI flows (device groups, face upload, remote enrol) to mark pending syncs instead of contacting devices immediately

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68cf8a205f8c832c83283e8a982890d9