### PR TITLE
Ensure Akuvox dashboard keeps Home Assistant auth signatures

### DIFF
--- a/custom_components/AK_Access_ctrl/www/device_edit.html
+++ b/custom_components/AK_Access_ctrl/www/device_edit.html
@@ -141,6 +141,76 @@ function findHaToken() {
 const SAME_ORIGIN = { credentials: 'same-origin' };
 const REJECTED_TOKENS = new Set();
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search) {
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value) {
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      const parent = window.parent;
+      try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig() {
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+
 function nextBearerToken(){
   const token = findHaToken();
   if (!token) return null;
@@ -222,6 +292,8 @@ function buildHref(slug, params = {}) {
   });
   const token = sessionStorage.getItem('akuvox_ll_token');
   if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const clean = String(slug || '').replace(/_/g, '-');
   return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
@@ -266,7 +338,22 @@ function redirectToUnauthorized(params = {}) {
   let href = '/akuvox-ac/unauthorized';
   try {
     href = buildHref('unauthorized', targetParams);
-  } catch (err) {}
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      if (targetParams && typeof targetParams === 'object') {
+        Object.entries(targetParams).forEach(([key, value]) => {
+          if (value !== undefined && value !== null && value !== '') search.set(key, value);
+        });
+      }
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
 
   let delivered = false;
   try {

--- a/custom_components/AK_Access_ctrl/www/face_rec.html
+++ b/custom_components/AK_Access_ctrl/www/face_rec.html
@@ -26,6 +26,76 @@ function findHaToken(){ const t = sessionStorage.getItem('akuvox_ll_token'); ret
 const SAME_ORIGIN = { credentials: 'same-origin' };
 const REJECTED_TOKENS = new Set();
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search){
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value){
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      const parent = window.parent;
+      try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig(){
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+
 function nextBearerToken(){
   const token = findHaToken();
   if (!token) return null;
@@ -85,12 +155,13 @@ function redirectToUnauthorized(){
 
   let href = '/akuvox-ac/unauthorized';
   try {
+    const search = new URLSearchParams();
     const token = sessionStorage.getItem('akuvox_ll_token');
-    if (token) {
-      const search = new URLSearchParams();
-      search.set('token', token);
-      href = `/akuvox-ac/unauthorized?${search.toString()}`;
-    }
+    if (token) search.set('token', token);
+    const authSig = currentAuthSig();
+    if (authSig) search.set('authSig', authSig);
+    const query = search.toString();
+    if (query) href = `/akuvox-ac/unauthorized?${query}`;
   } catch (err) {}
 
   try { window.location.replace(href); }

--- a/custom_components/AK_Access_ctrl/www/head.html
+++ b/custom_components/AK_Access_ctrl/www/head.html
@@ -135,6 +135,76 @@ function getToken(){
   return sessionStorage.getItem('akuvox_ll_token') || null;
 }
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search) {
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value) {
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      try { window.parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig() {
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+window.AK_AC_AUTH_SIG = currentAuthSig();
+
 function collectSignedPaths(){
   const result = {};
   const merge = (candidate) => {
@@ -187,6 +257,8 @@ function buildUrl(view, params = {}){
   });
   const token = getToken();
   if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const slug = view.replace(/_/g,'-');
   return `${UI_ROOT}/${slug}${query ? `?${query}` : ''}`;
@@ -230,6 +302,8 @@ function updateHistory(view, params, { replaceState = false } = {}){
   });
   if (view !== DEFAULT_VIEW) search.set('view', view);
   else search.delete('view');
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const url = query ? `${location.pathname}?${query}` : location.pathname;
   if (replaceState) history.replaceState(state, '', url);

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -92,6 +92,76 @@ function findHaToken() {
 const SAME_ORIGIN = { credentials: 'same-origin' };
 const REJECTED_TOKENS = new Set();
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search) {
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value) {
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      const parent = window.parent;
+      try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig() {
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+
 function nextBearerToken(){
   const token = findHaToken();
   if (!token) return null;
@@ -182,6 +252,8 @@ function buildHref(slug, params = {}) {
   });
   const token = sessionStorage.getItem('akuvox_ll_token');
   if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const clean = String(slug || '').replace(/_/g, '-');
   return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
@@ -228,7 +300,20 @@ function redirectToUnauthorized(params = {}) {
     if (typeof buildHref === 'function') {
       href = buildHref('unauthorized', targetParams);
     }
-  } catch (err) {}
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      Object.entries(targetParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') search.set(key, value);
+      });
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
 
   let delivered = false;
   try {

--- a/custom_components/AK_Access_ctrl/www/schedules.html
+++ b/custom_components/AK_Access_ctrl/www/schedules.html
@@ -19,6 +19,76 @@ const UI_ROOT = '/akuvox-ac';
 const SAME_ORIGIN = { credentials: 'same-origin' };
 const REJECTED_TOKENS = new Set();
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search){
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value){
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      const parent = window.parent;
+      try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig(){
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+
 function findHaToken(){
   return sessionStorage.getItem('akuvox_ll_token') || null;
 }
@@ -74,6 +144,8 @@ function buildHref(slug, params = {}){
   });
   const token = findHaToken();
   if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const clean = String(slug || '').replace(/_/g, '-');
   return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
@@ -320,10 +392,26 @@ async function load(){
     <div class="mt-3 d-flex gap-2">
       <button class="btn btn-success" onclick="save()">Save</button>
       <button class="btn btn-danger" onclick="del()">Delete</button>
-      <a class="btn btn-secondary" href="/akuvox-ac/index">Back</a>
+      <a class="btn btn-secondary" id="backBtn" href="#">Back</a>
     </div>
   </div>
 </div>
-<script>load()</script>
+<script>
+load();
+(function initBackButton(){
+  try {
+    const back = document.getElementById('backBtn');
+    if (!back) return;
+    const href = buildHref('index');
+    back.setAttribute('href', href);
+    back.addEventListener('click', (ev) => {
+      const delivered = requestParentNav('index', {}, { replaceState: false });
+      if (delivered) {
+        ev.preventDefault();
+      }
+    });
+  } catch (err) {}
+})();
+</script>
 </body>
 </html>

--- a/custom_components/AK_Access_ctrl/www/settings.html
+++ b/custom_components/AK_Access_ctrl/www/settings.html
@@ -116,6 +116,76 @@ function findHaToken(){
 const SAME_ORIGIN = { credentials: 'same-origin' };
 const REJECTED_TOKENS = new Set();
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search){
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value){
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      const parent = window.parent;
+      try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig(){
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+
 function nextBearerToken(){
   const token = findHaToken();
   if (!token) return null;
@@ -171,7 +241,20 @@ function redirectToUnauthorized(params = {}){
   let href = '/akuvox-ac/unauthorized';
   try {
     href = buildHref('unauthorized', targetParams);
-  } catch (err) {}
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      Object.entries(targetParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') search.set(key, value);
+      });
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
 
   let delivered = false;
   try {
@@ -263,6 +346,8 @@ function buildHref(slug, params = {}) {
   });
   const token = sessionStorage.getItem('akuvox_ll_token');
   if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const clean = String(slug || '').replace(/_/g, '-');
   return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;

--- a/custom_components/AK_Access_ctrl/www/unauthorized.html
+++ b/custom_components/AK_Access_ctrl/www/unauthorized.html
@@ -55,6 +55,76 @@
   </div>
 
   <script>
+  const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+  function readAuthSigFrom(search = location.search){
+    try {
+      const params = new URLSearchParams(search);
+      const value = params.get('authSig');
+      return value || '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function rememberAuthSig(value){
+    if (!value) return;
+    try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+    try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+    try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+    try {
+      if (window.parent && window.parent !== window) {
+        const parent = window.parent;
+        try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+        try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+        try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+      }
+    } catch (err) {}
+  }
+
+  function currentAuthSig(){
+    const fromUrl = readAuthSigFrom();
+    if (fromUrl) {
+      rememberAuthSig(fromUrl);
+      return fromUrl;
+    }
+
+    const sources = [
+      () => {
+        try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+      },
+      () => {
+        try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+      },
+      () => {
+        try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+      },
+      () => {
+        try {
+          if (window.parent && window.parent !== window) {
+            const parent = window.parent;
+            return parent.AK_AC_AUTH_SIG
+              || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+              || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+          }
+        } catch (err) {}
+        return null;
+      }
+    ];
+
+    for (const getter of sources) {
+      const value = getter();
+      if (value) {
+        rememberAuthSig(value);
+        return value;
+      }
+    }
+
+    return '';
+  }
+
+  rememberAuthSig(readAuthSigFrom());
+
   (function(){
     const retryBtn = document.getElementById('retry');
     if (!retryBtn) return;
@@ -63,11 +133,19 @@
         const params = new URLSearchParams(location.search);
         const token = sessionStorage.getItem('akuvox_ll_token');
         if (token && !params.has('token')) params.set('token', token);
+        const authSig = currentAuthSig();
+        if (authSig && !params.has('authSig')) params.set('authSig', authSig);
         const search = params.toString();
         const target = `/akuvox-ac/index${search ? `?${search}` : ''}`;
         window.location.replace(target);
       } catch (err) {
-        window.location.replace('/akuvox-ac/index');
+        const authSig = currentAuthSig();
+        if (authSig) {
+          const suffix = `?authSig=${encodeURIComponent(authSig)}`;
+          window.location.replace(`/akuvox-ac/index${suffix}`);
+        } else {
+          window.location.replace('/akuvox-ac/index');
+        }
       }
     });
   })();

--- a/custom_components/AK_Access_ctrl/www/users.html
+++ b/custom_components/AK_Access_ctrl/www/users.html
@@ -71,6 +71,76 @@ function findHaToken(){
 const SAME_ORIGIN = { credentials: 'same-origin' };
 const REJECTED_TOKENS = new Set();
 
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search){
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value){
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      const parent = window.parent;
+      try { parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig(){
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+
+  const sources = [
+    () => {
+      try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; }
+    },
+    () => {
+      try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; }
+    },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+
+  return '';
+}
+
+rememberAuthSig(readAuthSigFrom());
+
 function nextBearerToken(){
   const token = findHaToken();
   if (!token) return null;
@@ -126,7 +196,20 @@ function redirectToUnauthorized(params = {}){
   let href = '/akuvox-ac/unauthorized';
   try {
     href = buildHref('unauthorized', targetParams);
-  } catch (err) {}
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      Object.entries(targetParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') search.set(key, value);
+      });
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
 
   let delivered = false;
   try {
@@ -229,6 +312,8 @@ function buildHref(slug, params = {}) {
   });
   const token = sessionStorage.getItem('akuvox_ll_token');
   if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
   const query = search.toString();
   const clean = String(slug || '').replace(/_/g, '-');
   return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;


### PR DESCRIPTION
## Summary
- capture the Home Assistant `authSig` query on all Akuvox UI pages and persist it for reuse
- update dashboard navigation helpers to append the stored signature when building links and redirects
- adjust unauthorized fallbacks and back links so reloads keep working when already signed in

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfede25888832c9ebf7df26f380d7b