### PR TITLE
Improve mobile dashboard navigation

### DIFF
--- a/custom_components/AK_Access_ctrl/www/head.html
+++ b/custom_components/AK_Access_ctrl/www/head.html
@@ -146,13 +146,6 @@
       padding: 0 1.5rem 1rem;
       gap: 0.75rem;
     }
-    .mobile-launcher .mobile-group-title {
-      font-size: 0.78rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--muted);
-      margin-bottom: 0.35rem;
-    }
     .mobile-group {
       display: flex;
       flex-direction: column;
@@ -239,6 +232,28 @@
       color: var(--muted);
       text-align: right;
     }
+    .mobile-back-btn {
+      display: none;
+      align-items: center;
+      gap: 0.4rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text);
+      padding: 0.4rem 0.95rem;
+      font-size: 0.9rem;
+      cursor: pointer;
+      transition: all .2s ease;
+    }
+    .mobile-back-btn .bi {
+      font-size: 1.1rem;
+    }
+    .mobile-back-btn:focus,
+    .mobile-back-btn:hover {
+      background: rgba(13,202,240,.12);
+      border-color: rgba(13,202,240,.5);
+      outline: none;
+    }
     @media (max-width: 900px) {
       header.app-header {
         padding: 0.85rem 1rem 0.65rem;
@@ -264,6 +279,13 @@
       .mobile-launcher { display: grid; }
       .frame-wrap { padding: 0.5rem 0.75rem 1rem; }
       footer.app-footer { padding: 0.5rem 0.75rem 1rem; text-align: left; }
+      body.mobile-stage-nav .frame-wrap,
+      body.mobile-stage-nav footer.app-footer { display: none; }
+      body.mobile-stage-nav .mobile-launcher { display: grid; }
+      body.mobile-stage-content .mobile-launcher { display: none; }
+      body.mobile-stage-content .frame-wrap,
+      body.mobile-stage-content footer.app-footer { display: block; }
+      body.mobile-stage-content .mobile-back-btn { display: inline-flex; }
     }
   </style>
 </head>
@@ -274,6 +296,10 @@
       <h1 class="visually-hidden">Akuvox Access Control</h1>
       <span class="logo-mark" aria-hidden="true"><i class="bi bi-shield-lock-fill"></i></span>
     </div>
+    <button class="mobile-back-btn" type="button" id="mobileBackBtn">
+      <i class="bi bi-chevron-left"></i>
+      <span>Back</span>
+    </button>
     <nav class="nav-buttons" aria-label="Primary navigation">
       <button class="nav-btn" type="button" data-view="index">
         <i class="bi bi-speedometer2"></i>
@@ -321,8 +347,7 @@
   </header>
   <section class="mobile-launcher" id="mobileLauncher" aria-label="Quick actions">
     <div class="mobile-group" data-group="users">
-      <div class="mobile-group-title">User management</div>
-      <button class="mobile-tile" type="button" data-view="index" data-section="users" data-group-toggle="users" aria-expanded="false">
+      <button class="mobile-tile" type="button" data-group-toggle="users" aria-expanded="false">
         <div class="tile-text">
           <span class="tile-title">User management</span>
           <small>Review access levels and sync state</small>
@@ -330,6 +355,13 @@
         <i class="bi bi-people-fill"></i>
       </button>
       <div class="mobile-subgrid">
+        <button class="mobile-tile sub" type="button" data-view="index" data-section="users">
+          <div class="tile-text">
+            <span class="tile-title">User overview</span>
+            <small>See device sync and assigned groups</small>
+          </div>
+          <i class="bi bi-layout-text-window-reverse"></i>
+        </button>
         <button class="mobile-tile sub" type="button" data-view="users" data-mode="add">
           <div class="tile-text">
             <span class="tile-title">Add user</span>
@@ -347,8 +379,7 @@
       </div>
     </div>
     <div class="mobile-group" data-group="global">
-      <div class="mobile-group-title">Global actions</div>
-      <button class="mobile-tile" type="button" data-view="index" data-section="global-actions" data-group-toggle="global" aria-expanded="false">
+      <button class="mobile-tile" type="button" data-group-toggle="global" aria-expanded="false">
         <div class="tile-text">
           <span class="tile-title">Global actions</span>
           <small>Trigger device-wide jobs</small>
@@ -356,6 +387,13 @@
         <i class="bi bi-lightning-fill"></i>
       </button>
       <div class="mobile-subgrid">
+        <button class="mobile-tile sub" type="button" data-view="index" data-section="global-actions">
+          <div class="tile-text">
+            <span class="tile-title">Action dashboard</span>
+            <small>Open system-wide controls</small>
+          </div>
+          <i class="bi bi-speedometer"></i>
+        </button>
         <button class="mobile-tile sub" type="button" data-action="reboot_all">
           <div class="tile-text">
             <span class="tile-title">Reboot all</span>
@@ -416,6 +454,10 @@
 const UI_ROOT = '/akuvox-ac';
 const DEFAULT_VIEW = 'index';
 let expandedGroup = null;
+const MOBILE_BREAKPOINT = '(max-width: 720px)';
+const mobileMedia = window.matchMedia(MOBILE_BREAKPOINT);
+let isMobileMode = mobileMedia.matches;
+let mobileStage = isMobileMode ? 'nav' : 'content';
 
 function getToken(){
   return sessionStorage.getItem('akuvox_ll_token') || null;
@@ -565,6 +607,61 @@ function walkAuthWindows(start) {
   }
   attach(window);
 })();
+
+function applyMobileFlags(){
+  const body = document.body;
+  if (!body) return;
+  body.classList.toggle('mobile-mode', isMobileMode);
+  body.classList.toggle('mobile-stage-nav', isMobileMode && mobileStage === 'nav');
+  body.classList.toggle('mobile-stage-content', !isMobileMode || mobileStage === 'content');
+}
+
+function syncHistoryStage(forceStage){
+  try {
+    const current = history.state || {};
+    const nextStage = typeof forceStage === 'string' && forceStage
+      ? forceStage
+      : (isMobileMode ? mobileStage : 'content');
+    const nextState = { ...current, mobileStage: nextStage };
+    history.replaceState(nextState, '', location.href);
+  } catch (err) {}
+}
+
+function setMobileStage(stage, { preserveGroups = false } = {}){
+  if (!isMobileMode) {
+    mobileStage = 'content';
+    return;
+  }
+  mobileStage = stage === 'content' ? 'content' : 'nav';
+  if (mobileStage === 'nav' && !preserveGroups) {
+    expandedGroup = null;
+  }
+  applyMobileFlags();
+  updateGroupExpansion();
+  syncHistoryStage();
+}
+
+function handleMobileMediaChange(ev){
+  isMobileMode = !!ev.matches;
+  if (isMobileMode) {
+    mobileStage = 'nav';
+    applyMobileFlags();
+    updateGroupExpansion();
+    syncHistoryStage('nav');
+  } else {
+    mobileStage = 'content';
+    applyMobileFlags();
+    updateGroupExpansion();
+    syncHistoryStage('content');
+  }
+}
+
+applyMobileFlags();
+if (typeof mobileMedia.addEventListener === 'function') {
+  mobileMedia.addEventListener('change', handleMobileMediaChange);
+} else if (typeof mobileMedia.addListener === 'function') {
+  mobileMedia.addListener(handleMobileMediaChange);
+}
 
 const AUTH_SIG_KEY = 'akuvox_auth_sig';
 
@@ -803,19 +900,22 @@ function setActiveNav(view){
   const userActive = view === 'users' || (view === 'index' && sectionLower === 'users');
   const globalActive = view === 'index' && sectionLower === 'global-actions';
 
-  if (userActive) {
-    expandedGroup = 'users';
-  } else if (globalActive) {
-    expandedGroup = 'global';
-  } else if (expandedGroup) {
-    expandedGroup = null;
+  const allowAutoExpand = !(isMobileMode && mobileStage === 'nav');
+  if (allowAutoExpand) {
+    if (userActive) {
+      expandedGroup = 'users';
+    } else if (globalActive) {
+      expandedGroup = 'global';
+    } else if (expandedGroup) {
+      expandedGroup = null;
+    }
   }
 
   updateGroupExpansion();
 }
 
 function updateHistory(view, params, { replaceState = false } = {}){
-  const state = { view, params };
+  const state = { view, params, mobileStage: isMobileMode ? mobileStage : 'content' };
   const search = new URLSearchParams();
   Object.entries(params || {}).forEach(([k,v]) => {
     if (v !== undefined && v !== null && v !== '') search.set(k, v);
@@ -864,6 +964,7 @@ function runDashboardAction(action){
   if (!frame) return;
 
   const previousHref = frame.dataset.currentHref;
+  if (isMobileMode) setMobileStage('content', { preserveGroups: true });
   loadView('index', { section: 'global-actions' });
   const changed = frame.dataset.currentHref !== previousHref;
 
@@ -914,29 +1015,42 @@ document.querySelectorAll('nav.nav-buttons .nav-btn').forEach(btn => {
     const view = normalizeView(btn.dataset.view);
     const params = paramsFromButton(btn);
     const group = btn.dataset.groupToggle || null;
-    expandedGroup = group || null;
+    if (group) {
+      expandedGroup = expandedGroup === group ? null : group;
+    } else {
+      expandedGroup = null;
+    }
     updateGroupExpansion();
     loadView(view, params, { replaceState: false });
   });
 });
 
-document.querySelectorAll('.mobile-launcher [data-view]').forEach(btn => {
+document.querySelectorAll('.mobile-launcher [data-view], .mobile-launcher [data-group-toggle]').forEach(btn => {
   btn.addEventListener('click', (ev) => {
     ev.preventDefault();
-    const view = normalizeView(btn.dataset.view);
-    const params = paramsFromButton(btn);
+    const rawView = btn.dataset.view || '';
+    const hasView = rawView.trim() !== '';
+    const view = hasView ? normalizeView(rawView) : null;
+    const params = hasView ? paramsFromButton(btn) : {};
     const isSubAction = !!btn.closest('.mobile-subgrid');
     const toggleGroup = btn.dataset.groupToggle || null;
     const parentGroup = btn.closest('[data-group]')?.dataset.group || null;
 
     if (toggleGroup) {
-      expandedGroup = toggleGroup;
+      const wasExpanded = expandedGroup === toggleGroup;
+      expandedGroup = wasExpanded ? null : toggleGroup;
+      updateGroupExpansion();
+      if (isMobileMode && !isSubAction) {
+        if (!hasView) return;
+        if (!wasExpanded) return;
+      }
+      if (!hasView && !isSubAction) return;
     } else if (isSubAction && parentGroup) {
       expandedGroup = parentGroup;
-    } else if (!isSubAction) {
-      expandedGroup = null;
+      updateGroupExpansion();
     }
-    updateGroupExpansion();
+    if (!hasView) return;
+    if (isMobileMode) setMobileStage('content');
     loadView(view, params, { replaceState: false });
   });
 });
@@ -947,8 +1061,9 @@ document.querySelectorAll('#navQuickActions [data-view]').forEach(btn => {
     const view = normalizeView(btn.dataset.view);
     const params = paramsFromButton(btn);
     const group = btn.closest('[data-group]')?.dataset.group || null;
-    if (group) expandedGroup = group;
+    if (group) expandedGroup = expandedGroup === group ? null : group;
     updateGroupExpansion();
+    if (isMobileMode) setMobileStage('content', { preserveGroups: true });
     loadView(view, params, { replaceState: false });
   });
 });
@@ -962,8 +1077,18 @@ document.querySelectorAll('#navQuickActions [data-action], .mobile-launcher [dat
     if (group) expandedGroup = group;
     updateGroupExpansion();
     runDashboardAction(action);
+    if (isMobileMode) setMobileStage('content', { preserveGroups: true });
   });
 });
+
+const mobileBackBtn = document.getElementById('mobileBackBtn');
+if (mobileBackBtn) {
+  mobileBackBtn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    if (!isMobileMode) return;
+    setMobileStage('nav');
+  });
+}
 
 updateGroupExpansion();
 
@@ -984,6 +1109,10 @@ window.addEventListener('popstate', (event) => {
   const state = event.state || {};
   const view = normalizeView(state.view || new URLSearchParams(location.search).get('view') || DEFAULT_VIEW);
   const params = state.params || paramsFromSearch(location.search);
+  if (isMobileMode) {
+    const targetStage = state.mobileStage || 'content';
+    setMobileStage(targetStage, { preserveGroups: true });
+  }
   loadView(view, params, { updateHistory: false });
 });
 


### PR DESCRIPTION
## Summary
- rework the mobile dashboard header to include a back button and hide the iframe/footer until a section is opened
- adjust the mobile launcher tiles so user/global groups expand/collapse properly and offer dedicated overview buttons instead of duplicate headings
- add mobile layout state handling in JavaScript to sync history, drive the new navigation stage, and keep quick actions responsive

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68d076850814832c83f55ad1cd494ab3