### PR TITLE
Refine header actions and global control flow

### DIFF
--- a/custom_components/AK_Access_ctrl/www/head.html
+++ b/custom_components/AK_Access_ctrl/www/head.html
@@ -9,7 +9,8 @@
   <style>
     :root {
       --bg:#0b1320; --panel:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#a5b5cc;
-      --accent:#0dcaf0; --accent-dark:#0a92ad;
+      --accent:#2ff0c4; --accent-dark:#1ba987;
+      --mint:#2ff0c4; --mint-soft:rgba(47,240,196,.18); --mint-glow:rgba(47,240,196,.35);
     }
     html, body { height: 100%; }
     body {
@@ -36,28 +37,37 @@
     }
     header.app-header .brand {
       display: flex;
-      flex-direction: column;
-      gap: 0.35rem;
-    }
-    header.app-header h1 {
-      font-size: 1.5rem;
-      margin: 0;
-      display: flex;
       align-items: center;
       gap: 0.75rem;
     }
-    header.app-header h1 .bi {
-      font-size: 1.3em;
-      color: var(--accent);
+    header.app-header h1 {
+      font-size: 1.25rem;
+      margin: 0;
     }
-    header.app-header .version-badge {
-      align-self: flex-start;
-      font-size: 0.85rem;
-      background: rgba(13,202,240,.15);
-      color: var(--accent);
-      border: 1px solid rgba(13,202,240,.35);
-      border-radius: 999px;
-      padding: 0.2rem 0.75rem;
+    header.app-header .logo-mark {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.75rem;
+      height: 2.75rem;
+      border-radius: 0.9rem;
+      background: linear-gradient(135deg, var(--mint), rgba(132,255,231,.85));
+      box-shadow: 0 0.6rem 1.2rem rgba(47,240,196,.22);
+      position: relative;
+      overflow: hidden;
+    }
+    header.app-header .logo-mark::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 30% 30%, rgba(255,255,255,.35), rgba(255,255,255,0));
+      pointer-events: none;
+    }
+    header.app-header .logo-mark .bi {
+      font-size: 1.35rem;
+      color: #031d21;
+      position: relative;
+      z-index: 1;
     }
     nav.nav-buttons {
       display: flex;
@@ -90,7 +100,44 @@
       background: var(--accent);
       border-color: var(--accent);
       color: #031420;
-      box-shadow: 0 0 0 0.15rem rgba(13,202,240,.25);
+      box-shadow: 0 0 0 0.15rem rgba(47,240,196,.28);
+    }
+    .nav-quick-actions {
+      display: none;
+      width: 100%;
+      margin-top: 0.35rem;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .nav-quick-actions.active { display: flex; }
+    .nav-quick-actions .quick-group {
+      display: none;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .nav-quick-actions .quick-group.expanded { display: flex; }
+    .nav-quick-actions .quick-btn {
+      border-radius: 0.75rem;
+      border: 1px solid var(--mint-glow);
+      background: var(--mint-soft);
+      color: var(--text);
+      padding: 0.35rem 0.9rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: all .2s ease;
+    }
+    .nav-quick-actions .quick-btn .bi {
+      color: var(--mint);
+      font-size: 1rem;
+    }
+    .nav-quick-actions .quick-btn:hover,
+    .nav-quick-actions .quick-btn:focus {
+      background: rgba(47,240,196,.25);
+      border-color: rgba(47,240,196,.6);
+      outline: none;
     }
     .mobile-launcher {
       display: none;
@@ -106,10 +153,24 @@
       color: var(--muted);
       margin-bottom: 0.35rem;
     }
+    .mobile-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
+    .mobile-group + .mobile-group { margin-top: 0.5rem; }
     .mobile-launcher .mobile-subgrid {
-      display: grid;
+      display: none;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       gap: 0.6rem;
+    }
+    .mobile-group.expanded .mobile-subgrid { display: grid; }
+    .mobile-group [data-group-toggle] {
+      border: 1px solid rgba(47,240,196,.25);
+    }
+    .mobile-group.expanded [data-group-toggle] {
+      border-color: rgba(47,240,196,.55);
+      box-shadow: 0 0.8rem 1.5rem rgba(3,20,32,.55);
     }
     .mobile-tile {
       border: 1px solid rgba(13,202,240,.25);
@@ -199,6 +260,7 @@
       }
       header.app-header h1 { font-size: 1.25rem; }
       nav.nav-buttons { width: 100%; justify-content: flex-start; display: none; }
+      .nav-quick-actions { display: none !important; }
       .mobile-launcher { display: grid; }
       .frame-wrap { padding: 0.5rem 0.75rem 1rem; }
       footer.app-footer { padding: 0.5rem 0.75rem 1rem; text-align: left; }
@@ -209,32 +271,58 @@
 <div class="head-wrap">
   <header class="app-header">
     <div class="brand">
-      <h1><i class="bi bi-shield-lock-fill"></i> Akuvox Access Control</h1>
-      <span class="version-badge" id="appVersion">Loading…</span>
+      <h1 class="visually-hidden">Akuvox Access Control</h1>
+      <span class="logo-mark" aria-hidden="true"><i class="bi bi-shield-lock-fill"></i></span>
     </div>
     <nav class="nav-buttons" aria-label="Primary navigation">
-      <button class="nav-btn" data-view="index">
+      <button class="nav-btn" type="button" data-view="index">
         <i class="bi bi-speedometer2"></i>
         <span>Overview</span>
       </button>
-      <button class="nav-btn" data-view="users">
+      <button class="nav-btn" type="button" data-view="users" data-group-toggle="users">
         <i class="bi bi-people-fill"></i>
         <span>User Management</span>
       </button>
-      <button class="nav-btn" data-view="device-edit">
+      <button class="nav-btn" type="button" data-view="index" data-section="global-actions" data-group-toggle="global">
+        <i class="bi bi-lightning-fill"></i>
+        <span>Global Actions</span>
+      </button>
+      <button class="nav-btn" type="button" data-view="device-edit">
         <i class="bi bi-hdd-network"></i>
         <span>Device Management</span>
       </button>
-      <button class="nav-btn" data-view="settings">
+      <button class="nav-btn" type="button" data-view="settings">
         <i class="bi bi-gear-wide-connected"></i>
         <span>Global Settings</span>
       </button>
     </nav>
+    <div class="nav-quick-actions" id="navQuickActions">
+      <div class="quick-group" data-group="users">
+        <button type="button" class="quick-btn" data-view="users" data-mode="add">
+          <i class="bi bi-person-plus-fill"></i>
+          <span>Add user</span>
+        </button>
+        <button type="button" class="quick-btn" data-view="users" data-mode="edit">
+          <i class="bi bi-person-gear"></i>
+          <span>Edit user</span>
+        </button>
+      </div>
+      <div class="quick-group" data-group="global">
+        <button type="button" class="quick-btn" data-action="reboot_all">
+          <i class="bi bi-arrow-repeat"></i>
+          <span>Reboot all</span>
+        </button>
+        <button type="button" class="quick-btn" data-action="force_full_sync">
+          <i class="bi bi-lightning-charge-fill"></i>
+          <span>Force full sync</span>
+        </button>
+      </div>
+    </div>
   </header>
   <section class="mobile-launcher" id="mobileLauncher" aria-label="Quick actions">
-    <div>
+    <div class="mobile-group" data-group="users">
       <div class="mobile-group-title">User management</div>
-      <button class="mobile-tile" data-view="index" data-section="users">
+      <button class="mobile-tile" type="button" data-view="index" data-section="users" data-group-toggle="users" aria-expanded="false">
         <div class="tile-text">
           <span class="tile-title">User management</span>
           <small>Review access levels and sync state</small>
@@ -242,14 +330,14 @@
         <i class="bi bi-people-fill"></i>
       </button>
       <div class="mobile-subgrid">
-        <button class="mobile-tile sub" data-view="users" data-mode="add">
+        <button class="mobile-tile sub" type="button" data-view="users" data-mode="add">
           <div class="tile-text">
             <span class="tile-title">Add user</span>
             <small>Create a new access profile</small>
           </div>
           <i class="bi bi-person-plus-fill"></i>
         </button>
-        <button class="mobile-tile sub" data-view="users" data-mode="edit">
+        <button class="mobile-tile sub" type="button" data-view="users" data-mode="edit">
           <div class="tile-text">
             <span class="tile-title">Edit user</span>
             <small>Pick someone to update or revoke access</small>
@@ -258,21 +346,47 @@
         </button>
       </div>
     </div>
-    <button class="mobile-tile" data-view="index" data-section="devices">
+    <div class="mobile-group" data-group="global">
+      <div class="mobile-group-title">Global actions</div>
+      <button class="mobile-tile" type="button" data-view="index" data-section="global-actions" data-group-toggle="global" aria-expanded="false">
+        <div class="tile-text">
+          <span class="tile-title">Global actions</span>
+          <small>Trigger device-wide jobs</small>
+        </div>
+        <i class="bi bi-lightning-fill"></i>
+      </button>
+      <div class="mobile-subgrid">
+        <button class="mobile-tile sub" type="button" data-action="reboot_all">
+          <div class="tile-text">
+            <span class="tile-title">Reboot all</span>
+            <small>Restart every connected panel</small>
+          </div>
+          <i class="bi bi-arrow-repeat"></i>
+        </button>
+        <button class="mobile-tile sub" type="button" data-action="force_full_sync">
+          <div class="tile-text">
+            <span class="tile-title">Force full sync</span>
+            <small>Refresh credentials everywhere</small>
+          </div>
+          <i class="bi bi-lightning-charge-fill"></i>
+        </button>
+      </div>
+    </div>
+    <button class="mobile-tile" type="button" data-view="index" data-section="devices">
       <div class="tile-text">
         <span class="tile-title">Device management</span>
         <small>Check health, reboot or sync panels</small>
       </div>
       <i class="bi bi-hdd-network"></i>
     </button>
-    <button class="mobile-tile" data-view="index" data-section="events">
+    <button class="mobile-tile" type="button" data-view="index" data-section="events">
       <div class="tile-text">
         <span class="tile-title">Event history</span>
         <small>See the latest entries and alarms</small>
       </div>
       <i class="bi bi-clock-history"></i>
     </button>
-    <button class="mobile-tile" data-view="settings">
+    <button class="mobile-tile" type="button" data-view="settings">
       <div class="tile-text">
         <span class="tile-title">Global settings</span>
         <small>Tune schedules, relays and automation</small>
@@ -301,6 +415,7 @@
 
 const UI_ROOT = '/akuvox-ac';
 const DEFAULT_VIEW = 'index';
+let expandedGroup = null;
 
 function getToken(){
   return sessionStorage.getItem('akuvox_ll_token') || null;
@@ -602,6 +717,26 @@ function paramsFromSearch(search){
   return out;
 }
 
+function updateGroupExpansion(){
+  document.querySelectorAll('[data-group]').forEach(group => {
+    const key = group.dataset.group;
+    if (!key) return;
+    const expanded = expandedGroup === key;
+    group.classList.toggle('expanded', expanded);
+  });
+  document.querySelectorAll('[data-group-toggle]').forEach(toggle => {
+    const key = toggle.dataset.groupToggle;
+    if (!key) return;
+    const expanded = expandedGroup === key;
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  });
+  const quickContainer = document.getElementById('navQuickActions');
+  if (quickContainer) {
+    const hasExpanded = !!quickContainer.querySelector('.quick-group.expanded');
+    quickContainer.classList.toggle('active', hasExpanded);
+  }
+}
+
 function setActiveNav(view){
   let frameParams = null;
   try {
@@ -615,31 +750,68 @@ function setActiveNav(view){
   const activeMode = frameParams ? (frameParams.searchParams.get('mode') || '') : '';
   const hasUserId = frameParams ? frameParams.searchParams.has('id') : false;
   const currentSection = frameParams ? (frameParams.searchParams.get('section') || '') : '';
+  const sectionLower = currentSection.toLowerCase();
 
   document.querySelectorAll('nav.nav-buttons .nav-btn').forEach(btn => {
     const target = normalizeView(btn.dataset.view);
-    if (target === view) btn.classList.add('active');
-    else btn.classList.remove('active');
-  });
-  document.querySelectorAll('.mobile-launcher [data-view]').forEach(btn => {
-    const target = normalizeView(btn.dataset.view);
-    let isActive = target === view;
-    if (isActive && target === 'users') {
-      const btnMode = (btn.dataset.mode || '').toLowerCase();
-      if (btnMode === 'edit') {
-        isActive = hasUserId || activeMode === 'edit';
-      } else if (btnMode === 'add') {
-        isActive = !hasUserId && activeMode !== 'edit';
+    let isActive = false;
+    if (target === 'index') {
+      if (view === 'index') {
+        const btnSection = (btn.dataset.section || '').toLowerCase();
+        if (btnSection) {
+          isActive = sectionLower === btnSection;
+        } else {
+          isActive = !sectionLower;
+        }
       }
-    } else if (isActive && target === 'index') {
-      const btnSection = (btn.dataset.section || '').toLowerCase();
-      if (btnSection) {
-        isActive = currentSection.toLowerCase() === btnSection;
-      }
+    } else {
+      isActive = target === view;
     }
     if (isActive) btn.classList.add('active');
     else btn.classList.remove('active');
   });
+
+  document.querySelectorAll('.mobile-launcher [data-view]').forEach(btn => {
+    const target = normalizeView(btn.dataset.view);
+    let isActive = false;
+    if (target === 'users') {
+      if (view === 'users') {
+        isActive = true;
+        const btnMode = (btn.dataset.mode || '').toLowerCase();
+        if (btnMode === 'edit') {
+          isActive = hasUserId || activeMode === 'edit';
+        } else if (btnMode === 'add') {
+          isActive = !hasUserId && activeMode !== 'edit';
+        }
+      }
+    } else if (target === 'index') {
+      if (view === 'index') {
+        const btnSection = (btn.dataset.section || '').toLowerCase();
+        if (btnSection) {
+          isActive = sectionLower === btnSection;
+        } else {
+          isActive = !sectionLower;
+        }
+      }
+    } else {
+      isActive = target === view;
+    }
+    if (isActive) btn.classList.add('active');
+    else btn.classList.remove('active');
+  });
+
+  const userActive = view === 'users' || (view === 'index' && sectionLower === 'users');
+  const globalActive = view === 'index' && sectionLower === 'global-actions';
+
+  if (userActive) {
+    expandedGroup = 'users';
+  } else if (globalActive) {
+    expandedGroup = 'global';
+  } else if (expandedGroup) {
+    expandedGroup = null;
+  }
+
+  updateGroupExpansion();
 }
 
 function updateHistory(view, params, { replaceState = false } = {}){
@@ -662,9 +834,12 @@ function loadView(view, params = {}, options = {}){
   const normalized = normalizeView(view);
   const href = buildUrl(normalized, params);
   const frame = document.getElementById('viewFrame');
-  if (frame.dataset.currentHref !== href) {
-    frame.src = href;
-    frame.dataset.currentHref = href;
+  if (frame) {
+    if (frame.dataset.currentHref !== href) {
+      frame.src = href;
+      frame.dataset.currentHref = href;
+    }
+    frame.dataset.currentView = normalized;
   }
   setActiveNav(normalized);
   if (options.updateHistory !== false) {
@@ -682,6 +857,35 @@ function paramsFromButton(btn){
   return params;
 }
 
+function runDashboardAction(action){
+  const normalized = String(action || '').toLowerCase();
+  if (!normalized) return;
+  const frame = document.getElementById('viewFrame');
+  if (!frame) return;
+
+  const previousHref = frame.dataset.currentHref;
+  loadView('index', { section: 'global-actions' });
+  const changed = frame.dataset.currentHref !== previousHref;
+
+  const deliver = () => {
+    try {
+      frame.contentWindow?.postMessage({ type: 'akuvox-action', action: normalized }, window.location.origin);
+    } catch (err) {
+      console.warn('Failed to deliver Akuvox action', err);
+    }
+  };
+
+  if (changed) {
+    const onLoad = () => {
+      frame.removeEventListener('load', onLoad);
+      deliver();
+    };
+    frame.addEventListener('load', onLoad, { once: true });
+  } else {
+    deliver();
+  }
+}
+
 async function fetchVersion(){
   const badge = document.getElementById('appVersion');
   const footer = document.getElementById('appFooter');
@@ -695,12 +899,12 @@ async function fetchVersion(){
     if (!res.ok) throw new Error(await res.text());
     const data = await res.json();
     const label = data?.kpis?.version || '—';
-    badge.textContent = label;
+    if (badge) badge.textContent = label;
     const raw = data?.kpis?.version_raw || '';
-    footer.textContent = raw ? `Integration version ${label} (${raw})` : `Integration version ${label}`;
+    if (footer) footer.textContent = raw ? `Integration version ${label} (${raw})` : `Integration version ${label}`;
   } catch (err) {
-    badge.textContent = 'Version unavailable';
-    footer.textContent = 'Unable to load version information';
+    if (badge) badge.textContent = 'Version unavailable';
+    if (footer) footer.textContent = 'Unable to load version information';
   }
 }
 
@@ -709,6 +913,9 @@ document.querySelectorAll('nav.nav-buttons .nav-btn').forEach(btn => {
     ev.preventDefault();
     const view = normalizeView(btn.dataset.view);
     const params = paramsFromButton(btn);
+    const group = btn.dataset.groupToggle || null;
+    expandedGroup = group || null;
+    updateGroupExpansion();
     loadView(view, params, { replaceState: false });
   });
 });
@@ -718,9 +925,47 @@ document.querySelectorAll('.mobile-launcher [data-view]').forEach(btn => {
     ev.preventDefault();
     const view = normalizeView(btn.dataset.view);
     const params = paramsFromButton(btn);
+    const isSubAction = !!btn.closest('.mobile-subgrid');
+    const toggleGroup = btn.dataset.groupToggle || null;
+    const parentGroup = btn.closest('[data-group]')?.dataset.group || null;
+
+    if (toggleGroup) {
+      expandedGroup = toggleGroup;
+    } else if (isSubAction && parentGroup) {
+      expandedGroup = parentGroup;
+    } else if (!isSubAction) {
+      expandedGroup = null;
+    }
+    updateGroupExpansion();
     loadView(view, params, { replaceState: false });
   });
 });
+
+document.querySelectorAll('#navQuickActions [data-view]').forEach(btn => {
+  btn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    const view = normalizeView(btn.dataset.view);
+    const params = paramsFromButton(btn);
+    const group = btn.closest('[data-group]')?.dataset.group || null;
+    if (group) expandedGroup = group;
+    updateGroupExpansion();
+    loadView(view, params, { replaceState: false });
+  });
+});
+
+document.querySelectorAll('#navQuickActions [data-action], .mobile-launcher [data-action]').forEach(btn => {
+  btn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    const action = (btn.dataset.action || '').toLowerCase();
+    if (!action) return;
+    const group = btn.closest('[data-group]')?.dataset.group || null;
+    if (group) expandedGroup = group;
+    updateGroupExpansion();
+    runDashboardAction(action);
+  });
+});
+
+updateGroupExpansion();
 
 window.addEventListener('message', (event) => {
   if (event.origin !== window.location.origin) return;

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -1285,6 +1285,20 @@ function focusSectionFromParams(){
   } catch (err) {}
 }
 
+window.addEventListener('message', (event) => {
+  if (event.origin !== window.location.origin) return;
+  const data = event.data || {};
+  if (data.type !== 'akuvox-action') return;
+  const action = String(data.action || '').toLowerCase();
+  if (action === 'reboot_all' || action === 'reboot') {
+    rebootAll();
+  } else if (action === 'force_full_sync' || action === 'sync_all') {
+    forceFullSync();
+  } else if (action === 'sync_now') {
+    syncAllNow();
+  }
+});
+
 // ✅ Wait until the DOM exists before wiring buttons/inputs
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btnSyncNowEta')?.addEventListener('click', syncAllNow);
@@ -1392,11 +1406,6 @@ setInterval(refresh, 5000);
   <div class="workspace">
     <div class="kpi">
       <div class="kpi-group">
-        <div class="box2"><button id="btnRebootAll" class="btn btn-danger"><i class="bi bi-power"></i> Reboot All</button></div>
-        <div class="box2"><button id="btnForceFull" class="btn btn-warning"><i class="bi bi-arrow-repeat"></i> Force Full Sync</button></div>
-        <div class="box2"><button id="btnGlobalSettings" class="btn btn-secondary"><i class="bi bi-gear"></i> Global Settings</button></div>
-      </div>
-      <div class="kpi-group justify-content-end">
         <div class="box text-end"><div>Users</div><div id="kpiUsers">—</div></div>
         <div class="box text-end"><div>Devices</div><div id="kpiDevices">—</div></div>
         <div class="box text-end"><div>Pending Sync</div><div id="kpiPending">—</div></div>


### PR DESCRIPTION
## Summary
- restyle the dashboard header with a mint integration mark and collapsible quick-action controls
- add desktop and mobile quick actions for users and new global actions that trigger dashboard services
- remove redundant global buttons from the overview and relay global actions through the iframe

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d06a533860832c9aad17a4a5b30a2a