### PR TITLE
Redirect dashboard traffic to a dedicated unauthorized page

### DIFF
--- a/custom_components/AK_Access_ctrl/coordinator.py
+++ b/custom_components/AK_Access_ctrl/coordinator.py
@@ -146,8 +146,8 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             root = self.hass.data.get(DOMAIN, {}) or {}
             sq = root.get("sync_queue")
             if sq:
-                # Show 'pending' right away so UI reflects the action
-                self.health["sync_status"] = "pending"
+                # Surface an in-progress state immediately so dashboards update
+                self.health["sync_status"] = "in_progress"
                 await sq.sync_now(self.entry_id)
         except Exception:
             # best-effort only

--- a/custom_components/AK_Access_ctrl/www/app.js
+++ b/custom_components/AK_Access_ctrl/www/app.js
@@ -62,6 +62,8 @@ async function loadDevices() {
     const onlineBadge = online ? badge("Online", "badge-online") : badge("Offline", "badge-offline");
     const syncBadge = syncState === "in_sync"
       ? badge("In Sync", "badge-in-sync")
+      : syncState === "in_progress"
+      ? badge("In Progress", "badge-in-progress bg-info text-dark")
       : syncState === "pending"
       ? badge("Pending Sync", "badge-pending")
       : badge(esc(syncState), "bg-secondary");

--- a/custom_components/AK_Access_ctrl/www/device_edit.html
+++ b/custom_components/AK_Access_ctrl/www/device_edit.html
@@ -141,9 +141,27 @@ function findHaToken() {
 const BEARER = findHaToken();
 const AUTH_HEADERS = BEARER ? { 'Authorization': 'Bearer ' + BEARER } : {};
 const SAME_ORIGIN = { credentials: 'same-origin' };
+function buildError(res, text) {
+  const msg = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(msg);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+function isAuthError(err) {
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
 async function apiGet(url) {
   const r = await fetch(url, { ...SAME_ORIGIN, headers: AUTH_HEADERS });
-  if (!r.ok) throw new Error(`${r.status}: ${await r.text()}`);
+  if (!r.ok) {
+    const text = await r.text();
+    const err = buildError(r, text);
+    handleAuthError(err);
+    throw err;
+  }
   return r.json();
 }
 async function apiPost(url, body) {
@@ -153,7 +171,12 @@ async function apiPost(url, body) {
     headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
     body: JSON.stringify(body || {})
   });
-  if (!r.ok) throw new Error(`${r.status}: ${await r.text()}`);
+  if (!r.ok) {
+    const text = await r.text();
+    const err = buildError(r, text);
+    handleAuthError(err);
+    throw err;
+  }
   return r.json();
 }
 
@@ -203,6 +226,43 @@ function openInApp(view, params = {}, options = {}) {
     window.location.href = href;
   }
   return delivered;
+}
+
+function redirectToUnauthorized(params = {}) {
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    href = buildHref('unauthorized', targetParams);
+  } catch (err) {}
+
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  } catch (err) {}
+
+  if (!delivered) {
+    try {
+      window.location.replace(href);
+    } catch (err) {
+      window.location.href = href;
+    }
+  }
+  return true;
+}
+
+function handleAuthError(err) {
+  if (!isAuthError(err)) {
+    return false;
+  }
+  redirectToUnauthorized();
+  return true;
 }
 
 /* ===== UI helpers ===== */
@@ -274,7 +334,6 @@ async function createGroup(name){
 
 /* ===== Init & wiring ===== */
 async function init(){
-  if (!BEARER) { showError('No auth token found. Open inside Home Assistant or append ?token='); return; }
   if (!ENTRY_ID) { showError('Missing device id in URL (?entry_id=ENTRY_ID)'); return; }
 
   document.getElementById('btnBack').addEventListener('click', (e)=>{ e.preventDefault(); goBack(); });
@@ -320,6 +379,7 @@ async function init(){
         renderGroupChecklist(all, cur);
         document.getElementById('createSaveRow').classList.remove('hidden');
       }catch(e){
+        if (handleAuthError(e)) return;
         showError('Failed to create group: ' + (e.message || e));
       }
     });
@@ -337,6 +397,7 @@ async function init(){
         renderGroupChecklist(all, cur);
         document.getElementById('createSaveRow').classList.remove('hidden');
       }catch(e){
+        if (handleAuthError(e)) return;
         showError('Failed to create group: ' + (e.message || e));
       }
     });
@@ -348,11 +409,13 @@ async function init(){
         await saveDeviceGroups(groups);
         showOK('Saved ✓');
       }catch(e){
+        if (handleAuthError(e)) return;
         showError('Save failed: ' + (e.message || e));
       }
     });
 
   }catch(e){
+    if (handleAuthError(e)) return;
     showError(String(e));
   }
 }

--- a/custom_components/AK_Access_ctrl/www/face_rec.html
+++ b/custom_components/AK_Access_ctrl/www/face_rec.html
@@ -26,6 +26,56 @@ function findHaToken(){ const t = sessionStorage.getItem('akuvox_ll_token'); ret
 const AUTH_HEADERS = (findHaToken()) ? { 'Authorization': 'Bearer ' + findHaToken() } : {};
 const SAME_ORIGIN = { credentials: 'same-origin' };
 
+function buildError(res, text){
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err){
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+function redirectToUnauthorized(){
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+
+  try {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ type: 'akuvox-nav', view: 'unauthorized', slug: 'unauthorized', params: {} }, window.location.origin);
+    }
+  } catch (err) {}
+
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    const token = sessionStorage.getItem('akuvox_ll_token');
+    if (token) {
+      const search = new URLSearchParams();
+      search.set('token', token);
+      href = `/akuvox-ac/unauthorized?${search.toString()}`;
+    }
+  } catch (err) {}
+
+  try { window.location.replace(href); }
+  catch (err) { window.location.href = href; }
+  return true;
+}
+
+function handleAuthError(err){
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
 function qsGet(k){ return new URLSearchParams(location.search).get(k) || ''; }
 const USER_ID = qsGet('user');      // e.g. HA001
 const DEVICE_ID = qsGet('device');  // informational for now
@@ -108,11 +158,15 @@ async function uploadBlobAsJpg(blob){
     let res = {};
     try { res = JSON.parse(text); } catch { res = { ok: r.ok, raw: text }; }
     if (!r.ok || res.ok === false){
-      setStatus('Upload failed: ' + (res.error || text || r.status), false);
+      const err = res && res.error ? new Error(res.error) : buildError(r, text);
+      handleAuthError(err);
+      if (res && res.error) err.message = res.error;
+      setStatus('Upload failed: ' + (res.error || text || err.message || r.status), false);
       return;
     }
     setStatus('Face uploaded. A sync will push it to the device shortly.', true);
   }catch(e){
+    if (handleAuthError(e)) return;
     setStatus('Upload error: ' + (e && e.message ? e.message : e), false);
   }finally{
     setBusy(false);

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -18,6 +18,7 @@
     .card-header{ border-bottom:1px solid var(--border); font-weight:600; color:var(--text); }
     thead{ background:#0f1a2c; color:var(--muted) }
     .badge-in-sync{background:#198754}
+    .badge-in-progress{background:#0dcaf0;color:#111}
     .badge-pending{background:#ffc107;color:#111}
     .badge-offline{background:#dc3545}
     .badge-online{background:#0dcaf0;color:#111}
@@ -92,9 +93,27 @@ const BEARER = findHaToken();
 const AUTH_HEADERS = BEARER ? { 'Authorization': 'Bearer ' + BEARER } : {};
 const SAME_ORIGIN = { credentials: 'same-origin' };
 
+function buildError(res, text) {
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+function isAuthError(err) {
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
 async function apiGet(url) {
   const res = await fetch(url, { ...SAME_ORIGIN, headers: AUTH_HEADERS });
-  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`);
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
   return res.json();
 }
 async function apiPost(url, body) {
@@ -104,7 +123,12 @@ async function apiPost(url, body) {
     headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
     body: JSON.stringify(body || {})
   });
-  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`);
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
   return res.json();
 }
 async function callService(domain, service, data = {}) {
@@ -115,7 +139,12 @@ async function callService(domain, service, data = {}) {
     headers: { 'Content-Type': 'application/json', ...AUTH_HEADERS },
     body: JSON.stringify(data)
   });
-  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`);
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
   return res.json();
 }
 const UI_ROOT = '/akuvox-ac';
@@ -160,18 +189,61 @@ function openInApp(view, params = {}, options = {}) {
   return delivered;
 }
 
+function redirectToUnauthorized(params = {}) {
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    if (typeof buildHref === 'function') {
+      href = buildHref('unauthorized', targetParams);
+    }
+  } catch (err) {}
+
+  let delivered = false;
+  try {
+    if (typeof requestParentNav === 'function') {
+      delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+    }
+  } catch (err) {}
+
+  if (!delivered) {
+    try {
+      window.location.replace(href);
+    } catch (err) {
+      window.location.href = href;
+    }
+  }
+  return true;
+}
+
+function handleAuthError(err) {
+  if (!isAuthError(err)) {
+    return false;
+  }
+  redirectToUnauthorized();
+  return true;
+}
+
 /* ========= RENDERERS + WIRING ========= */
 const stateUrl  = '/api/akuvox_ac/ui/state';
 const actionUrl = '/api/akuvox_ac/ui/action';
 const $ = (sel) => document.querySelector(sel);
 
-function badge(text, kind){
+function badge(text, kind, attrs = ''){
   const k = kind === 'online' ? 'badge-online'
           : kind === 'offline' ? 'badge-offline'
           : kind === 'rebooting' ? 'badge-rebooting'
           : kind === 'in_sync' ? 'badge-in-sync'
+          : kind === 'in_progress' ? 'badge-in-progress'
           : 'badge-pending';
-  return `<span class="badge ${k}">${text}</span>`;
+  const attr = attrs ? ` ${attrs}` : '';
+  return `<span class="badge ${k}"${attr}>${text}</span>`;
 }
 
 let autoSyncSavedTimer = null;
@@ -222,16 +294,32 @@ function showAutoSyncSaved(msg = 'Saved ✓', restoreValue = null){
 }
 
 function renderKPIs(k){
-  if (k.next_sync_eta) startNextSyncCountdown(k.next_sync_eta, k.auto_sync_time);
+  const nextEl = document.getElementById('kpiNext');
+  if (k.next_sync_eta) {
+    startNextSyncCountdown(k.next_sync_eta, k.auto_sync_time || k.next_sync);
+  } else if (nextEl) {
+    nextEl.textContent = k.next_sync || k.auto_sync_time || '—';
+  }
   $('#kpiDevices').textContent = k.devices ?? '0';
   $('#kpiUsers').textContent   = k.users ?? '0';
   const pendingRaw = Number(k?.pending ?? 0);
   const pendingCount = Number.isFinite(pendingRaw) ? pendingRaw : 0;
   $('#kpiPending').textContent = String(pendingCount);
-  $('#kpiNext').textContent    = (k.next_sync || '—');
+  const syncActive = !!k.sync_active;
   const syncNowBox = document.getElementById('kpiSyncNowBox');
   if (syncNowBox) {
-    syncNowBox.style.display = pendingCount > 1 ? '' : 'none';
+    const showSync = pendingCount > 1 && !syncActive;
+    syncNowBox.style.display = showSync ? '' : 'none';
+    const btn = syncNowBox.querySelector('button');
+    if (btn) {
+      if (showSync) btn.removeAttribute('disabled');
+      else btn.setAttribute('disabled', 'disabled');
+    }
+  }
+  const forceBtn = document.getElementById('btnForceFull');
+  if (forceBtn) {
+    if (syncActive) forceBtn.setAttribute('disabled', 'disabled');
+    else forceBtn.removeAttribute('disabled');
   }
   const auto = k.auto_sync_time;
   if (auto) {
@@ -252,6 +340,33 @@ function renderKPIs(k){
   }
 }
 
+const ESCAPE_HTML_LOOKUP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+};
+
+function escapeHtml(value){
+  return String(value ?? '').replace(/[&<>"']/g, ch => ESCAPE_HTML_LOOKUP[ch] ?? ch);
+}
+
+function normalizeGroupsList(groups){
+  if (Array.isArray(groups)) {
+    return groups.length ? groups.map(g => String(g)) : ['Default'];
+  }
+  if (groups === null || groups === undefined || groups === '') {
+    return ['Default'];
+  }
+  return [String(groups)];
+}
+
+function groupsIntersect(a, b){
+  const set = new Set((b || []).map(g => String(g).toLowerCase()));
+  return (a || []).some(g => set.has(String(g).toLowerCase()));
+}
+
 function safeDeviceName(d){
   // prefer the most intentional field from backend
   return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
@@ -269,13 +384,20 @@ function renderDevices(devs){
     else if (statusKey === 'offline') statusBadge = badge('Offline', 'offline');
     else statusBadge = badge(statusKeyRaw, 'pending');
 
-    const syncBadge = statusKey === 'offline'
-      ? '—'
-      : d.sync_status === 'in_sync'
-        ? badge('In Sync', 'in_sync')
-        : badge('Pending', 'pending');
-    const last   = d.last_sync || '—';
     const id     = d.entry_id || d.id || '';
+    const syncStatusRaw = String(d.sync_status || '').toLowerCase();
+    const syncAttr = id ? `data-sync-status="${escapeHtml(id)}"` : '';
+    let syncBadge;
+    if (statusKey === 'offline') {
+      syncBadge = '—';
+    } else if (syncStatusRaw === 'in_sync') {
+      syncBadge = badge('In Sync', 'in_sync', syncAttr);
+    } else if (syncStatusRaw === 'in_progress') {
+      syncBadge = badge('In Progress', 'in_progress', syncAttr);
+    } else {
+      syncBadge = badge('Pending', 'pending', syncAttr);
+    }
+    const last   = d.last_sync || '—';
     const name   = safeDeviceName(d);
 
     const syncBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-primary" data-act="sync_now" data-id="${id}">Sync</button>`   : '';
@@ -381,42 +503,128 @@ function idMatchesFilter(id){
   return /^HA\d{3}$/.test(id) || /^User0000\d{2}$/.test(id);
 }
 function renderUsers(devs, registryUsers){
+  const devices = Array.isArray(devs) ? devs : [];
+  const normalizedDevices = devices.map(d => {
+    const entryId = String(d.entry_id || d.id || '');
+    const groups = normalizeGroupsList(d.sync_groups);
+    const participates = d.participate_in_sync !== false;
+    const online = d.online !== false;
+    const syncStatusRaw = String(d.sync_status || '').toLowerCase();
+    const syncStatus = syncStatusRaw || 'pending';
+    return { entryId, groups, participates, online, syncStatus };
+  });
+
   const by = new Map();
 
   (registryUsers || []).forEach(r => {
     const key = String(r.id || r.UserID || r.ID || '');
     if (!key) return;
+    const groups = normalizeGroupsList(r.groups || []);
     by.set(key, {
-      id: key, name: r.name || key, groups: r.groups || [],
-      access: 'Pending', isCloud: false, last: '—', presentOnDevice: false
+      id: key,
+      name: r.name || key,
+      groups,
+      access: 'Pending',
+      isCloud: false,
+      last: '—',
+      presentOnDevice: false,
+      fromRegistry: true,
+      status: r.status || 'active',
+      schedule_name: r.schedule_name || '24/7 Access',
+      schedule_id: r.schedule_id || '',
+      access_level: r.access_level || '',
+      key_holder: !!r.key_holder,
+      _seenOn: new Set(),
+      _denied: false
     });
   });
 
-  (devs || []).forEach(d => (d._users || d.users || []).forEach(u => {
-    const key = String(u.ID || u.UserID || u.Name || '');
-    if (!key) return;
-    const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
-    const accessAllowed = !(String(u.WebRelay) === '0' || u.AccessEnabled === false);
-    const last = u.LastAccess || u.last_access || '—';
+  devices.forEach(d => {
+    const entryId = String(d.entry_id || d.id || '');
+    const deviceGroups = normalizeGroupsList(d.sync_groups || []);
+    (d._users || d.users || []).forEach(u => {
+      const key = String(u.ID || u.UserID || u.Name || '');
+      if (!key) return;
+      const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
+      const accessAllowed = !(String(u.WebRelay) === '0' || u.AccessEnabled === false);
+      const last = u.LastAccess || u.last_access || '—';
 
-    if (!by.has(key)) {
-      by.set(key, { id:key, name:u.Name||key, groups:u.Groups||u.groups||[], access: accessAllowed?'Allowed':'Denied', isCloud, last, presentOnDevice:true });
-    } else {
+      if (!by.has(key)) {
+        by.set(key, {
+          id: key,
+          name: u.Name || key,
+          groups: normalizeGroupsList(u.Groups || u.groups || deviceGroups),
+          access: accessAllowed ? 'Allowed' : 'Denied',
+          isCloud,
+          last,
+          presentOnDevice: true,
+          fromRegistry: false
+        });
+        return;
+      }
+
       const cur = by.get(key);
       cur.isCloud = cur.isCloud || isCloud;
       cur.presentOnDevice = true;
-      cur.groups = cur.groups && cur.groups.length ? cur.groups : (u.Groups || u.groups || []);
-      cur.access = accessAllowed ? 'Allowed' : 'Denied';
+      if (!cur.groups || cur.groups.length === 0) {
+        cur.groups = normalizeGroupsList(u.Groups || u.groups || deviceGroups);
+      }
       cur.last = last || cur.last;
+      if (cur.fromRegistry && cur._seenOn instanceof Set && entryId) {
+        cur._seenOn.add(entryId);
+      }
+      if (cur.fromRegistry && !accessAllowed) {
+        cur._denied = true;
+      } else if (!cur.fromRegistry) {
+        cur.access = accessAllowed ? 'Allowed' : 'Denied';
+      }
       by.set(key, cur);
-    }
-  }));
+    });
+  });
 
-  const list = [...by.values()]
+  const list = Array.from(by.values()).map(item => {
+    if (!item.fromRegistry) {
+      return item;
+    }
+    const seenIds = Array.from(item._seenOn instanceof Set ? item._seenOn : []);
+    const shouldHost = normalizedDevices.filter(dev =>
+      dev.participates &&
+      dev.online &&
+      groupsIntersect(item.groups, dev.groups)
+    );
+    const requiredIds = shouldHost.map(dev => dev.entryId).filter(id => !!id);
+    const pendingDevices = shouldHost.filter(dev => dev.syncStatus !== 'in_sync');
+    const readyDevices = shouldHost.filter(dev => dev.syncStatus === 'in_sync');
+    const allVerified = readyDevices.length
+      ? readyDevices.every(dev => seenIds.includes(dev.entryId))
+      : !requiredIds.length;
+    const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
+    const baseLower = String(baseLabel).toLowerCase();
+    let accessText;
+    if (item._denied && baseLower !== 'no access') {
+      accessText = 'Denied';
+    } else if (String(item.status || '').toLowerCase() === 'pending') {
+      accessText = 'Pending';
+    } else if (pendingDevices.length) {
+      accessText = 'Pending';
+    } else if (!requiredIds.length || allVerified) {
+      accessText = baseLabel;
+    } else {
+      accessText = 'Pending';
+    }
+    const { _seenOn, _denied, ...rest } = item;
+    return {
+      ...rest,
+      access: accessText,
+      presentOnDevice: item.presentOnDevice || (readyDevices.length > 0 && allVerified)
+    };
+  });
+
+  const listSorted = list
     .filter(u => u.isCloud || idMatchesFilter(u.id))
     .sort((a,b) => String(a.name||'').localeCompare(String(b.name||''), undefined, {sensitivity:'base'}));
 
-  const rows = list.map(u => {
+  const rows = listSorted.map(u => {
     if (u.isCloud) {
       return `<tr>
         <td>${u.name}</td>
@@ -424,10 +632,12 @@ function renderUsers(devs, registryUsers){
       </tr>`;
     }
     const chips = (u.groups || []).map(g => `<span class="chip">${g}</span>`).join(' ');
+    const accessStr = String(u.access || '').trim();
+    const accessLower = accessStr.toLowerCase();
     let accessBadge = '';
-    if (u.access === 'Allowed') accessBadge = '<span class="badge badge-in-sync">Allowed</span>';
-    else if (u.access === 'Denied') accessBadge = '<span class="badge badge-pending">Denied</span>';
-    else accessBadge = '<span class="badge badge-pending">Pending</span>';
+    if (!accessStr || accessLower === 'pending') accessBadge = '<span class="badge badge-pending">Pending</span>';
+    else if (accessLower === 'denied') accessBadge = '<span class="badge badge-pending">Denied</span>';
+    else accessBadge = `<span class="badge badge-in-sync">${escapeHtml(accessStr)}</span>`;
 
     const editHref = buildHref('users', { id: u.id });
     const actions = /^HA\d{3}$/.test(u.id)
@@ -471,16 +681,6 @@ function renderUsers(devs, registryUsers){
 /* ===== Fetch + render ===== */
 async function refresh(){
   try{
-    if (!BEARER) {
-      document.querySelector('#tblDevices').innerHTML =
-        '<tr><td colspan="9" class="text-warning">No auth token found. Open this page inside Home Assistant or append <code>?token=&lt;LONG_LIVED_TOKEN&gt;</code> to the URL.</td></tr>';
-      document.querySelector('#eventList').innerHTML =
-        '<li class="event-item"><span class="event-title dim">No auth token found.</span></li>';
-      document.querySelector('#tblUsers').innerHTML =
-        '<tr><td colspan="5" class="text-warning">No auth token found.</td></tr>';
-      return;
-    }
-
     const state = await apiGet(stateUrl);
     renderKPIs(state.kpis || {devices:0, users:0, pending:0});
     const devs = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
@@ -489,33 +689,189 @@ async function refresh(){
     renderUsers(devs, state.registry_users || []);
   } catch(e){
     console.error('state load failed', e);
+    if (handleAuthError(e)) return;
     document.querySelector('#tblDevices').innerHTML =
-      `<tr><td colspan="9" class="text-danger">Failed to load: ${String(e)}</td></tr>`;
+      `<tr><td colspan="9" class="text-danger">Failed to load: ${escapeHtml(String(e))}</td></tr>`;
   }
 }
 
 async function syncAllNow(){
+  const syncNowBox = document.getElementById('kpiSyncNowBox');
+  const btn = document.getElementById('btnSyncNowEta');
+  if (btn) {
+    btn.setAttribute('disabled', 'disabled');
+  }
+  if (syncNowBox) {
+    syncNowBox.style.display = 'none';
+  }
+
+  const statusBadges = Array.from(document.querySelectorAll('[data-sync-status]'));
+  const badgeSnapshots = statusBadges.map(el => ({
+    el,
+    text: el.textContent,
+    className: el.className,
+  }));
+  statusBadges.forEach(el => {
+    el.textContent = 'In Progress';
+    el.classList.remove('badge-pending', 'badge-in-sync');
+    el.classList.add('badge-in-progress');
+  });
+
   let ok = false;
-  try { await apiPost(actionUrl, { action: 'sync_now' }); ok = true; } catch {}
-  try { await callService('akuvox_ac','sync_now', {}); ok = true; } catch {}
-  if (!ok) alert('Sync Now failed to trigger');
+  let lastError = '';
+  try {
+    const res = await apiPost(actionUrl, { action: 'sync_now' });
+    if (res && typeof res === 'object') {
+      if (res.ok) ok = true;
+      else if ('ok' in res && !res.ok) lastError = res.error || '';
+    } else if (res === true) {
+      ok = true;
+    }
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    lastError = err?.message || String(err);
+  }
+
+  if (!ok) {
+    try {
+      await callService('akuvox_ac','sync_now', {});
+      ok = true;
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      if (!lastError) lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    badgeSnapshots.forEach(({ el, text, className }) => {
+      el.textContent = text;
+      el.className = className;
+    });
+    if (syncNowBox) {
+      syncNowBox.style.display = '';
+    }
+    if (btn) {
+      btn.removeAttribute('disabled');
+    }
+    alert(`Sync Now failed${lastError ? `: ${lastError}` : ''}`);
+    return;
+  }
+
   refresh();
 }
 
 async function forceFullSync(){
+  const syncNowBox = document.getElementById('kpiSyncNowBox');
+  const syncBtn = document.getElementById('btnSyncNowEta');
+  const forceBtn = document.getElementById('btnForceFull');
+
+  if (forceBtn) {
+    forceBtn.setAttribute('disabled', 'disabled');
+  }
+  if (syncBtn) {
+    syncBtn.setAttribute('disabled', 'disabled');
+  }
+  if (syncNowBox) {
+    syncNowBox.style.display = 'none';
+  }
+
+  const statusBadges = Array.from(document.querySelectorAll('[data-sync-status]'));
+  const badgeSnapshots = statusBadges.map(el => ({
+    el,
+    text: el.textContent,
+    className: el.className,
+  }));
+  statusBadges.forEach(el => {
+    el.textContent = 'In Progress';
+    el.classList.remove('badge-pending', 'badge-in-sync');
+    el.classList.add('badge-in-progress');
+  });
+
   let ok = false;
-  try { await apiPost(actionUrl, { action: 'sync_all' }); ok = true; } catch {}
-  if (!ok) { try { await apiPost(actionUrl, { action: 'force_full_sync' }); ok = true; } catch {} }
-  try { await callService('akuvox_ac','force_full_sync', {}); ok = true; } catch {}
-  if (!ok) { try { await callService('akuvox_ac','sync_now', {}); ok = true; } catch {} }
-  if (!ok) alert('Force Full Sync failed to trigger');
+  let lastError = '';
+
+  const handleResult = (res) => {
+    if (res && typeof res === 'object') {
+      if (res.ok) ok = true;
+      else if ('ok' in res && !res.ok) lastError = res.error || lastError;
+    } else if (res === true) {
+      ok = true;
+    }
+  };
+
+  if (!ok) {
+    try {
+      const res = await apiPost(actionUrl, { action: 'sync_all' });
+      handleResult(res);
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    try {
+      const res = await apiPost(actionUrl, { action: 'force_full_sync' });
+      handleResult(res);
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      if (!lastError) lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    try {
+      await callService('akuvox_ac','force_full_sync', {});
+      ok = true;
+    } catch (err) {
+      if (!lastError) lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    try {
+      await callService('akuvox_ac','sync_now', {});
+      ok = true;
+    } catch (err) {
+      if (!lastError) lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    badgeSnapshots.forEach(({ el, text, className }) => {
+      el.textContent = text;
+      el.className = className;
+    });
+    if (syncNowBox) {
+      syncNowBox.style.display = '';
+    }
+    if (syncBtn) {
+      syncBtn.removeAttribute('disabled');
+    }
+    if (forceBtn) {
+      forceBtn.removeAttribute('disabled');
+    }
+    alert(`Force Full Sync failed${lastError ? `: ${lastError}` : ''}`);
+    return;
+  }
+
   refresh();
 }
 
 async function rebootAll(){
   let ok = false;
-  try { await apiPost(actionUrl, { action: 'reboot_all' }); ok = true; } catch {}
-  try { await callService('akuvox_ac','reboot_device', {}); ok = true; } catch {}
+  try {
+    await apiPost(actionUrl, { action: 'reboot_all' });
+    ok = true;
+  } catch (err) {
+    if (handleAuthError(err)) return;
+  }
+  try {
+    await callService('akuvox_ac','reboot_device', {});
+    ok = true;
+  } catch (err) {
+    if (handleAuthError(err)) return;
+  }
   if (!ok) alert('Reboot All failed to trigger');
   refresh();
 }
@@ -546,14 +902,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const v = (autoEl.value || '').trim();
     if (!/^\d{2}:\d{2}$/.test(v)) { alert('Use HH:MM'); return; }
     let ok = false;
-    try{
+    try {
       await apiPost(actionUrl, { action:'set_daily_sync', payload:{ time:v } });
       ok = true;
-    }catch(e){
+    } catch (err) {
+      if (handleAuthError(err)) return;
       try {
         await callService('akuvox_ac','set_daily_sync', { time: v });
         ok = true;
-      } catch {}
+      } catch (fallbackErr) {
+        if (handleAuthError(fallbackErr)) return;
+      }
     }
     if (ok) {
       document.getElementById('kpiNext').textContent = v;
@@ -572,17 +931,26 @@ document.addEventListener('DOMContentLoaded', () => {
 let nextSyncTimer = null;
 let nextSyncWatchdog = null;
 function startNextSyncCountdown(iso, fallbackTime){
+  const nextEl = document.getElementById('kpiNext');
   if (nextSyncTimer) { clearInterval(nextSyncTimer); nextSyncTimer = null; }
   if (nextSyncWatchdog) { clearInterval(nextSyncWatchdog); nextSyncWatchdog = null; }
-  if (!iso) return;
+  if (!iso || !nextEl) {
+    if (nextEl) nextEl.textContent = fallbackTime || '—';
+    return;
+  }
 
-  const eta = new Date(iso).getTime();
+  const eta = Date.parse(iso);
+  if (Number.isNaN(eta)) {
+    nextEl.textContent = fallbackTime || '—';
+    return;
+  }
+
   function tick(){
     const now = Date.now();
-    let diff = Math.max(0, Math.floor((eta - now)/1000));
+    const diff = Math.max(0, Math.floor((eta - now)/1000));
     const mm = String(Math.floor(diff/60)).padStart(2,'0');
     const ss = String(diff%60).padStart(2,'0');
-    document.getElementById('kpiNext').textContent = `${mm}:${ss}`;
+    nextEl.textContent = `${mm}:${ss}`;
     if (diff <= 0){ clearInterval(nextSyncTimer); nextSyncTimer=null; }
   }
   tick();
@@ -597,7 +965,10 @@ function startNextSyncCountdown(iso, fallbackTime){
       if (allOk){
         clearInterval(nextSyncTimer); nextSyncTimer=null;
         clearInterval(nextSyncWatchdog); nextSyncWatchdog=null;
-        document.getElementById('kpiNext').textContent = state.kpis?.auto_sync_time || fallbackTime || '—';
+        const el = document.getElementById('kpiNext');
+        if (el) {
+          el.textContent = state.kpis?.auto_sync_time || fallbackTime || '—';
+        }
       }
     }catch{}
   }, 60000);

--- a/custom_components/AK_Access_ctrl/www/schedules.html
+++ b/custom_components/AK_Access_ctrl/www/schedules.html
@@ -9,13 +9,119 @@
 </head>
 <body>
 <script>
-(function(){ const qs=new URLSearchParams(location.search); const t=qs.get('token'); if(t) sessionStorage.setItem('akuvox_ll_token',t); })();
-const AUTH = ()=>{ const t=sessionStorage.getItem('akuvox_ll_token'); return t?{'Authorization':'Bearer '+t}:{}}; 
-async function getState(){ const r=await fetch('/api/akuvox_ac/ui/state',{headers:AUTH()}); if(!r.ok) throw new Error(await r.text()); return r.json(); }
-async function action(act,payload){ const r=await fetch('/api/akuvox_ac/ui/action',{method:'POST',headers:{'Content-Type':'application/json',...AUTH()},body:JSON.stringify({action:act,payload})}); if(!r.ok) throw new Error(await r.text()); return r.json(); }
+(function captureToken(){
+  const qs = new URLSearchParams(location.search);
+  const token = qs.get('token');
+  if (token) sessionStorage.setItem('akuvox_ll_token', token);
+})();
 
-let SCHEDS={};
-function row(day, idx, start='', end=''){
+const UI_ROOT = '/akuvox-ac';
+const SAME_ORIGIN = { credentials: 'same-origin' };
+
+function currentBearer(){
+  return sessionStorage.getItem('akuvox_ll_token') || null;
+}
+
+function authHeaders(){
+  const token = currentBearer();
+  return token ? { 'Authorization': 'Bearer ' + token } : {};
+}
+
+function buildError(res, text){
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err){
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+function buildHref(slug, params = {}){
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = currentBearer();
+  if (token) search.set('token', token);
+  const query = search.toString();
+  const clean = String(slug || '').replace(/_/g, '-');
+  return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
+}
+
+function requestParentNav(view, params = {}, options = {}){
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = { type: 'akuvox-nav', view: String(view || ''), slug: String(view || ''), params };
+      if (options.updateHistory === false) msg.updateHistory = false;
+      if (options.replaceState) msg.replaceState = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return true;
+    }
+  } catch (err) {}
+  return false;
+}
+
+function redirectToUnauthorized(params = {}){
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+
+  const targetParams = params && typeof params === 'object' ? params : {};
+  const href = buildHref('unauthorized', targetParams);
+  const delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  if (!delivered) {
+    try { window.location.replace(href); }
+    catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err){
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
+async function getState(){
+  const res = await fetch('/api/akuvox_ac/ui/state', { ...SAME_ORIGIN, headers: authHeaders() });
+  if (!res.ok){
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function action(act, payload){
+  const res = await fetch('/api/akuvox_ac/ui/action', {
+    method: 'POST',
+    ...SAME_ORIGIN,
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ action: act, payload })
+  });
+  if (!res.ok){
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+let SCHEDS = {};
+
+function row(day, idx, start = '', end = ''){
   return `<div class="row g-2 align-items-center mb-1" data-day="${day}" data-idx="${idx}">
     <div class="col-2 text-capitalize">${day}</div>
     <div class="col-4"><input class="form-control form-control-sm" placeholder="HH:MM" value="${start}"/></div>
@@ -23,43 +129,92 @@ function row(day, idx, start='', end=''){
     <div class="col-2"><button class="btn btn-sm btn-outline-danger" onclick="removeRow('${day}',${idx})">Remove</button></div>
   </div>`;
 }
+
 function render(name){
-  const container=document.getElementById('editor'); container.innerHTML='';
-  const days=['mon','tue','wed','thu','fri','sat','sun'];
-  days.forEach(d=>{
-    const spans=(SCHEDS[name]&&SCHEDS[name][d])||[];
-    if(!spans.length) container.insertAdjacentHTML('beforeend', row(d,0,'',''));
-    else spans.forEach((sp,i)=>container.insertAdjacentHTML('beforeend',row(d,i,sp[0],sp[1])));
+  const container = document.getElementById('editor');
+  container.innerHTML = '';
+  const days = ['mon','tue','wed','thu','fri','sat','sun'];
+  days.forEach(day => {
+    const spans = (SCHEDS[name] && SCHEDS[name][day]) || [];
+    if (!spans.length) {
+      container.insertAdjacentHTML('beforeend', row(day, 0, '', ''));
+    } else {
+      spans.forEach((span, idx) => container.insertAdjacentHTML('beforeend', row(day, idx, span[0], span[1])));
+    }
   });
 }
-function removeRow(day, idx){ const rows=[...document.querySelectorAll(`[data-day="${day}"]`)]; const row=rows[idx]; if(row) row.remove(); }
-function addRow(day){ const rows=[...document.querySelectorAll(`[data-day="${day}"]`)]; const idx=rows.length; document.getElementById('editor').insertAdjacentHTML('beforeend', row(day, idx,'','')); }
+
+function removeRow(day, idx){
+  const rows = [...document.querySelectorAll(`[data-day="${day}"]`)];
+  const rowEl = rows[idx];
+  if (rowEl) rowEl.remove();
+}
+
+function addRow(day){
+  const rows = [...document.querySelectorAll(`[data-day="${day}"]`)];
+  const idx = rows.length;
+  document.getElementById('editor').insertAdjacentHTML('beforeend', row(day, idx, '', ''));
+}
+
 async function save(){
-  const name=document.getElementById('schedName').value.trim();
-  if(!name){ alert('Enter a schedule name'); return; }
-  if(name==='24/7 Access' || name==='No Access'){ alert('Built-in schedules are fixed. Create a custom schedule.'); return; }
-  const out={}; const days=['mon','tue','wed','thu','fri','sat','sun'];
-  days.forEach(d=>{ out[d]=[]; document.querySelectorAll(`[data-day="${d}"]`).forEach(div=>{ const ins=div.querySelectorAll('input'); const s=ins[0].value.trim(); const e=ins[1].value.trim(); if(s&&e) out[d].push([s,e]); }); });
-  await action('upsert_schedule',{ name, spec: out });
-  location.reload();
+  const name = document.getElementById('schedName').value.trim();
+  if (!name){ alert('Enter a schedule name'); return; }
+  if (name === '24/7 Access' || name === 'No Access'){ alert('Built-in schedules are fixed. Create a custom schedule.'); return; }
+  const out = {};
+  const days = ['mon','tue','wed','thu','fri','sat','sun'];
+  days.forEach(day => {
+    out[day] = [];
+    document.querySelectorAll(`[data-day="${day}"]`).forEach(div => {
+      const inputs = div.querySelectorAll('input');
+      const start = inputs[0].value.trim();
+      const end = inputs[1].value.trim();
+      if (start && end) out[day].push([start, end]);
+    });
+  });
+  try {
+    await action('upsert_schedule', { name, spec: out });
+    location.reload();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    alert('Failed to save schedule: ' + (err && err.message ? err.message : err));
+  }
 }
+
 async function del(){
-  const name=document.getElementById('schedName').value.trim();
-  if(!name) return;
-  if(name==='24/7 Access' || name==='No Access'){ alert('Built-in schedules cannot be deleted.'); return; }
-  await action('delete_schedule',{ name });
-  location.reload();
+  const name = document.getElementById('schedName').value.trim();
+  if (!name) return;
+  if (name === '24/7 Access' || name === 'No Access'){ alert('Built-in schedules cannot be deleted.'); return; }
+  try {
+    await action('delete_schedule', { name });
+    location.reload();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    alert('Failed to delete schedule: ' + (err && err.message ? err.message : err));
+  }
 }
+
 async function load(){
-  const st=await getState(); SCHEDS=st.schedules||{};
-  const sel=document.getElementById('schedSel'); 
-  const names=Object.keys(SCHEDS);
-  sel.innerHTML=names.map(n=>`<option>${n}</option>`).join('');
-  sel.addEventListener('change', e=>{ document.getElementById('schedName').value=e.target.value; render(e.target.value); });
-  if(names.length){
-    sel.value = names[0];
-    document.getElementById('schedName').value=sel.value; 
-    render(sel.value);
+  try {
+    const st = await getState();
+    SCHEDS = st.schedules || {};
+    const sel = document.getElementById('schedSel');
+    const names = Object.keys(SCHEDS);
+    sel.innerHTML = names.map(n => `<option>${n}</option>`).join('');
+    sel.addEventListener('change', (e) => {
+      document.getElementById('schedName').value = e.target.value;
+      render(e.target.value);
+    });
+    if (names.length){
+      sel.value = names[0];
+      document.getElementById('schedName').value = sel.value;
+      render(sel.value);
+    } else {
+      document.getElementById('schedName').value = '';
+      document.getElementById('editor').innerHTML = '';
+    }
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    alert('Failed to load schedules: ' + (err && err.message ? err.message : err));
   }
 }
 </script>

--- a/custom_components/AK_Access_ctrl/www/settings.html
+++ b/custom_components/AK_Access_ctrl/www/settings.html
@@ -13,6 +13,25 @@
     label{ color:#fff; }
     .muted{ color:var(--muted); }
     .small-mono{ font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .saved-input-wrap{ position:relative; max-width:220px; width:100%; }
+    .saved-input-wrap input{ width:100%; }
+    .saved-overlay{
+      position:absolute;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      border-radius:0.375rem;
+      background:rgba(25,135,84,0.85);
+      color:#fff;
+      font-weight:600;
+      letter-spacing:0.05em;
+      text-transform:uppercase;
+      pointer-events:none;
+      opacity:0;
+      transition:opacity 0.2s ease-in-out;
+    }
+    .saved-overlay.visible{ opacity:1; }
   </style>
 </head>
 <body>
@@ -69,14 +88,71 @@ const BEARER = findHaToken();
 const AUTH_HEADERS = BEARER ? { 'Authorization': 'Bearer ' + BEARER } : {};
 const SAME_ORIGIN = { credentials: 'same-origin' };
 
+function buildError(res, text){
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err){
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+function redirectToUnauthorized(params = {}){
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    href = buildHref('unauthorized', targetParams);
+  } catch (err) {}
+
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  } catch (err) {}
+
+  if (!delivered) {
+    try { window.location.replace(href); }
+    catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err){
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
 async function apiGet(url){
   const r = await fetch(url, { ...SAME_ORIGIN, headers: AUTH_HEADERS });
-  if (!r.ok) throw new Error(await r.text());
+  if (!r.ok){
+    const text = await r.text();
+    const err = buildError(r, text);
+    handleAuthError(err);
+    throw err;
+  }
   return r.json();
 }
 async function apiPost(url, body){
   const r = await fetch(url, { method:'POST', ...SAME_ORIGIN, headers:{'Content-Type':'application/json', ...AUTH_HEADERS}, body: JSON.stringify(body||{}) });
-  if (!r.ok) throw new Error(await r.text());
+  if (!r.ok){
+    const text = await r.text();
+    const err = buildError(r, text);
+    handleAuthError(err);
+    throw err;
+  }
   return r.json();
 }
 const UI_ROOT = '/akuvox-ac';
@@ -121,20 +197,100 @@ function openInApp(view, params = {}, options = {}) {
 const API_SETTINGS = '/api/akuvox_ac/ui/settings';
 const API_PHONES = '/api/akuvox_ac/ui/phones';
 
-let SETTINGS_DATA = { integrity_interval_minutes: null, alerts: { targets: {} }, registry_users: [] };
+let SETTINGS_DATA = { integrity_interval_minutes: null, auto_sync_delay_minutes: 30, alerts: { targets: {} }, registry_users: [] };
 let PHONES = [];
 let USERS = [];
 let ALERT_TARGETS = {};
 let alertsSaving = false;
 let integritySaving = false;
+let integritySavedTimer = null;
+let autoSyncSaving = false;
+let autoSyncSavedTimer = null;
 
 function setBusy(yes){ document.getElementById('busy').style.display = yes ? 'inline-block':'none'; }
+function hideIntegritySavedOverlay(){
+  const overlay = document.getElementById('integritySavedOverlay');
+  if (!overlay) return;
+  overlay.classList.remove('visible');
+  if (integritySavedTimer){
+    clearTimeout(integritySavedTimer);
+    integritySavedTimer = null;
+  }
+}
+function showIntegritySavedOverlay(message = 'Saved'){
+  const overlay = document.getElementById('integritySavedOverlay');
+  if (!overlay) return;
+  overlay.textContent = message;
+  overlay.classList.add('visible');
+  if (integritySavedTimer){
+    clearTimeout(integritySavedTimer);
+  }
+  integritySavedTimer = setTimeout(() => {
+    overlay.classList.remove('visible');
+    integritySavedTimer = null;
+  }, 5000);
+}
+function hideAutoSyncSavedOverlay(){
+  const overlay = document.getElementById('autoSyncSavedOverlay');
+  if (!overlay) return;
+  overlay.classList.remove('visible');
+  if (autoSyncSavedTimer){
+    clearTimeout(autoSyncSavedTimer);
+    autoSyncSavedTimer = null;
+  }
+}
+function showAutoSyncSavedOverlay(message = 'Saved'){
+  const overlay = document.getElementById('autoSyncSavedOverlay');
+  if (!overlay) return;
+  overlay.textContent = message;
+  overlay.classList.add('visible');
+  if (autoSyncSavedTimer){
+    clearTimeout(autoSyncSavedTimer);
+  }
+  autoSyncSavedTimer = setTimeout(() => {
+    overlay.classList.remove('visible');
+    autoSyncSavedTimer = null;
+  }, 5000);
+}
 function setIntegrityStatus(text, tone = 'muted') {
   const el = document.getElementById('integrityStatus');
   if (!el) return;
-  if (!text) { el.textContent = ''; el.classList.add('visually-hidden'); return; }
+  if (tone === 'success') {
+    el.textContent = '';
+    el.className = 'visually-hidden small mt-2';
+    showIntegritySavedOverlay(text || 'Saved');
+    return;
+  }
+  hideIntegritySavedOverlay();
+  if (!text) {
+    el.textContent = '';
+    el.className = 'visually-hidden small mt-2';
+    return;
+  }
   el.textContent = text;
-  el.className = tone === 'error' ? 'text-danger' : tone === 'success' ? 'text-success' : 'muted';
+  el.className = 'small mt-2';
+  if (tone === 'error') el.classList.add('text-danger');
+  else el.classList.add('muted');
+}
+function setAutoSyncStatus(text, tone = 'muted') {
+  const el = document.getElementById('autoSyncStatus');
+  if (!el) return;
+  if (tone === 'success') {
+    el.textContent = '';
+    el.className = 'visually-hidden small mt-2';
+    showAutoSyncSavedOverlay(text || 'Saved');
+    return;
+  }
+  hideAutoSyncSavedOverlay();
+  if (!text) {
+    el.textContent = '';
+    el.className = 'visually-hidden small mt-2';
+    return;
+  }
+  el.textContent = text;
+  el.className = 'small mt-2';
+  if (tone === 'error') el.classList.add('text-danger');
+  else el.classList.add('muted');
 }
 function setAlertsStatus(text, tone = 'muted') {
   const el = document.getElementById('alertsStatus');
@@ -143,6 +299,31 @@ function setAlertsStatus(text, tone = 'muted') {
   el.textContent = text;
   el.className = tone === 'error' ? 'text-danger small' : tone === 'success' ? 'text-success small' : 'muted small';
   el.classList.remove('visually-hidden');
+}
+
+function autoSyncRange(){
+  const minRaw = Number(SETTINGS_DATA?.min_auto_sync_delay_minutes);
+  const maxRaw = Number(SETTINGS_DATA?.max_auto_sync_delay_minutes);
+  const min = Number.isFinite(minRaw) ? Math.max(1, Math.round(minRaw)) : 5;
+  let max = Number.isFinite(maxRaw) ? Math.round(maxRaw) : 60;
+  if (max < min) max = min;
+  return { min, max };
+}
+
+function renderAutoSyncDelay(){
+  const input = document.getElementById('autoSyncDelayInput');
+  if (!input) return;
+  const { min, max } = autoSyncRange();
+  let minutes = Number(SETTINGS_DATA.auto_sync_delay_minutes);
+  if (!Number.isFinite(minutes)) minutes = 30;
+  minutes = Math.round(minutes);
+  if (minutes < min) minutes = min;
+  if (minutes > max) minutes = max;
+  SETTINGS_DATA.auto_sync_delay_minutes = minutes;
+  input.min = String(min);
+  input.max = String(max);
+  input.value = String(minutes);
+  setAutoSyncStatus('');
 }
 
 function minutesToHHMM(minutes){
@@ -333,15 +514,40 @@ async function saveIntegrity(minutes){
     const res = await apiPost(API_SETTINGS, { integrity_interval_minutes: minutes });
     if (res.integrity_interval_minutes){
       SETTINGS_DATA.integrity_interval_minutes = res.integrity_interval_minutes;
-      setIntegrityStatus('Saved ✓', 'success');
+      setIntegrityStatus('Saved', 'success');
     } else {
-      setIntegrityStatus('Saved ✓', 'success');
+      setIntegrityStatus('Saved', 'success');
     }
   }catch(err){
+    if (handleAuthError(err)) return;
     setIntegrityStatus('Save failed', 'error');
     alert('Failed to update integrity interval: ' + (err && err.message ? err.message : err));
   }finally{
     integritySaving = false;
+  }
+}
+
+async function saveAutoSyncDelay(minutes){
+  if (autoSyncSaving) return;
+  autoSyncSaving = true;
+  try{
+    setAutoSyncStatus('Saving…');
+    const res = await apiPost(API_SETTINGS, { auto_sync_delay_minutes: minutes });
+    const returned = Number(res.auto_sync_delay_minutes);
+    if (Number.isFinite(returned)){
+      const { min, max } = autoSyncRange();
+      const normalized = Math.min(max, Math.max(min, Math.round(returned)));
+      SETTINGS_DATA.auto_sync_delay_minutes = normalized;
+      const input = document.getElementById('autoSyncDelayInput');
+      if (input) input.value = String(normalized);
+    }
+    setAutoSyncStatus('Saved', 'success');
+  }catch(err){
+    if (handleAuthError(err)) return;
+    setAutoSyncStatus('Save failed', 'error');
+    alert('Failed to update automatic sync delay: ' + (err && err.message ? err.message : err));
+  }finally{
+    autoSyncSaving = false;
   }
 }
 
@@ -358,6 +564,7 @@ async function saveAlerts(){
     }
     setAlertsStatus('Saved ✓', 'success');
   }catch(err){
+    if (handleAuthError(err)) return;
     setAlertsStatus('Save failed', 'error');
     alert('Failed to update alerts: ' + (err && err.message ? err.message : err));
   }finally{
@@ -370,16 +577,34 @@ async function loadData(){
   try{
     const [settingsResp, phonesResp] = await Promise.all([
       apiGet(API_SETTINGS),
-      apiGet(API_PHONES).catch(() => ({ phones: [] }))
+      apiGet(API_PHONES).catch((err) => {
+        handleAuthError(err);
+        return { phones: [] };
+      })
     ]);
-    SETTINGS_DATA = settingsResp || { integrity_interval_minutes: 15, alerts: { targets: {} }, registry_users: [] };
+    SETTINGS_DATA = settingsResp || { integrity_interval_minutes: 15, auto_sync_delay_minutes: 30, alerts: { targets: {} }, registry_users: [] };
+    const minDelay = Number(settingsResp?.min_auto_sync_delay_minutes);
+    const maxDelay = Number(settingsResp?.max_auto_sync_delay_minutes);
+    const safeMinDelay = Number.isFinite(minDelay) ? Math.max(1, Math.round(minDelay)) : 5;
+    const safeMaxDelay = Number.isFinite(maxDelay) ? Math.max(safeMinDelay, Math.round(maxDelay)) : Math.max(safeMinDelay, 60);
+    SETTINGS_DATA.min_auto_sync_delay_minutes = safeMinDelay;
+    SETTINGS_DATA.max_auto_sync_delay_minutes = safeMaxDelay;
+    const rawDelayValue = SETTINGS_DATA.auto_sync_delay_minutes;
+    let delayValue = Number(rawDelayValue);
+    if (!Number.isFinite(delayValue) || rawDelayValue === null || rawDelayValue === undefined || rawDelayValue === '') delayValue = 30;
+    delayValue = Math.round(delayValue);
+    if (delayValue < safeMinDelay) delayValue = safeMinDelay;
+    if (delayValue > safeMaxDelay) delayValue = safeMaxDelay;
+    SETTINGS_DATA.auto_sync_delay_minutes = delayValue;
     PHONES = Array.isArray(phonesResp.phones) ? phonesResp.phones : [];
     USERS = Array.isArray(SETTINGS_DATA.registry_users) ? SETTINGS_DATA.registry_users : [];
     ALERT_TARGETS = (SETTINGS_DATA.alerts && SETTINGS_DATA.alerts.targets) ? { ...SETTINGS_DATA.alerts.targets } : {};
     Object.keys(ALERT_TARGETS).forEach(ensureTargetDefaults);
+    renderAutoSyncDelay();
     renderIntegrity();
     renderAlerts();
   } catch (err){
+    if (handleAuthError(err)) return;
     alert('Failed to load settings: ' + (err && err.message ? err.message : err));
   } finally {
     setBusy(false);
@@ -392,7 +617,35 @@ document.addEventListener('DOMContentLoaded', () => {
     openInApp('index', {}, { replaceState: true });
   });
 
+  const autoSyncInput = document.getElementById('autoSyncDelayInput');
+  autoSyncInput?.addEventListener('input', () => {
+    hideAutoSyncSavedOverlay();
+    setAutoSyncStatus('');
+  });
+  autoSyncInput?.addEventListener('change', async () => {
+    const { min, max } = autoSyncRange();
+    const rawStr = (autoSyncInput.value ?? '').toString().trim();
+    if (!rawStr){
+      setAutoSyncStatus(`Enter a number between ${min} and ${max}`, 'error');
+      return;
+    }
+    const raw = Number(rawStr);
+    if (!Number.isFinite(raw)){
+      setAutoSyncStatus(`Enter a number between ${min} and ${max}`, 'error');
+      return;
+    }
+    const val = Math.round(raw);
+    if (val < min || val > max){
+      setAutoSyncStatus(`Enter a number between ${min} and ${max}`, 'error');
+      return;
+    }
+    SETTINGS_DATA.auto_sync_delay_minutes = val;
+    autoSyncInput.value = String(val);
+    await saveAutoSyncDelay(val);
+  });
+
   const integrityInput = document.getElementById('integrityInput');
+  integrityInput?.addEventListener('input', hideIntegritySavedOverlay);
   integrityInput?.addEventListener('change', async () => {
     const val = hhmmToMinutes(integrityInput.value);
     if (val === null){
@@ -426,11 +679,24 @@ document.addEventListener('DOMContentLoaded', () => {
   </div>
 
   <div class="card mt-3">
+    <div class="card-header">Automatic Change Sync Delay</div>
+    <div class="card-body">
+      <p class="muted">Set how long to wait before automatically syncing user updates to every participating device. Lower values push changes out sooner, while higher values batch multiple edits together. Choose between 5 and 60 minutes.</p>
+      <div class="saved-input-wrap">
+        <input id="autoSyncDelayInput" class="form-control" type="number" min="5" max="60" step="1" />
+        <div id="autoSyncSavedOverlay" class="saved-overlay">Saved</div>
+      </div>
+      <div id="autoSyncStatus" class="visually-hidden small mt-2"></div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
     <div class="card-header">Integrity Check Interval</div>
     <div class="card-body">
-      <p class="muted">Set how often Home Assistant performs the integrity check. Minimum 5 minutes, maximum 24 hours.</p>
-      <div class="d-flex align-items-center gap-2" style="max-width: 220px;">
+      <p class="muted">Integrity checks automatically compare each device's data with the server so everything stays accurate and up to date. Choose how often to run them (minimum 5 minutes, maximum 24 hours).</p>
+      <div class="saved-input-wrap">
         <input id="integrityInput" class="form-control" placeholder="HH:MM" />
+        <div id="integritySavedOverlay" class="saved-overlay">Saved</div>
       </div>
       <div id="integrityStatus" class="visually-hidden small mt-2"></div>
     </div>

--- a/custom_components/AK_Access_ctrl/www/unauthorized.html
+++ b/custom_components/AK_Access_ctrl/www/unauthorized.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Access Denied</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
+  <style>
+    :root{
+      --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#a5b5cc;
+      --accent:#0dcaf0; --accent-dark:#0a92ad;
+    }
+    html, body { height:100%; }
+    body {
+      margin:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      background:var(--bg);
+      color:var(--text);
+      font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    .card{
+      background:var(--card);
+      border:1px solid var(--border);
+      border-radius:0.75rem;
+      max-width:420px;
+      padding:2.25rem 2rem;
+      text-align:center;
+      box-shadow:0 1.25rem 2.5rem rgba(0,0,0,0.35);
+    }
+    h1{ font-size:1.5rem; margin-bottom:1rem; }
+    p{ color:var(--muted); margin-bottom:1.25rem; }
+    .btn-primary{
+      background:var(--accent);
+      border-color:var(--accent-dark);
+      color:#02131d;
+      font-weight:600;
+    }
+    .btn-primary:hover,
+    .btn-primary:focus{
+      background:var(--accent-dark);
+      border-color:var(--accent-dark);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Authentication Required</h1>
+    <p>The Akuvox dashboard can only be opened from inside your Home Assistant UI or with a valid long-lived access token.</p>
+    <div class="d-grid gap-2">
+      <a class="btn btn-primary" href="/">Go to Home Assistant</a>
+      <button class="btn btn-outline-light" id="retry">Retry dashboard</button>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const retryBtn = document.getElementById('retry');
+    if (!retryBtn) return;
+    retryBtn.addEventListener('click', () => {
+      try {
+        const params = new URLSearchParams(location.search);
+        const token = sessionStorage.getItem('akuvox_ll_token');
+        if (token && !params.has('token')) params.set('token', token);
+        const search = params.toString();
+        const target = `/akuvox-ac/index${search ? `?${search}` : ''}`;
+        window.location.replace(target);
+      } catch (err) {
+        window.location.replace('/akuvox-ac/index');
+      }
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/custom_components/AK_Access_ctrl/www/users.html
+++ b/custom_components/AK_Access_ctrl/www/users.html
@@ -72,14 +72,71 @@ const BEARER = findHaToken();
 const AUTH_HEADERS = BEARER ? { 'Authorization': 'Bearer ' + BEARER } : {};
 const SAME_ORIGIN = { credentials: 'same-origin' };
 
+function buildError(res, text){
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err){
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+function redirectToUnauthorized(params = {}){
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    href = buildHref('unauthorized', targetParams);
+  } catch (err) {}
+
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  } catch (err) {}
+
+  if (!delivered) {
+    try { window.location.replace(href); }
+    catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err){
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
 async function apiGet(url){
   const r = await fetch(url, { ...SAME_ORIGIN, headers: AUTH_HEADERS });
-  if (!r.ok) throw new Error(await r.text());
+  if (!r.ok){
+    const text = await r.text();
+    const err = buildError(r, text);
+    handleAuthError(err);
+    throw err;
+  }
   return r.json();
 }
 async function apiPost(url, body){
   const r = await fetch(url, { method:'POST', ...SAME_ORIGIN, headers:{'Content-Type':'application/json', ...AUTH_HEADERS}, body: JSON.stringify(body||{}) });
-  if (!r.ok) throw new Error(await r.text());
+  if (!r.ok){
+    const text = await r.text();
+    const err = buildError(r, text);
+    handleAuthError(err);
+    throw err;
+  }
   return r.json();
 }
 const UI_ROOT = '/akuvox-ac';
@@ -179,6 +236,7 @@ async function heartbeatTick() {
     }
     reservationMisses = 0;
   } catch (err) {
+    if (handleAuthError(err)) return;
     reservationMisses += 1;
     if (reservationMisses >= 6) {
       setReservationMessage('Connection lost. Releasing reserved ID and trying again…', 'warning');
@@ -217,6 +275,7 @@ async function reserveNewId(options = {}) {
     return newId;
   } catch (err) {
     RESERVED_ID = null;
+    if (handleAuthError(err)) return '';
     if (options.showWarning !== false) {
       setReservationMessage('ID reserve failed. You can still press <b>Save</b> to create a user, then return to upload a face.', 'warning');
     }
@@ -310,6 +369,7 @@ async function load(){
     try {
       state = await apiGet('/api/akuvox_ac/ui/state');
     } catch (err) {
+      if (handleAuthError(err)) return;
       console.warn('Failed to load Akuvox state', err);
       alert('Failed to load Akuvox data. Default values will be used until the connection succeeds.');
       state = { schedules: {}, registry_users: [] };
@@ -322,6 +382,7 @@ async function load(){
       const resp = await apiGet('/api/akuvox_ac/ui/phones');
       PHONES = resp.phones || [];
     } catch (err) {
+      if (handleAuthError(err)) return;
       console.warn('Failed to load phone list', err);
       PHONES = [];
     }
@@ -451,7 +512,9 @@ async function save(){
           document.getElementById('idRow').style.display = 'block';
           document.getElementById('user_id').value = CURRENT.id;
         }
-      }catch{}
+      }catch(err){
+        if (handleAuthError(err)) return;
+      }
       if (!CURRENT.id){
         alert('Could not reserve a user ID. Please try again.');
         return;
@@ -472,11 +535,18 @@ async function save(){
     };
 
     // Save/update the profile against the reserved ID
-    await fetch('/api/services/akuvox_ac/edit_user', {
+    const saveRes = await fetch('/api/services/akuvox_ac/edit_user', {
       method:'POST',
       headers:{'Content-Type':'application/json', ...AUTH_HEADERS},
       body: JSON.stringify({ id: CURRENT.id, ...payload })
     });
+    if (!saveRes.ok){
+      const txt = await saveRes.text();
+      const err = buildError(saveRes, txt);
+      handleAuthError(err);
+      throw err;
+    }
+    try { await saveRes.json(); } catch {}
 
     // If a photo is selected, upload it now
     const fileInput = document.getElementById('facefile');
@@ -492,7 +562,9 @@ async function save(){
       });
       if (!r.ok){
         const t = await r.text();
-        throw new Error(t || 'Face upload failed');
+        const err = buildError(r, t);
+        handleAuthError(err);
+        throw err;
       }
       try { await r.json(); } catch {}
     }
@@ -504,10 +576,11 @@ async function save(){
     if (remoteVisible && phoneService){
       try{
         await apiPost('/api/akuvox_ac/ui/remote_enrol', { id: CURRENT.id, phone_service: phoneService });
-        const resSpan = document.getElementById('remoteResult'); 
+        const resSpan = document.getElementById('remoteResult');
         if (resSpan) resSpan.textContent = 'Enrolment request sent.';
       }catch(e){
-        const resSpan = document.getElementById('remoteResult'); 
+        if (handleAuthError(e)) return;
+        const resSpan = document.getElementById('remoteResult');
         if (resSpan) resSpan.textContent = 'Failed to send enrolment request.';
       }
     }
@@ -517,6 +590,7 @@ async function save(){
     RESERVED_ID = null;
     openInApp('index', {}, { replaceState: true });
   } catch (e){
+    if (handleAuthError(e)) return;
     alert('Save failed: ' + (e && e.message ? e.message : e));
   } finally {
     setBusy(false);


### PR DESCRIPTION
## Summary
- add an unauthorised static page and register it so the dashboard can send users there instead of rendering the main views
- teach each dashboard page to detect authentication failures and redirect to the unauthorised page rather than showing inline warnings
- harden face upload and schedule editors to surface real errors while using the same redirect handling

## Testing
- python -m compileall custom_components

------
https://chatgpt.com/codex/tasks/task_e_68cfc450fbe8832c8cfc1ae9fbb5eeff