### PR TITLE
Align dashboard actions with KPI row

### DIFF
--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -33,10 +33,12 @@
     .section-33{height:32.5vh; display:flex; gap:1rem}
     .section-50{height:32.5vh; display:flex; flex-direction:column; min-height:0}
     .card-body{ overflow:auto; }
-    .kpi{display:flex;justify-content:space-between;align-items:center;gap:2rem;flex-wrap:nowrap}
-    .kpi-group{display:flex;gap:.75rem;flex-wrap:nowrap}
-    .box,.box2{background:#0e1a2c;border:1px solid #1c2e4f;border-radius:.5rem;padding:.5rem 1rem;min-width:110px;display:flex;flex-direction:column;justify-content:center}
-    .box2{align-items:center}
+    .kpi{display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap}
+    .kpi-actions{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}
+    .kpi-actions .btn{white-space:nowrap}
+    .kpi-sync-now{display:flex;align-items:center}
+    .kpi-group{display:flex;gap:.75rem;flex-wrap:wrap;margin-left:auto;justify-content:flex-end}
+    .box{background:#0e1a2c;border:1px solid #1c2e4f;border-radius:.5rem;padding:.5rem 1rem;min-width:110px;display:flex;flex-direction:column;justify-content:center}
     .btn{font-size:.85rem}
     .footer-note{opacity:.65;font-size:.8rem;text-align:center}
     .table-center th, .table-center td { text-align:center; vertical-align:middle; }
@@ -48,7 +50,6 @@
     .event-title.bad{color:var(--bad)}
     .event-title.dim{color:var(--dim)}
     .event-time{display:block; font-size:.78rem; color:var(--muted); margin-top:.15rem}
-    .autosync-flash{background:rgba(46,204,113,.18);color:var(--ok);font-weight:600;border-color:var(--ok)!important}
     .card.pulse-highlight{border-color:rgba(13,202,240,.55);box-shadow:0 0 0 0.15rem rgba(13,202,240,.25);transition:border-color .3s ease, box-shadow .3s ease}
     @media (max-width: 1200px){
       .workspace{ width:95vw; }
@@ -56,16 +57,19 @@
     @media (max-width: 992px){
       .workspace{ width:96vw; }
       .kpi{flex-direction:column;align-items:stretch;gap:1rem;}
-      .kpi-group{flex-wrap:wrap;justify-content:flex-start;}
+      .kpi-actions{width:100%;}
+      .kpi-group{flex-wrap:wrap;justify-content:flex-start;width:100%;}
     }
     @media (max-width: 720px){
       body{font-size:0.95rem;}
       .workspace{ width:100%; padding:0 0.75rem 1.5rem; gap:0.75rem; }
       .kpi{flex-direction:column;gap:0.75rem;}
+      .kpi-actions{flex-direction:column;align-items:stretch;gap:0.5rem;}
+      .kpi-actions .btn{width:100%;}
+      .kpi-sync-now{width:100%;}
+      .kpi-sync-now .btn{width:100%;}
       .kpi-group{flex-wrap:wrap;gap:0.5rem;width:100%;justify-content:stretch;}
-      .box,.box2{min-width:0;width:100%;align-items:flex-start;text-align:left;}
-      .box2{flex-direction:row;justify-content:space-between;}
-      .box2 .btn, .box .btn{width:100%;}
+      .box{min-width:0;width:100%;align-items:flex-start;text-align:left;}
       .section-33,.section-50{height:auto;flex-direction:column;}
       .card-body{overflow:auto;max-height:none;}
       .card-header{flex-wrap:wrap;gap:0.5rem;}
@@ -554,53 +558,6 @@ function badge(text, kind, attrs = ''){
   return `<span class="badge status-indicator ${k}" title="${label}" aria-label="${label}"${attr}><span class="status-dot" aria-hidden="true"></span><span class="status-text">${label}</span></span>`;
 }
 
-let autoSyncSavedTimer = null;
-function resetAutoSyncIndicator(){
-  const input = document.getElementById('autoSyncInput');
-  if (!input) return;
-  if (autoSyncSavedTimer){
-    clearTimeout(autoSyncSavedTimer);
-    autoSyncSavedTimer = null;
-  }
-  const prev = input.dataset.prevValue;
-  const wasReadonly = input.dataset.prevReadonly;
-  if (prev !== undefined) {
-    input.value = prev;
-  }
-  if (wasReadonly === '0') {
-    input.removeAttribute('readonly');
-  }
-  delete input.dataset.prevValue;
-  delete input.dataset.prevReadonly;
-  input.classList.remove('autosync-flash');
-}
-function showAutoSyncSaved(msg = 'Saved ✓', restoreValue = null){
-  const input = document.getElementById('autoSyncInput');
-  if (!input) return;
-  const status = document.getElementById('autoSyncStatus');
-  if (status) {
-    status.textContent = msg;
-  }
-  const restore = restoreValue !== null ? restoreValue : input.value;
-  input.dataset.prevValue = restore;
-  input.dataset.prevReadonly = input.hasAttribute('readonly') ? '1' : '0';
-  input.value = msg;
-  input.classList.add('autosync-flash');
-  input.setAttribute('readonly', 'readonly');
-  if (autoSyncSavedTimer) clearTimeout(autoSyncSavedTimer);
-  autoSyncSavedTimer = setTimeout(() => {
-    const prev = input.dataset.prevValue ?? '';
-    input.value = prev;
-    if (input.dataset.prevReadonly === '0') {
-      input.removeAttribute('readonly');
-    }
-    delete input.dataset.prevValue;
-    delete input.dataset.prevReadonly;
-    input.classList.remove('autosync-flash');
-    autoSyncSavedTimer = null;
-  }, 1500);
-}
-
 function renderKPIs(k){
   const nextEl = document.getElementById('kpiNext');
   if (k.next_sync_eta) {
@@ -630,9 +587,9 @@ function renderKPIs(k){
     else forceBtn.removeAttribute('disabled');
   }
   const auto = k.auto_sync_time;
-  if (auto) {
-    const el = document.getElementById('autoSyncInput');
-    if (el && !el.value) el.value = auto;
+  const autoEl = document.getElementById('kpiAutoSync');
+  if (autoEl) {
+    autoEl.textContent = auto || '—';
   }
   const footer = document.querySelector('.footer-note');
   if (footer) {
@@ -1319,32 +1276,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const autoEl = document.getElementById('autoSyncInput');
-  autoEl?.addEventListener('focus', resetAutoSyncIndicator);
-  autoEl?.addEventListener('change', async () => {
-    const v = (autoEl.value || '').trim();
-    if (!/^\d{2}:\d{2}$/.test(v)) { alert('Use HH:MM'); return; }
-    let ok = false;
-    try {
-      await apiPost(actionUrl, { action:'set_daily_sync', payload:{ time:v } });
-      ok = true;
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      try {
-        await callService('akuvox_ac','set_daily_sync', { time: v });
-        ok = true;
-      } catch (fallbackErr) {
-        if (handleAuthError(fallbackErr)) return;
-      }
-    }
-    if (ok) {
-      document.getElementById('kpiNext').textContent = v;
-      showAutoSyncSaved(undefined, v);
-    } else {
-      alert('Failed to update auto sync time');
-    }
-  });
-
   // initial + poll
   refresh();
   setInterval(refresh, 5000);
@@ -1405,17 +1336,20 @@ setInterval(refresh, 5000);
 
   <div class="workspace">
     <div class="kpi">
+      <div class="kpi-actions">
+        <div class="kpi-sync-now" id="kpiSyncNowBox" style="display:none;">
+          <button id="btnSyncNowEta" class="btn btn-sm btn-primary"><i class="bi bi-lightning-fill"></i> Sync Now</button>
+        </div>
+        <button id="btnForceFull" class="btn btn-sm btn-outline-light"><i class="bi bi-lightning-charge-fill"></i> Force Full Sync</button>
+        <button id="btnRebootAll" class="btn btn-sm btn-outline-light"><i class="bi bi-arrow-repeat"></i> Reboot All</button>
+        <button id="btnGlobalSettings" class="btn btn-sm btn-outline-light"><i class="bi bi-gear-wide-connected"></i> Global Settings</button>
+      </div>
       <div class="kpi-group">
         <div class="box text-end"><div>Users</div><div id="kpiUsers">—</div></div>
         <div class="box text-end"><div>Devices</div><div id="kpiDevices">—</div></div>
         <div class="box text-end"><div>Pending Sync</div><div id="kpiPending">—</div></div>
         <div class="box text-end"><div>Next Sync</div><div id="kpiNext">—</div></div>
-        <div class="box2" id="kpiSyncNowBox" style="display:none;"><button id="btnSyncNowEta" class="btn btn-sm btn-primary"><i class="bi bi-lightning-fill"></i> Sync Now </button></div>
-        <div class="box text-end">
-          <div>Auto Sync</div>
-          <input id="autoSyncInput" class="form-control form-control-sm" placeholder="HH:MM" style="width:6rem;display:inline-block">
-          <div id="autoSyncStatus" class="visually-hidden">Saved ✓</div>
-        </div>
+        <div class="box text-end"><div>Auto Sync</div><div id="kpiAutoSync">—</div></div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- place dashboard action buttons on the same row as the KPI counters with updated flex styling
- surface the auto sync time as a read-only KPI value and remove the inline editor from the overview page
- keep button wiring intact for sync, force sync, reboot, and global settings shortcuts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d072475bc0832c86fe6111659177a3