### PR TITLE
Add diagnostics view to review recent device API requests

### DIFF
--- a/custom_components/AK_Access_ctrl/www/diagnostics-mob.html
+++ b/custom_components/AK_Access_ctrl/www/diagnostics-mob.html
@@ -1,0 +1,687 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Akuvox Device Diagnostics</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  <style>
+    :root{
+      --bg:#0b1320;
+      --panel:#111a2b;
+      --border:#1b2942;
+      --text:#e6edf3;
+      --muted:#a5b5cc;
+      --accent:#2ff0c4;
+    }
+    body{
+      margin:0;
+      background:var(--bg);
+      color:var(--text);
+      font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    .diag-container{ max-width: 960px; }
+    .muted{ color: var(--muted); }
+    .card{ background:var(--panel); border:1px solid var(--border); }
+    .diag-card{ margin-top:1rem; border-radius:1rem; overflow:hidden; }
+    .diag-toggle{
+      width:100%;
+      border:0;
+      background:transparent;
+      color:inherit;
+      text-align:left;
+      padding:1rem 1.25rem;
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:1rem;
+      cursor:pointer;
+      font-size:1rem;
+    }
+    .diag-toggle:focus{ outline:2px solid rgba(47,240,196,0.35); outline-offset:2px; }
+    .diag-toggle:hover{ background:rgba(47,240,196,0.08); }
+    .diag-toggle .bi{ transition:transform 0.2s ease; }
+    .diag-toggle[aria-expanded="true"] .bi{ transform:rotate(180deg); }
+    .diag-name{ font-weight:600; }
+    .diag-meta{ font-size:0.9rem; color:var(--muted); margin-top:0.25rem; }
+    .diag-body{ background:#0d1729; border-top:1px solid var(--border); padding:1.25rem; }
+    .diag-summary-meta{ font-size:0.85rem; color:var(--muted); display:flex; gap:0.75rem; flex-wrap:wrap; }
+    .diag-request{ background:#0b172d; border:1px solid #1c2e4f; border-radius:0.75rem; margin-bottom:0.75rem; padding:0.75rem 1rem; }
+    .diag-request:last-child{ margin-bottom:0; }
+    .diag-request summary{
+      cursor:pointer;
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      gap:0.5rem;
+      font-size:0.95rem;
+      list-style:none;
+    }
+    .diag-request summary::-webkit-details-marker{ display:none; }
+    .diag-request summary:focus{ outline:2px solid rgba(47,240,196,0.35); outline-offset:2px; }
+    .diag-request-body{ margin-top:0.75rem; font-size:0.9rem; }
+    .diag-request-body .diag-row{ display:flex; flex-wrap:wrap; gap:0.75rem; margin-bottom:0.5rem; color:var(--muted); }
+    .diag-request-body .diag-row strong{ color:var(--text); font-weight:600; }
+    .diag-section{ margin-top:0.75rem; }
+    .diag-section-title{ font-weight:600; margin-bottom:0.35rem; }
+    pre{
+      background:#091021;
+      border:1px solid #15233b;
+      border-radius:0.5rem;
+      padding:0.75rem;
+      color:var(--text);
+      font-size:0.85rem;
+      line-height:1.35;
+      max-height:320px;
+      overflow:auto;
+    }
+    code{ font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .badge.method{
+      background:rgba(47,240,196,0.12);
+      color:var(--accent);
+      letter-spacing:0.05em;
+      text-transform:uppercase;
+      font-size:0.7rem;
+    }
+    .badge.method.get{ background:rgba(13,202,240,0.18); color:#0dcaf0; }
+    .badge.method.post{ background:rgba(111,66,193,0.22); color:#d5b7ff; }
+    .diag-status-badge{ font-size:0.7rem; text-transform:uppercase; letter-spacing:0.04em; }
+    .diag-status-ok{ background:rgba(25,135,84,0.22); color:#2ff0c4; }
+    .diag-status-error{ background:rgba(220,53,69,0.25); color:#ff7d8a; }
+    .diag-error-text{ color:#ff7d8a; font-weight:500; }
+    .alert.d-none{ display:none !important; }
+    @media (max-width: 768px){
+      .diag-container{ max-width:100%; padding:0 1rem; }
+      .diag-toggle{ padding:0.85rem 1rem; }
+      .diag-body{ padding:1rem; }
+      .diag-request{ padding:0.65rem 0.85rem; }
+      pre{ font-size:0.8rem; }
+    }
+  </style>
+</head>
+<body>
+<script>
+(function () {
+  const qs = new URLSearchParams(location.search);
+  const qsToken = qs.get('token');
+  if (qsToken) sessionStorage.setItem('akuvox_ll_token', qsToken);
+})();
+function persistTokens(access, refresh) {
+  if (!access) return null;
+  const payload = { access_token: access };
+  if (refresh) payload.refresh_token = refresh;
+  try { sessionStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  try { localStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  return access;
+}
+
+function extractTokenFromAuth(auth) {
+  if (!auth || typeof auth !== 'object') return null;
+  const access = auth.accessToken
+    || auth.access_token
+    || auth?.token?.access_token
+    || auth?.data?.access_token
+    || null;
+  const refresh = auth.refreshToken
+    || auth.refresh_token
+    || auth?.token?.refresh_token
+    || auth?.data?.refresh_token
+    || null;
+  if (access) {
+    return persistTokens(access, refresh);
+  }
+  return null;
+}
+
+function scanTokenStorage(storage) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem('hassTokens');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {
+        if (typeof raw === 'string' && raw.trim()) {
+          return persistTokens(raw.trim());
+        }
+      }
+    }
+    for (const key of Object.keys(storage)) {
+      if (!/auth|token|hass/i.test(key)) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {}
+    }
+  } catch (err) {}
+  return null;
+}
+
+function tokenFromWindow(win) {
+  if (!win) return null;
+  let token = null;
+  token = scanTokenStorage(win.sessionStorage) || scanTokenStorage(win.localStorage);
+  if (token) return token;
+
+  token = extractTokenFromAuth(win.hassAuth)
+    || extractTokenFromAuth(win.auth)
+    || extractTokenFromAuth(win.AK_AC_HA_AUTH)
+    || null;
+  if (token) return token;
+
+  try {
+    const conn = win.hassConnection;
+    if (conn && typeof conn.then === 'function') {
+      conn.then((resolved) => {
+        try {
+          extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+        } catch (err) {}
+      }).catch(() => {});
+    } else if (conn) {
+      token = extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      if (token) return token;
+    }
+  } catch (err) {}
+
+  return null;
+}
+
+function walkAuthWindows(start) {
+  const visited = new Set();
+  let current = start;
+  while (current && !visited.has(current)) {
+    const token = tokenFromWindow(current);
+    if (token) return token;
+    visited.add(current);
+
+    let next = null;
+    try {
+      next = current.parent;
+    } catch (err) {
+      next = null;
+    }
+    if (next && next !== current && !visited.has(next)) {
+      current = next;
+      continue;
+    }
+
+    try {
+      next = current.opener;
+    } catch (err) {
+      next = null;
+    }
+    if (next && next !== current && !visited.has(next)) {
+      current = next;
+      continue;
+    }
+
+    break;
+  }
+  return null;
+}
+
+(function bootstrapAuthWatchers() {
+  const seen = new WeakSet();
+  function attach(win) {
+    if (!win || seen.has(win)) return;
+    seen.add(win);
+    try { extractTokenFromAuth(win.hassAuth || win.auth || win.AK_AC_HA_AUTH); } catch (err) {}
+    try {
+      const conn = win.hassConnection;
+      if (conn && typeof conn.then === 'function') {
+        conn.then((resolved) => {
+          try {
+            extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+          } catch (err) {}
+        }).catch(() => {});
+      } else if (conn) {
+        extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      }
+    } catch (err) {}
+    try {
+      if (win.parent && win.parent !== win) attach(win.parent);
+    } catch (err) {}
+    try {
+      if (win.opener) attach(win.opener);
+    } catch (err) {}
+  }
+  attach(window);
+})();
+
+function findHaToken(){
+  const existing = sessionStorage.getItem('akuvox_ll_token');
+  if (existing) return existing;
+  const token = walkAuthWindows(window);
+  if (token) {
+    try { sessionStorage.setItem('akuvox_ll_token', token); } catch (err) {}
+  }
+  return token;
+}
+const SAME_ORIGIN = { credentials: 'same-origin' };
+const REJECTED_TOKENS = new Set();
+
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search){
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function currentAuthSig(){
+  const stored = sessionStorage.getItem(AUTH_SIG_KEY) || localStorage.getItem(AUTH_SIG_KEY) || '';
+  if (stored) return stored;
+  const fromQuery = readAuthSigFrom();
+  if (fromQuery) {
+    try { sessionStorage.setItem(AUTH_SIG_KEY, fromQuery); } catch (err) {}
+    try { localStorage.setItem(AUTH_SIG_KEY, fromQuery); } catch (err) {}
+    return fromQuery;
+  }
+  return '';
+}
+
+async function fetchWithAuth(url, options = {}) {
+  const token = findHaToken();
+  const headers = new Headers(options.headers || {});
+  if (token && !REJECTED_TOKENS.has(token)) {
+    headers.set('Authorization', 'Bearer ' + token);
+  }
+  const merged = { ...options, headers, ...SAME_ORIGIN };
+  try {
+    const response = await fetch(url, merged);
+    if (response.status === 401 || response.status === 403) {
+      if (token) REJECTED_TOKENS.add(token);
+    }
+    return response;
+  } catch (err) {
+    throw err;
+  }
+}
+
+function buildError(response, text) {
+  const err = new Error(response.statusText || 'Request failed');
+  err.status = response.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err){
+  if (!err) return false;
+  const status = err.status || err.code || err.error || null;
+  if (!status) return false;
+  return status === 401 || status === 403;
+}
+
+function redirectToUnauthorized(){
+  const params = new URLSearchParams(location.search);
+  const targetParams = new URLSearchParams();
+  params.forEach((value, key) => {
+    if (key === 'view' || key === 'authSig') return;
+    targetParams.set(key, value);
+  });
+  const authSig = currentAuthSig();
+  if (authSig) targetParams.set('authSig', authSig);
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) targetParams.set('token', token);
+  const query = targetParams.toString();
+  let href = `/akuvox-ac/unauthorized${query ? `?${query}` : ''}`;
+  try {
+    if (window.parent && window.parent !== window) {
+      const search = new URLSearchParams(targetParams);
+      if (authSig) search.set('authSig', authSig);
+      if (token) search.set('token', token);
+      const clean = search.toString();
+      if (clean) href = `/akuvox-ac/unauthorized?${clean}`;
+    }
+  } catch (err) {}
+
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', Object.fromEntries(targetParams), { replaceState: true });
+  } catch (err) {}
+
+  if (!delivered) {
+    try { window.location.replace(href); }
+    catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err){
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
+function collectSignedPaths(){
+  const result = {};
+  const merge = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') return;
+    for (const [key, value] of Object.entries(candidate)) {
+      if (typeof value === 'string' && value) result[key] = value;
+    }
+  };
+  const read = (storage) => {
+    if (!storage) return;
+    try {
+      const raw = storage.getItem('akuvox_signed_paths');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        merge(parsed);
+      }
+    } catch (err) {}
+  };
+
+  try { merge(window.AK_AC_SIGNED_PATHS); } catch (err) {}
+  try { read(typeof sessionStorage !== 'undefined' ? sessionStorage : null); } catch (err) {}
+  try { read(typeof localStorage !== 'undefined' ? localStorage : null); } catch (err) {}
+
+  try {
+    if (window.parent && window.parent !== window) {
+      try { merge(window.parent.AK_AC_SIGNED_PATHS); } catch (err) {}
+      try { read(window.parent.sessionStorage); } catch (err) {}
+      try { read(window.parent.localStorage); } catch (err) {}
+    }
+  } catch (err) {}
+
+  return result;
+}
+
+const SIGNED_PATHS = collectSignedPaths();
+
+function signedPath(key, fallback){
+  if (SIGNED_PATHS && typeof SIGNED_PATHS[key] === 'string' && SIGNED_PATHS[key]) {
+    return SIGNED_PATHS[key];
+  }
+  return fallback;
+}
+
+const UI_ROOT = '/akuvox-ac';
+function buildHref(slug, params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
+  const query = search.toString();
+  const clean = String(slug || '').replace(/_/g, '-');
+  return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
+}
+function requestParentNav(view, params = {}, options = {}) {
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = {
+        type: 'akuvox-nav',
+        view: String(view || ''),
+        slug: String(view || ''),
+        params
+      };
+      if (options.updateHistory === false) msg.updateHistory = false;
+      if (options.replaceState) msg.replaceState = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return true;
+    }
+  } catch (err) {}
+  return false;
+}
+function openInApp(view, params = {}, options = {}) {
+  const href = buildHref(view, params);
+  const delivered = requestParentNav(view, params, options);
+  if (!delivered) {
+    window.location.href = href;
+  }
+  return delivered;
+}
+</script>
+
+<div class="diag-container container py-3">
+  <div class="d-flex align-items-center gap-2 flex-wrap">
+    <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
+    <h2 class="m-0 flex-grow-1">Device Diagnostics</h2>
+    <button class="btn btn-outline-info" id="btnRefresh"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+    <span id="busy" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display:none;"></span>
+  </div>
+  <p class="muted mt-2">Review the most recent HTTP requests sent from Home Assistant to each Akuvox device. Entries include the request payload, status and timing so you can validate what was delivered.</p>
+  <div id="statusMessage" class="alert alert-danger d-none" role="alert"></div>
+  <div id="diagnosticDevices" class="mt-3"></div>
+</div>
+
+<script>
+const API_DIAGNOSTICS = signedPath('diagnostics', '/api/akuvox_ac/ui/diagnostics');
+const busyEl = document.getElementById('busy');
+const statusEl = document.getElementById('statusMessage');
+const devicesEl = document.getElementById('diagnosticDevices');
+let DIAG_DATA = [];
+
+function setBusy(active){
+  if (!busyEl) return;
+  busyEl.style.display = active ? 'inline-block' : 'none';
+}
+
+function showStatus(message, tone = 'danger'){
+  if (!statusEl) return;
+  if (!message){
+    statusEl.textContent = '';
+    statusEl.classList.add('d-none');
+    statusEl.classList.remove('alert-danger', 'alert-warning', 'alert-success');
+    return;
+  }
+  statusEl.textContent = message;
+  statusEl.classList.remove('d-none', 'alert-danger', 'alert-warning', 'alert-success');
+  statusEl.classList.add(tone === 'warning' ? 'alert-warning' : tone === 'success' ? 'alert-success' : 'alert-danger');
+}
+
+function escapeHtml(value){
+  return (value == null ? '' : String(value)).replace(/[&<>"']/g, (m) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+}
+
+function formatDateTime(value){
+  if (!value) return '—';
+  try {
+    const dt = new Date(value);
+    if (Number.isNaN(dt.getTime())) return escapeHtml(String(value));
+    return dt.toLocaleString();
+  } catch (err) {
+    return escapeHtml(String(value));
+  }
+}
+
+function formatDuration(ms){
+  const num = Number(ms);
+  if (!Number.isFinite(num)) return '—';
+  if (Math.abs(num) >= 1000) {
+    return (num / 1000).toFixed(2) + ' s';
+  }
+  return Math.round(num) + ' ms';
+}
+
+function formatBody(data){
+  if (data === null || data === undefined || data === '') return '—';
+  if (typeof data === 'string') return data;
+  try {
+    return JSON.stringify(data, null, 2);
+  } catch (err) {
+    return String(data);
+  }
+}
+
+function renderDevices(devices){
+  if (!devicesEl) return;
+  devicesEl.innerHTML = '';
+  if (!devices || !devices.length){
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = 'No devices are currently registered.';
+    devicesEl.appendChild(empty);
+    return;
+  }
+  devices.forEach((device, index) => {
+    const card = document.createElement('div');
+    card.className = 'card diag-card';
+    const lastTs = device.last_request_at || (device.requests && device.requests[0]?.timestamp);
+    const metaParts = [];
+    if (device.device_type) metaParts.push(device.device_type);
+    if (device.ip) metaParts.push('IP ' + device.ip);
+    if (device.host && device.host !== device.ip) metaParts.push('Host ' + device.host);
+    if (lastTs) metaParts.push('Last request ' + formatDateTime(lastTs));
+    card.innerHTML = `
+      <button class="diag-toggle" type="button" aria-expanded="${index === 0 ? 'true' : 'false'}">
+        <div>
+          <div class="diag-name">${escapeHtml(device.name || 'Device')}</div>
+          <div class="diag-meta">${escapeHtml(metaParts.join(' • '))}</div>
+        </div>
+        <i class="bi bi-chevron-down"></i>
+      </button>
+      <div class="diag-body" ${index === 0 ? '' : 'hidden'}></div>
+    `;
+    const toggle = card.querySelector('.diag-toggle');
+    const body = card.querySelector('.diag-body');
+    const ensureRendered = () => {
+      if (!body) return;
+      if (body.dataset.rendered === '1') return;
+      renderRequestList(body, device);
+      body.dataset.rendered = '1';
+    };
+    if (index === 0) {
+      ensureRendered();
+    }
+    toggle?.addEventListener('click', () => {
+      if (!toggle || !body) return;
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      body.hidden = expanded;
+      if (!expanded) ensureRendered();
+    });
+    devicesEl.appendChild(card);
+  });
+}
+
+function renderRequestList(container, device){
+  container.innerHTML = '';
+  const requests = Array.isArray(device.requests) ? device.requests : [];
+  if (!requests.length){
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = 'No requests have been recorded for this device yet.';
+    container.appendChild(empty);
+    return;
+  }
+  requests.forEach((req, idx) => {
+    const details = document.createElement('details');
+    details.className = 'diag-request';
+    if (idx === 0) details.open = true;
+    const method = String(req.method || 'GET').toUpperCase();
+    const methodBadge = `<span class="badge method ${method.toLowerCase()}">${escapeHtml(method)}</span>`;
+    const path = req.path || '';
+    const status = req.status != null ? String(req.status) : '—';
+    const ok = req.ok === true;
+    const summary = document.createElement('summary');
+    summary.innerHTML = `
+      ${methodBadge}
+      <code>${escapeHtml(path || (req.url || ''))}</code>
+      <span class="diag-summary-meta">
+        <span>Status: ${escapeHtml(status)}</span>
+        <span>${formatDateTime(req.timestamp)}</span>
+        <span>${formatDuration(req.duration_ms)}</span>
+      </span>
+      ${ok ? '<span class="badge diag-status-badge diag-status-ok">OK</span>' : req.error ? '<span class="badge diag-status-badge diag-status-error">Error</span>' : ''}
+    `;
+    details.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'diag-request-body';
+    const urlRow = document.createElement('div');
+    urlRow.className = 'diag-row';
+    urlRow.innerHTML = `<strong>URL</strong><span>${escapeHtml(req.url || '')}</span>`;
+    const transportBits = [];
+    if (req.scheme) transportBits.push(req.scheme.toUpperCase());
+    if (req.port) transportBits.push('port ' + req.port);
+    if (req.verify_ssl === false) transportBits.push('SSL verify disabled');
+    const transportRow = document.createElement('div');
+    transportRow.className = 'diag-row';
+    transportRow.innerHTML = `<strong>Transport</strong><span>${escapeHtml(transportBits.join(' • ') || '—')}</span>`;
+    const statusRow = document.createElement('div');
+    statusRow.className = 'diag-row';
+    statusRow.innerHTML = `<strong>Duration</strong><span>${formatDuration(req.duration_ms)}</span>`;
+
+    body.appendChild(urlRow);
+    body.appendChild(transportRow);
+    body.appendChild(statusRow);
+
+    if (req.error){
+      const errRow = document.createElement('div');
+      errRow.className = 'diag-row diag-error-text';
+      errRow.textContent = `Error: ${req.error}`;
+      body.appendChild(errRow);
+    }
+
+    if (req.payload){
+      const section = document.createElement('div');
+      section.className = 'diag-section';
+      section.innerHTML = `<div class="diag-section-title">Request body</div><pre>${escapeHtml(formatBody(req.payload))}</pre>`;
+      body.appendChild(section);
+    }
+
+    if (req.response_excerpt){
+      const section = document.createElement('div');
+      section.className = 'diag-section';
+      section.innerHTML = `<div class="diag-section-title">Response preview</div><pre>${escapeHtml(formatBody(req.response_excerpt))}</pre>`;
+      body.appendChild(section);
+    }
+
+    details.appendChild(body);
+    container.appendChild(details);
+  });
+}
+
+async function loadDiagnostics(){
+  setBusy(true);
+  showStatus('');
+  try {
+    const response = await fetchWithAuth(API_DIAGNOSTICS);
+    if (!response.ok){
+      const text = await response.text();
+      const err = buildError(response, text);
+      if (!handleAuthError(err)) {
+        throw err;
+      }
+      return;
+    }
+    const data = await response.json();
+    DIAG_DATA = Array.isArray(data.devices) ? data.devices : [];
+    renderDevices(DIAG_DATA);
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    console.error('Failed to load diagnostics', err);
+    showStatus('Failed to load diagnostics: ' + (err && err.message ? err.message : err));
+  } finally {
+    setBusy(false);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('btnBack')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openInApp('settings', {}, { replaceState: false });
+  });
+  document.getElementById('btnRefresh')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    loadDiagnostics();
+  });
+  loadDiagnostics();
+});
+</script>
+</body>
+</html>

--- a/custom_components/AK_Access_ctrl/www/diagnostics.html
+++ b/custom_components/AK_Access_ctrl/www/diagnostics.html
@@ -1,0 +1,687 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Akuvox Device Diagnostics</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  <style>
+    :root{
+      --bg:#0b1320;
+      --panel:#111a2b;
+      --border:#1b2942;
+      --text:#e6edf3;
+      --muted:#a5b5cc;
+      --accent:#2ff0c4;
+    }
+    body{
+      margin:0;
+      background:var(--bg);
+      color:var(--text);
+      font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    .diag-container{ max-width: 960px; }
+    .muted{ color: var(--muted); }
+    .card{ background:var(--panel); border:1px solid var(--border); }
+    .diag-card{ margin-top:1rem; border-radius:1rem; overflow:hidden; }
+    .diag-toggle{
+      width:100%;
+      border:0;
+      background:transparent;
+      color:inherit;
+      text-align:left;
+      padding:1rem 1.25rem;
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:1rem;
+      cursor:pointer;
+      font-size:1rem;
+    }
+    .diag-toggle:focus{ outline:2px solid rgba(47,240,196,0.35); outline-offset:2px; }
+    .diag-toggle:hover{ background:rgba(47,240,196,0.08); }
+    .diag-toggle .bi{ transition:transform 0.2s ease; }
+    .diag-toggle[aria-expanded="true"] .bi{ transform:rotate(180deg); }
+    .diag-name{ font-weight:600; }
+    .diag-meta{ font-size:0.9rem; color:var(--muted); margin-top:0.25rem; }
+    .diag-body{ background:#0d1729; border-top:1px solid var(--border); padding:1.25rem; }
+    .diag-summary-meta{ font-size:0.85rem; color:var(--muted); display:flex; gap:0.75rem; flex-wrap:wrap; }
+    .diag-request{ background:#0b172d; border:1px solid #1c2e4f; border-radius:0.75rem; margin-bottom:0.75rem; padding:0.75rem 1rem; }
+    .diag-request:last-child{ margin-bottom:0; }
+    .diag-request summary{
+      cursor:pointer;
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      gap:0.5rem;
+      font-size:0.95rem;
+      list-style:none;
+    }
+    .diag-request summary::-webkit-details-marker{ display:none; }
+    .diag-request summary:focus{ outline:2px solid rgba(47,240,196,0.35); outline-offset:2px; }
+    .diag-request-body{ margin-top:0.75rem; font-size:0.9rem; }
+    .diag-request-body .diag-row{ display:flex; flex-wrap:wrap; gap:0.75rem; margin-bottom:0.5rem; color:var(--muted); }
+    .diag-request-body .diag-row strong{ color:var(--text); font-weight:600; }
+    .diag-section{ margin-top:0.75rem; }
+    .diag-section-title{ font-weight:600; margin-bottom:0.35rem; }
+    pre{
+      background:#091021;
+      border:1px solid #15233b;
+      border-radius:0.5rem;
+      padding:0.75rem;
+      color:var(--text);
+      font-size:0.85rem;
+      line-height:1.35;
+      max-height:320px;
+      overflow:auto;
+    }
+    code{ font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .badge.method{
+      background:rgba(47,240,196,0.12);
+      color:var(--accent);
+      letter-spacing:0.05em;
+      text-transform:uppercase;
+      font-size:0.7rem;
+    }
+    .badge.method.get{ background:rgba(13,202,240,0.18); color:#0dcaf0; }
+    .badge.method.post{ background:rgba(111,66,193,0.22); color:#d5b7ff; }
+    .diag-status-badge{ font-size:0.7rem; text-transform:uppercase; letter-spacing:0.04em; }
+    .diag-status-ok{ background:rgba(25,135,84,0.22); color:#2ff0c4; }
+    .diag-status-error{ background:rgba(220,53,69,0.25); color:#ff7d8a; }
+    .diag-error-text{ color:#ff7d8a; font-weight:500; }
+    .alert.d-none{ display:none !important; }
+    @media (max-width: 768px){
+      .diag-container{ max-width:100%; padding:0 1rem; }
+      .diag-toggle{ padding:0.85rem 1rem; }
+      .diag-body{ padding:1rem; }
+      .diag-request{ padding:0.65rem 0.85rem; }
+      pre{ font-size:0.8rem; }
+    }
+  </style>
+</head>
+<body>
+<script>
+(function () {
+  const qs = new URLSearchParams(location.search);
+  const qsToken = qs.get('token');
+  if (qsToken) sessionStorage.setItem('akuvox_ll_token', qsToken);
+})();
+function persistTokens(access, refresh) {
+  if (!access) return null;
+  const payload = { access_token: access };
+  if (refresh) payload.refresh_token = refresh;
+  try { sessionStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  try { localStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  return access;
+}
+
+function extractTokenFromAuth(auth) {
+  if (!auth || typeof auth !== 'object') return null;
+  const access = auth.accessToken
+    || auth.access_token
+    || auth?.token?.access_token
+    || auth?.data?.access_token
+    || null;
+  const refresh = auth.refreshToken
+    || auth.refresh_token
+    || auth?.token?.refresh_token
+    || auth?.data?.refresh_token
+    || null;
+  if (access) {
+    return persistTokens(access, refresh);
+  }
+  return null;
+}
+
+function scanTokenStorage(storage) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem('hassTokens');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {
+        if (typeof raw === 'string' && raw.trim()) {
+          return persistTokens(raw.trim());
+        }
+      }
+    }
+    for (const key of Object.keys(storage)) {
+      if (!/auth|token|hass/i.test(key)) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {}
+    }
+  } catch (err) {}
+  return null;
+}
+
+function tokenFromWindow(win) {
+  if (!win) return null;
+  let token = null;
+  token = scanTokenStorage(win.sessionStorage) || scanTokenStorage(win.localStorage);
+  if (token) return token;
+
+  token = extractTokenFromAuth(win.hassAuth)
+    || extractTokenFromAuth(win.auth)
+    || extractTokenFromAuth(win.AK_AC_HA_AUTH)
+    || null;
+  if (token) return token;
+
+  try {
+    const conn = win.hassConnection;
+    if (conn && typeof conn.then === 'function') {
+      conn.then((resolved) => {
+        try {
+          extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+        } catch (err) {}
+      }).catch(() => {});
+    } else if (conn) {
+      token = extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      if (token) return token;
+    }
+  } catch (err) {}
+
+  return null;
+}
+
+function walkAuthWindows(start) {
+  const visited = new Set();
+  let current = start;
+  while (current && !visited.has(current)) {
+    const token = tokenFromWindow(current);
+    if (token) return token;
+    visited.add(current);
+
+    let next = null;
+    try {
+      next = current.parent;
+    } catch (err) {
+      next = null;
+    }
+    if (next && next !== current && !visited.has(next)) {
+      current = next;
+      continue;
+    }
+
+    try {
+      next = current.opener;
+    } catch (err) {
+      next = null;
+    }
+    if (next && next !== current && !visited.has(next)) {
+      current = next;
+      continue;
+    }
+
+    break;
+  }
+  return null;
+}
+
+(function bootstrapAuthWatchers() {
+  const seen = new WeakSet();
+  function attach(win) {
+    if (!win || seen.has(win)) return;
+    seen.add(win);
+    try { extractTokenFromAuth(win.hassAuth || win.auth || win.AK_AC_HA_AUTH); } catch (err) {}
+    try {
+      const conn = win.hassConnection;
+      if (conn && typeof conn.then === 'function') {
+        conn.then((resolved) => {
+          try {
+            extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+          } catch (err) {}
+        }).catch(() => {});
+      } else if (conn) {
+        extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      }
+    } catch (err) {}
+    try {
+      if (win.parent && win.parent !== win) attach(win.parent);
+    } catch (err) {}
+    try {
+      if (win.opener) attach(win.opener);
+    } catch (err) {}
+  }
+  attach(window);
+})();
+
+function findHaToken(){
+  const existing = sessionStorage.getItem('akuvox_ll_token');
+  if (existing) return existing;
+  const token = walkAuthWindows(window);
+  if (token) {
+    try { sessionStorage.setItem('akuvox_ll_token', token); } catch (err) {}
+  }
+  return token;
+}
+const SAME_ORIGIN = { credentials: 'same-origin' };
+const REJECTED_TOKENS = new Set();
+
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search){
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function currentAuthSig(){
+  const stored = sessionStorage.getItem(AUTH_SIG_KEY) || localStorage.getItem(AUTH_SIG_KEY) || '';
+  if (stored) return stored;
+  const fromQuery = readAuthSigFrom();
+  if (fromQuery) {
+    try { sessionStorage.setItem(AUTH_SIG_KEY, fromQuery); } catch (err) {}
+    try { localStorage.setItem(AUTH_SIG_KEY, fromQuery); } catch (err) {}
+    return fromQuery;
+  }
+  return '';
+}
+
+async function fetchWithAuth(url, options = {}) {
+  const token = findHaToken();
+  const headers = new Headers(options.headers || {});
+  if (token && !REJECTED_TOKENS.has(token)) {
+    headers.set('Authorization', 'Bearer ' + token);
+  }
+  const merged = { ...options, headers, ...SAME_ORIGIN };
+  try {
+    const response = await fetch(url, merged);
+    if (response.status === 401 || response.status === 403) {
+      if (token) REJECTED_TOKENS.add(token);
+    }
+    return response;
+  } catch (err) {
+    throw err;
+  }
+}
+
+function buildError(response, text) {
+  const err = new Error(response.statusText || 'Request failed');
+  err.status = response.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err){
+  if (!err) return false;
+  const status = err.status || err.code || err.error || null;
+  if (!status) return false;
+  return status === 401 || status === 403;
+}
+
+function redirectToUnauthorized(){
+  const params = new URLSearchParams(location.search);
+  const targetParams = new URLSearchParams();
+  params.forEach((value, key) => {
+    if (key === 'view' || key === 'authSig') return;
+    targetParams.set(key, value);
+  });
+  const authSig = currentAuthSig();
+  if (authSig) targetParams.set('authSig', authSig);
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) targetParams.set('token', token);
+  const query = targetParams.toString();
+  let href = `/akuvox-ac/unauthorized${query ? `?${query}` : ''}`;
+  try {
+    if (window.parent && window.parent !== window) {
+      const search = new URLSearchParams(targetParams);
+      if (authSig) search.set('authSig', authSig);
+      if (token) search.set('token', token);
+      const clean = search.toString();
+      if (clean) href = `/akuvox-ac/unauthorized?${clean}`;
+    }
+  } catch (err) {}
+
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', Object.fromEntries(targetParams), { replaceState: true });
+  } catch (err) {}
+
+  if (!delivered) {
+    try { window.location.replace(href); }
+    catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err){
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
+function collectSignedPaths(){
+  const result = {};
+  const merge = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') return;
+    for (const [key, value] of Object.entries(candidate)) {
+      if (typeof value === 'string' && value) result[key] = value;
+    }
+  };
+  const read = (storage) => {
+    if (!storage) return;
+    try {
+      const raw = storage.getItem('akuvox_signed_paths');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        merge(parsed);
+      }
+    } catch (err) {}
+  };
+
+  try { merge(window.AK_AC_SIGNED_PATHS); } catch (err) {}
+  try { read(typeof sessionStorage !== 'undefined' ? sessionStorage : null); } catch (err) {}
+  try { read(typeof localStorage !== 'undefined' ? localStorage : null); } catch (err) {}
+
+  try {
+    if (window.parent && window.parent !== window) {
+      try { merge(window.parent.AK_AC_SIGNED_PATHS); } catch (err) {}
+      try { read(window.parent.sessionStorage); } catch (err) {}
+      try { read(window.parent.localStorage); } catch (err) {}
+    }
+  } catch (err) {}
+
+  return result;
+}
+
+const SIGNED_PATHS = collectSignedPaths();
+
+function signedPath(key, fallback){
+  if (SIGNED_PATHS && typeof SIGNED_PATHS[key] === 'string' && SIGNED_PATHS[key]) {
+    return SIGNED_PATHS[key];
+  }
+  return fallback;
+}
+
+const UI_ROOT = '/akuvox-ac';
+function buildHref(slug, params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
+  const query = search.toString();
+  const clean = String(slug || '').replace(/_/g, '-');
+  return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
+}
+function requestParentNav(view, params = {}, options = {}) {
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = {
+        type: 'akuvox-nav',
+        view: String(view || ''),
+        slug: String(view || ''),
+        params
+      };
+      if (options.updateHistory === false) msg.updateHistory = false;
+      if (options.replaceState) msg.replaceState = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return true;
+    }
+  } catch (err) {}
+  return false;
+}
+function openInApp(view, params = {}, options = {}) {
+  const href = buildHref(view, params);
+  const delivered = requestParentNav(view, params, options);
+  if (!delivered) {
+    window.location.href = href;
+  }
+  return delivered;
+}
+</script>
+
+<div class="diag-container container py-3">
+  <div class="d-flex align-items-center gap-2 flex-wrap">
+    <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
+    <h2 class="m-0 flex-grow-1">Device Diagnostics</h2>
+    <button class="btn btn-outline-info" id="btnRefresh"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+    <span id="busy" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display:none;"></span>
+  </div>
+  <p class="muted mt-2">Review the most recent HTTP requests sent from Home Assistant to each Akuvox device. Entries include the request payload, status and timing so you can validate what was delivered.</p>
+  <div id="statusMessage" class="alert alert-danger d-none" role="alert"></div>
+  <div id="diagnosticDevices" class="mt-3"></div>
+</div>
+
+<script>
+const API_DIAGNOSTICS = signedPath('diagnostics', '/api/akuvox_ac/ui/diagnostics');
+const busyEl = document.getElementById('busy');
+const statusEl = document.getElementById('statusMessage');
+const devicesEl = document.getElementById('diagnosticDevices');
+let DIAG_DATA = [];
+
+function setBusy(active){
+  if (!busyEl) return;
+  busyEl.style.display = active ? 'inline-block' : 'none';
+}
+
+function showStatus(message, tone = 'danger'){
+  if (!statusEl) return;
+  if (!message){
+    statusEl.textContent = '';
+    statusEl.classList.add('d-none');
+    statusEl.classList.remove('alert-danger', 'alert-warning', 'alert-success');
+    return;
+  }
+  statusEl.textContent = message;
+  statusEl.classList.remove('d-none', 'alert-danger', 'alert-warning', 'alert-success');
+  statusEl.classList.add(tone === 'warning' ? 'alert-warning' : tone === 'success' ? 'alert-success' : 'alert-danger');
+}
+
+function escapeHtml(value){
+  return (value == null ? '' : String(value)).replace(/[&<>"']/g, (m) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+}
+
+function formatDateTime(value){
+  if (!value) return '—';
+  try {
+    const dt = new Date(value);
+    if (Number.isNaN(dt.getTime())) return escapeHtml(String(value));
+    return dt.toLocaleString();
+  } catch (err) {
+    return escapeHtml(String(value));
+  }
+}
+
+function formatDuration(ms){
+  const num = Number(ms);
+  if (!Number.isFinite(num)) return '—';
+  if (Math.abs(num) >= 1000) {
+    return (num / 1000).toFixed(2) + ' s';
+  }
+  return Math.round(num) + ' ms';
+}
+
+function formatBody(data){
+  if (data === null || data === undefined || data === '') return '—';
+  if (typeof data === 'string') return data;
+  try {
+    return JSON.stringify(data, null, 2);
+  } catch (err) {
+    return String(data);
+  }
+}
+
+function renderDevices(devices){
+  if (!devicesEl) return;
+  devicesEl.innerHTML = '';
+  if (!devices || !devices.length){
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = 'No devices are currently registered.';
+    devicesEl.appendChild(empty);
+    return;
+  }
+  devices.forEach((device, index) => {
+    const card = document.createElement('div');
+    card.className = 'card diag-card';
+    const lastTs = device.last_request_at || (device.requests && device.requests[0]?.timestamp);
+    const metaParts = [];
+    if (device.device_type) metaParts.push(device.device_type);
+    if (device.ip) metaParts.push('IP ' + device.ip);
+    if (device.host && device.host !== device.ip) metaParts.push('Host ' + device.host);
+    if (lastTs) metaParts.push('Last request ' + formatDateTime(lastTs));
+    card.innerHTML = `
+      <button class="diag-toggle" type="button" aria-expanded="${index === 0 ? 'true' : 'false'}">
+        <div>
+          <div class="diag-name">${escapeHtml(device.name || 'Device')}</div>
+          <div class="diag-meta">${escapeHtml(metaParts.join(' • '))}</div>
+        </div>
+        <i class="bi bi-chevron-down"></i>
+      </button>
+      <div class="diag-body" ${index === 0 ? '' : 'hidden'}></div>
+    `;
+    const toggle = card.querySelector('.diag-toggle');
+    const body = card.querySelector('.diag-body');
+    const ensureRendered = () => {
+      if (!body) return;
+      if (body.dataset.rendered === '1') return;
+      renderRequestList(body, device);
+      body.dataset.rendered = '1';
+    };
+    if (index === 0) {
+      ensureRendered();
+    }
+    toggle?.addEventListener('click', () => {
+      if (!toggle || !body) return;
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      body.hidden = expanded;
+      if (!expanded) ensureRendered();
+    });
+    devicesEl.appendChild(card);
+  });
+}
+
+function renderRequestList(container, device){
+  container.innerHTML = '';
+  const requests = Array.isArray(device.requests) ? device.requests : [];
+  if (!requests.length){
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = 'No requests have been recorded for this device yet.';
+    container.appendChild(empty);
+    return;
+  }
+  requests.forEach((req, idx) => {
+    const details = document.createElement('details');
+    details.className = 'diag-request';
+    if (idx === 0) details.open = true;
+    const method = String(req.method || 'GET').toUpperCase();
+    const methodBadge = `<span class="badge method ${method.toLowerCase()}">${escapeHtml(method)}</span>`;
+    const path = req.path || '';
+    const status = req.status != null ? String(req.status) : '—';
+    const ok = req.ok === true;
+    const summary = document.createElement('summary');
+    summary.innerHTML = `
+      ${methodBadge}
+      <code>${escapeHtml(path || (req.url || ''))}</code>
+      <span class="diag-summary-meta">
+        <span>Status: ${escapeHtml(status)}</span>
+        <span>${formatDateTime(req.timestamp)}</span>
+        <span>${formatDuration(req.duration_ms)}</span>
+      </span>
+      ${ok ? '<span class="badge diag-status-badge diag-status-ok">OK</span>' : req.error ? '<span class="badge diag-status-badge diag-status-error">Error</span>' : ''}
+    `;
+    details.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'diag-request-body';
+    const urlRow = document.createElement('div');
+    urlRow.className = 'diag-row';
+    urlRow.innerHTML = `<strong>URL</strong><span>${escapeHtml(req.url || '')}</span>`;
+    const transportBits = [];
+    if (req.scheme) transportBits.push(req.scheme.toUpperCase());
+    if (req.port) transportBits.push('port ' + req.port);
+    if (req.verify_ssl === false) transportBits.push('SSL verify disabled');
+    const transportRow = document.createElement('div');
+    transportRow.className = 'diag-row';
+    transportRow.innerHTML = `<strong>Transport</strong><span>${escapeHtml(transportBits.join(' • ') || '—')}</span>`;
+    const statusRow = document.createElement('div');
+    statusRow.className = 'diag-row';
+    statusRow.innerHTML = `<strong>Duration</strong><span>${formatDuration(req.duration_ms)}</span>`;
+
+    body.appendChild(urlRow);
+    body.appendChild(transportRow);
+    body.appendChild(statusRow);
+
+    if (req.error){
+      const errRow = document.createElement('div');
+      errRow.className = 'diag-row diag-error-text';
+      errRow.textContent = `Error: ${req.error}`;
+      body.appendChild(errRow);
+    }
+
+    if (req.payload){
+      const section = document.createElement('div');
+      section.className = 'diag-section';
+      section.innerHTML = `<div class="diag-section-title">Request body</div><pre>${escapeHtml(formatBody(req.payload))}</pre>`;
+      body.appendChild(section);
+    }
+
+    if (req.response_excerpt){
+      const section = document.createElement('div');
+      section.className = 'diag-section';
+      section.innerHTML = `<div class="diag-section-title">Response preview</div><pre>${escapeHtml(formatBody(req.response_excerpt))}</pre>`;
+      body.appendChild(section);
+    }
+
+    details.appendChild(body);
+    container.appendChild(details);
+  });
+}
+
+async function loadDiagnostics(){
+  setBusy(true);
+  showStatus('');
+  try {
+    const response = await fetchWithAuth(API_DIAGNOSTICS);
+    if (!response.ok){
+      const text = await response.text();
+      const err = buildError(response, text);
+      if (!handleAuthError(err)) {
+        throw err;
+      }
+      return;
+    }
+    const data = await response.json();
+    DIAG_DATA = Array.isArray(data.devices) ? data.devices : [];
+    renderDevices(DIAG_DATA);
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    console.error('Failed to load diagnostics', err);
+    showStatus('Failed to load diagnostics: ' + (err && err.message ? err.message : err));
+  } finally {
+    setBusy(false);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('btnBack')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openInApp('settings', {}, { replaceState: false });
+  });
+  document.getElementById('btnRefresh')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    loadDiagnostics();
+  });
+  loadDiagnostics();
+});
+</script>
+</body>
+</html>

--- a/custom_components/AK_Access_ctrl/www/head-mob.html
+++ b/custom_components/AK_Access_ctrl/www/head-mob.html
@@ -977,6 +977,7 @@ function setActiveNav(view){
   const hasUserId = frameParams ? frameParams.searchParams.has('id') : false;
   const currentSection = frameParams ? (frameParams.searchParams.get('section') || '') : '';
   const sectionLower = currentSection.toLowerCase();
+  const navView = view === 'diagnostics' ? 'settings' : view;
 
   document.querySelectorAll('nav.nav-buttons .nav-btn').forEach(btn => {
     const target = normalizeView(btn.dataset.view);
@@ -991,7 +992,7 @@ function setActiveNav(view){
         }
       }
     } else {
-      isActive = target === view;
+      isActive = target === navView;
     }
     if (isActive) btn.classList.add('active');
     else btn.classList.remove('active');
@@ -1020,7 +1021,7 @@ function setActiveNav(view){
         }
       }
     } else {
-      isActive = target === view;
+      isActive = target === navView;
     }
     if (isActive) btn.classList.add('active');
     else btn.classList.remove('active');

--- a/custom_components/AK_Access_ctrl/www/head.html
+++ b/custom_components/AK_Access_ctrl/www/head.html
@@ -982,6 +982,7 @@ function setActiveNav(view){
   const hasUserId = frameParams ? frameParams.searchParams.has('id') : false;
   const currentSection = frameParams ? (frameParams.searchParams.get('section') || '') : '';
   const sectionLower = currentSection.toLowerCase();
+  const navView = view === 'diagnostics' ? 'settings' : view;
 
   document.querySelectorAll('nav.nav-buttons .nav-btn').forEach(btn => {
     const target = normalizeView(btn.dataset.view);
@@ -996,7 +997,7 @@ function setActiveNav(view){
         }
       }
     } else {
-      isActive = target === view;
+      isActive = target === navView;
     }
     if (isActive) btn.classList.add('active');
     else btn.classList.remove('active');
@@ -1025,7 +1026,7 @@ function setActiveNav(view){
         }
       }
     } else {
-      isActive = target === view;
+      isActive = target === navView;
     }
     if (isActive) btn.classList.add('active');
     else btn.classList.remove('active');

--- a/custom_components/AK_Access_ctrl/www/settings-mob.html
+++ b/custom_components/AK_Access_ctrl/www/settings-mob.html
@@ -1573,6 +1573,11 @@ document.addEventListener('DOMContentLoaded', () => {
     openInApp('index', {}, { replaceState: true });
   });
 
+  document.getElementById('openDiagnosticsBtn')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    openInApp('diagnostics');
+  });
+
   const deviceOptions = document.getElementById('deviceOptions');
   deviceOptions?.addEventListener('change', async (ev) => {
     const target = ev.target;
@@ -1691,6 +1696,16 @@ document.addEventListener('DOMContentLoaded', () => {
     <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
     <h2 class="m-0">Global Settings</h2>
     <span id="busy" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display:none;"></span>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
+      <div>
+        <div class="fw-semibold">Device diagnostics</div>
+        <div class="muted small">Open the diagnostics dashboard to inspect the last HTTP requests sent to each Akuvox device.</div>
+      </div>
+      <button class="btn btn-outline-info" id="openDiagnosticsBtn"><i class="bi bi-activity me-1"></i>Open diagnostics</button>
+    </div>
   </div>
 
   <div class="card mt-3">

--- a/custom_components/AK_Access_ctrl/www/settings.html
+++ b/custom_components/AK_Access_ctrl/www/settings.html
@@ -1573,6 +1573,11 @@ document.addEventListener('DOMContentLoaded', () => {
     openInApp('index', {}, { replaceState: true });
   });
 
+  document.getElementById('openDiagnosticsBtn')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    openInApp('diagnostics');
+  });
+
   const deviceOptions = document.getElementById('deviceOptions');
   deviceOptions?.addEventListener('change', async (ev) => {
     const target = ev.target;
@@ -1691,6 +1696,16 @@ document.addEventListener('DOMContentLoaded', () => {
     <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
     <h2 class="m-0">Global Settings</h2>
     <span id="busy" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display:none;"></span>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
+      <div>
+        <div class="fw-semibold">Device diagnostics</div>
+        <div class="muted small">Open the diagnostics dashboard to inspect the last HTTP requests sent to each Akuvox device.</div>
+      </div>
+      <button class="btn btn-outline-info" id="openDiagnosticsBtn"><i class="bi bi-activity me-1"></i>Open diagnostics</button>
+    </div>
   </div>
 
   <div class="card mt-3">


### PR DESCRIPTION
## Summary
- capture recent request metadata in the Akuvox API client and expose it through a new diagnostics API endpoint
- add desktop and mobile diagnostics pages that render each device with the last ten requests, including payload and response details
- surface a diagnostics shortcut in global settings and ensure the navigation treats the diagnostics page as part of settings

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68d1092965f8832c985d9d62c404e0a7