### PR TITLE
Push face uploads directly to devices

### DIFF
--- a/custom_components/AK_Access_ctrl/__init__.py
+++ b/custom_components/AK_Access_ctrl/__init__.py
@@ -1088,6 +1088,7 @@ class SyncManager:
                 "sync_manager",
                 "sync_queue",
                 "_ui_registered",
+                "_panel_registered",
                 "settings_store",
             ):
                 continue

--- a/custom_components/AK_Access_ctrl/www/device_edit-mob.html
+++ b/custom_components/AK_Access_ctrl/www/device_edit-mob.html
@@ -53,6 +53,32 @@
     </div>
   </div>
 
+  <!-- Relay mapping -->
+  <div class="card mb-3" id="relayCard">
+    <div class="card-header">Device Relays</div>
+    <div class="card-body">
+      <div class="row g-3">
+        <div class="col-sm-6 col-lg-4">
+          <label class="form-label" for="relayASelect">Relay A action</label>
+          <select class="form-select" id="relayASelect"></select>
+        </div>
+        <div class="col-sm-6 col-lg-4" id="relayBCol">
+          <label class="form-label" for="relayBSelect">Relay B action</label>
+          <select class="form-select" id="relayBSelect"></select>
+        </div>
+      </div>
+      <div class="form-text text-muted mt-2" id="relayKeypadNote"></div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="exitDeviceToggle">
+        <label class="form-check-label" for="exitDeviceToggle">Treat as exit device (bypass user schedules)</label>
+      </div>
+      <div class="form-text text-muted mt-3" id="relayHelper">
+        Setting a relay to <b>Alarm</b> or <b>Door and Alarm</b> enables the Key Holder option when editing users.
+      </div>
+      <div class="form-text text-muted mt-2" id="relayStatus"></div>
+    </div>
+  </div>
+
   <!-- Groups editor -->
   <div class="card" id="groupsCard">
     <div class="card-header d-flex align-items-center justify-content-between">
@@ -592,12 +618,212 @@ function getSelectedGroups(){
   return out;
 }
 
+const RELAY_ROLE_LABELS = {
+  none: 'Not used',
+  door: 'Door Relay',
+  alarm: 'Alarm Relay',
+  door_alarm: 'Door and Alarm Relay'
+};
+const RELAY_ROLE_ORDER = ['none', 'door', 'alarm', 'door_alarm'];
+
+let CURRENT_DEVICE = null;
+let relayStatusTimer = null;
+let relaySaving = false;
+let exitSaving = false;
+
+function relayValueNormalized(value, fallback = 'door'){
+  const raw = (value ?? '').toString().trim().toLowerCase();
+  if (!raw) return fallback;
+  const clean = raw.replace(/[\s-]+/g, '_');
+  if (RELAY_ROLE_ORDER.includes(clean)) return clean;
+  if (clean === 'not_used' || clean === 'unused' || clean === 'none') return 'none';
+  if (clean === 'door' || clean === 'door_relay') return 'door';
+  if (clean === 'alarm' || clean === 'alarm_relay') return 'alarm';
+  if (clean === 'door_and_alarm' || clean === 'door_alarm_relay' || clean === 'doorandalarm') return 'door_alarm';
+  return fallback;
+}
+
+function populateRelaySelect(select, value, fallback = 'door'){
+  if (!select) return;
+  const normalized = relayValueNormalized(value, fallback);
+  select.innerHTML = '';
+  RELAY_ROLE_ORDER.forEach(role => {
+    const opt = document.createElement('option');
+    opt.value = role;
+    opt.textContent = RELAY_ROLE_LABELS[role] || role;
+    select.appendChild(opt);
+  });
+  select.value = RELAY_ROLE_ORDER.includes(normalized) ? normalized : fallback;
+}
+
+function computeAlarmCapable(device){
+  if (!device || typeof device !== 'object') return false;
+  if (typeof device.alarm_capable === 'boolean') return device.alarm_capable;
+  const roles = device.relay_roles && typeof device.relay_roles === 'object' ? device.relay_roles : {};
+  const a = relayValueNormalized(roles.relay_a, 'door');
+  const b = relayValueNormalized(roles.relay_b, 'none');
+  return a === 'alarm' || a === 'door_alarm' || b === 'alarm' || b === 'door_alarm';
+}
+
+function setRelayStatus(text, tone = 'muted'){
+  const status = document.getElementById('relayStatus');
+  if (!status) return;
+  if (relayStatusTimer){
+    clearTimeout(relayStatusTimer);
+    relayStatusTimer = null;
+  }
+  if (!text){
+    status.textContent = '';
+    status.className = 'form-text text-muted mt-2';
+    return;
+  }
+  let cls = 'form-text mt-2';
+  if (tone === 'error') cls += ' text-danger';
+  else if (tone === 'success') cls += ' text-success';
+  else cls += ' text-muted';
+  status.className = cls;
+  status.textContent = text;
+  if (tone === 'success'){
+    relayStatusTimer = setTimeout(() => {
+      const el = document.getElementById('relayStatus');
+      if (el){
+        el.textContent = '';
+        el.className = 'form-text text-muted mt-2';
+      }
+      relayStatusTimer = null;
+    }, 4000);
+  }
+}
+
+function updateRelayHelper(){
+  const helper = document.getElementById('relayHelper');
+  if (!helper) return;
+  const baseClass = 'form-text mt-3';
+  const capable = computeAlarmCapable(CURRENT_DEVICE);
+  if (capable){
+    helper.className = `${baseClass} text-success`;
+    helper.innerHTML = 'Key Holder can be enabled for users because this device is alarm-capable.';
+  } else {
+    helper.className = `${baseClass} text-muted`;
+    helper.innerHTML = 'Setting a relay to <b>Alarm</b> or <b>Door and Alarm</b> enables the Key Holder option when editing users.';
+  }
+}
+
+function applyRelayUI(device){
+  const relayA = document.getElementById('relayASelect');
+  const relayB = document.getElementById('relayBSelect');
+  const relayBCol = document.getElementById('relayBCol');
+  const keypadNote = document.getElementById('relayKeypadNote');
+  const exitToggle = document.getElementById('exitDeviceToggle');
+  const roles = device && typeof device.relay_roles === 'object' ? device.relay_roles : {};
+  const isKeypad = String(device?.type || '').toLowerCase() === 'keypad';
+  populateRelaySelect(relayA, roles.relay_a, 'door');
+  populateRelaySelect(relayB, roles.relay_b, 'none');
+  if (relayBCol){
+    if (isKeypad) relayBCol.classList.add('d-none');
+    else relayBCol.classList.remove('d-none');
+  }
+  if (relayB){
+    relayB.value = isKeypad ? 'none' : relayValueNormalized(roles.relay_b, 'none');
+  }
+  if (keypadNote){
+    keypadNote.textContent = isKeypad ? 'Keypads expose Relay A only.' : '';
+  }
+  if (exitToggle){
+    exitToggle.checked = !!device?.exit_device;
+  }
+  setRelayStatus('');
+  updateRelayHelper();
+}
+
+async function saveRelayRoles(){
+  if (relaySaving || !CURRENT_DEVICE) return;
+  const relayA = document.getElementById('relayASelect');
+  const relayB = document.getElementById('relayBSelect');
+  const relayBCol = document.getElementById('relayBCol');
+  if (!relayA) return;
+  const includeRelayB = relayB && relayBCol && !relayBCol.classList.contains('d-none');
+  const payload = { relay_a: relayA.value };
+  if (includeRelayB) payload.relay_b = relayB.value;
+  const prev = {
+    relay_a: CURRENT_DEVICE.relay_roles?.relay_a,
+    relay_b: CURRENT_DEVICE.relay_roles?.relay_b
+  };
+  relaySaving = true;
+  setRelayStatus('Saving…');
+  relayA.disabled = true;
+  if (includeRelayB && relayB) relayB.disabled = true;
+  try {
+    const res = await apiPost(actionUrl, { action:'set_device_relays', entry_id: ENTRY_ID, payload });
+    const returned = res && res.relay_roles && typeof res.relay_roles === 'object' ? res.relay_roles : payload;
+    CURRENT_DEVICE.relay_roles = {
+      relay_a: relayValueNormalized(returned.relay_a, prev.relay_a || 'door'),
+      relay_b: includeRelayB ? relayValueNormalized(returned.relay_b, prev.relay_b || 'none') : 'none'
+    };
+    CURRENT_DEVICE.alarm_capable = res && 'alarm_capable' in res
+      ? !!res.alarm_capable
+      : computeAlarmCapable(CURRENT_DEVICE);
+    relayA.value = CURRENT_DEVICE.relay_roles.relay_a;
+    if (includeRelayB && relayB) relayB.value = CURRENT_DEVICE.relay_roles.relay_b;
+    updateRelayHelper();
+    setRelayStatus('Saved ✓', 'success');
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    relayA.value = relayValueNormalized(prev.relay_a, 'door');
+    if (includeRelayB && relayB) relayB.value = relayValueNormalized(prev.relay_b, 'none');
+    CURRENT_DEVICE.relay_roles = {
+      relay_a: relayValueNormalized(prev.relay_a, 'door'),
+      relay_b: relayValueNormalized(prev.relay_b, 'none')
+    };
+    updateRelayHelper();
+    setRelayStatus('Save failed', 'error');
+    alert('Failed to update relay mapping: ' + (err && err.message ? err.message : err));
+  } finally {
+    relaySaving = false;
+    relayA.disabled = false;
+    if (includeRelayB && relayB) relayB.disabled = false;
+  }
+}
+
+async function handleExitToggleChange(){
+  if (exitSaving || !CURRENT_DEVICE) return;
+  const toggle = document.getElementById('exitDeviceToggle');
+  if (!toggle) return;
+  const desired = toggle.checked;
+  exitSaving = true;
+  toggle.disabled = true;
+  setRelayStatus('Saving…');
+  try {
+    const res = await apiPost(actionUrl, { action:'set_exit_device', entry_id: ENTRY_ID, payload: { enabled: desired } });
+    CURRENT_DEVICE.exit_device = res && 'exit_device' in res ? !!res.exit_device : desired;
+    setRelayStatus('Saved ✓', 'success');
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    toggle.checked = !desired;
+    CURRENT_DEVICE.exit_device = toggle.checked;
+    setRelayStatus('Save failed', 'error');
+    alert('Failed to update exit device setting: ' + (err && err.message ? err.message : err));
+  } finally {
+    exitSaving = false;
+    toggle.disabled = false;
+    updateRelayHelper();
+  }
+}
+
 /* API-ish helpers built atop /state and /action */
 async function getState(){ return apiGet(stateUrl); }
 async function getDevice(){
   const st = await getState();
   const dev = (st.devices || []).find(d => (d.entry_id || d.id) === ENTRY_ID);
   if (!dev) throw new Error('Device not found');
+  const roles = dev && typeof dev.relay_roles === 'object' ? dev.relay_roles : {};
+  dev.relay_roles = {
+    relay_a: relayValueNormalized(roles.relay_a, 'door'),
+    relay_b: relayValueNormalized(roles.relay_b, 'none')
+  };
+  dev.exit_device = !!dev.exit_device;
+  if (typeof dev.alarm_capable === 'boolean') dev.alarm_capable = !!dev.alarm_capable;
+  else dev.alarm_capable = computeAlarmCapable(dev);
   // Current groups: prefer sync_groups → groups → Default
   const curGroups = dev.sync_groups || dev.groups || ['Default'];
   // All groups if present at root; fallback
@@ -626,6 +852,20 @@ async function init(){
     document.getElementById('devName').textContent = dev.name || '—';
     document.getElementById('devType').textContent = dev.type || '—';
     document.getElementById('devIP').textContent   = dev.ip || '—';
+
+    CURRENT_DEVICE = {
+      ...dev,
+      relay_roles: {
+        relay_a: dev.relay_roles?.relay_a || 'door',
+        relay_b: dev.relay_roles?.relay_b || 'none'
+      },
+      exit_device: !!dev.exit_device,
+      alarm_capable: computeAlarmCapable(dev)
+    };
+    applyRelayUI(CURRENT_DEVICE);
+    document.getElementById('relayASelect')?.addEventListener('change', saveRelayRoles);
+    document.getElementById('relayBSelect')?.addEventListener('change', saveRelayRoles);
+    document.getElementById('exitDeviceToggle')?.addEventListener('change', handleExitToggleChange);
 
     const onlyDefault = Array.isArray(allGroups) && allGroups.length <= 1;
 

--- a/custom_components/AK_Access_ctrl/www/device_edit.html
+++ b/custom_components/AK_Access_ctrl/www/device_edit.html
@@ -53,6 +53,32 @@
     </div>
   </div>
 
+  <!-- Relay mapping -->
+  <div class="card mb-3" id="relayCard">
+    <div class="card-header">Device Relays</div>
+    <div class="card-body">
+      <div class="row g-3">
+        <div class="col-sm-6 col-lg-4">
+          <label class="form-label" for="relayASelect">Relay A action</label>
+          <select class="form-select" id="relayASelect"></select>
+        </div>
+        <div class="col-sm-6 col-lg-4" id="relayBCol">
+          <label class="form-label" for="relayBSelect">Relay B action</label>
+          <select class="form-select" id="relayBSelect"></select>
+        </div>
+      </div>
+      <div class="form-text text-muted mt-2" id="relayKeypadNote"></div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="exitDeviceToggle">
+        <label class="form-check-label" for="exitDeviceToggle">Treat as exit device (bypass user schedules)</label>
+      </div>
+      <div class="form-text text-muted mt-3" id="relayHelper">
+        Setting a relay to <b>Alarm</b> or <b>Door and Alarm</b> enables the Key Holder option when editing users.
+      </div>
+      <div class="form-text text-muted mt-2" id="relayStatus"></div>
+    </div>
+  </div>
+
   <!-- Groups editor -->
   <div class="card" id="groupsCard">
     <div class="card-header d-flex align-items-center justify-content-between">
@@ -592,12 +618,212 @@ function getSelectedGroups(){
   return out;
 }
 
+const RELAY_ROLE_LABELS = {
+  none: 'Not used',
+  door: 'Door Relay',
+  alarm: 'Alarm Relay',
+  door_alarm: 'Door and Alarm Relay'
+};
+const RELAY_ROLE_ORDER = ['none', 'door', 'alarm', 'door_alarm'];
+
+let CURRENT_DEVICE = null;
+let relayStatusTimer = null;
+let relaySaving = false;
+let exitSaving = false;
+
+function relayValueNormalized(value, fallback = 'door'){
+  const raw = (value ?? '').toString().trim().toLowerCase();
+  if (!raw) return fallback;
+  const clean = raw.replace(/[\s-]+/g, '_');
+  if (RELAY_ROLE_ORDER.includes(clean)) return clean;
+  if (clean === 'not_used' || clean === 'unused' || clean === 'none') return 'none';
+  if (clean === 'door' || clean === 'door_relay') return 'door';
+  if (clean === 'alarm' || clean === 'alarm_relay') return 'alarm';
+  if (clean === 'door_and_alarm' || clean === 'door_alarm_relay' || clean === 'doorandalarm') return 'door_alarm';
+  return fallback;
+}
+
+function populateRelaySelect(select, value, fallback = 'door'){
+  if (!select) return;
+  const normalized = relayValueNormalized(value, fallback);
+  select.innerHTML = '';
+  RELAY_ROLE_ORDER.forEach(role => {
+    const opt = document.createElement('option');
+    opt.value = role;
+    opt.textContent = RELAY_ROLE_LABELS[role] || role;
+    select.appendChild(opt);
+  });
+  select.value = RELAY_ROLE_ORDER.includes(normalized) ? normalized : fallback;
+}
+
+function computeAlarmCapable(device){
+  if (!device || typeof device !== 'object') return false;
+  if (typeof device.alarm_capable === 'boolean') return device.alarm_capable;
+  const roles = device.relay_roles && typeof device.relay_roles === 'object' ? device.relay_roles : {};
+  const a = relayValueNormalized(roles.relay_a, 'door');
+  const b = relayValueNormalized(roles.relay_b, 'none');
+  return a === 'alarm' || a === 'door_alarm' || b === 'alarm' || b === 'door_alarm';
+}
+
+function setRelayStatus(text, tone = 'muted'){
+  const status = document.getElementById('relayStatus');
+  if (!status) return;
+  if (relayStatusTimer){
+    clearTimeout(relayStatusTimer);
+    relayStatusTimer = null;
+  }
+  if (!text){
+    status.textContent = '';
+    status.className = 'form-text text-muted mt-2';
+    return;
+  }
+  let cls = 'form-text mt-2';
+  if (tone === 'error') cls += ' text-danger';
+  else if (tone === 'success') cls += ' text-success';
+  else cls += ' text-muted';
+  status.className = cls;
+  status.textContent = text;
+  if (tone === 'success'){
+    relayStatusTimer = setTimeout(() => {
+      const el = document.getElementById('relayStatus');
+      if (el){
+        el.textContent = '';
+        el.className = 'form-text text-muted mt-2';
+      }
+      relayStatusTimer = null;
+    }, 4000);
+  }
+}
+
+function updateRelayHelper(){
+  const helper = document.getElementById('relayHelper');
+  if (!helper) return;
+  const baseClass = 'form-text mt-3';
+  const capable = computeAlarmCapable(CURRENT_DEVICE);
+  if (capable){
+    helper.className = `${baseClass} text-success`;
+    helper.innerHTML = 'Key Holder can be enabled for users because this device is alarm-capable.';
+  } else {
+    helper.className = `${baseClass} text-muted`;
+    helper.innerHTML = 'Setting a relay to <b>Alarm</b> or <b>Door and Alarm</b> enables the Key Holder option when editing users.';
+  }
+}
+
+function applyRelayUI(device){
+  const relayA = document.getElementById('relayASelect');
+  const relayB = document.getElementById('relayBSelect');
+  const relayBCol = document.getElementById('relayBCol');
+  const keypadNote = document.getElementById('relayKeypadNote');
+  const exitToggle = document.getElementById('exitDeviceToggle');
+  const roles = device && typeof device.relay_roles === 'object' ? device.relay_roles : {};
+  const isKeypad = String(device?.type || '').toLowerCase() === 'keypad';
+  populateRelaySelect(relayA, roles.relay_a, 'door');
+  populateRelaySelect(relayB, roles.relay_b, 'none');
+  if (relayBCol){
+    if (isKeypad) relayBCol.classList.add('d-none');
+    else relayBCol.classList.remove('d-none');
+  }
+  if (relayB){
+    relayB.value = isKeypad ? 'none' : relayValueNormalized(roles.relay_b, 'none');
+  }
+  if (keypadNote){
+    keypadNote.textContent = isKeypad ? 'Keypads expose Relay A only.' : '';
+  }
+  if (exitToggle){
+    exitToggle.checked = !!device?.exit_device;
+  }
+  setRelayStatus('');
+  updateRelayHelper();
+}
+
+async function saveRelayRoles(){
+  if (relaySaving || !CURRENT_DEVICE) return;
+  const relayA = document.getElementById('relayASelect');
+  const relayB = document.getElementById('relayBSelect');
+  const relayBCol = document.getElementById('relayBCol');
+  if (!relayA) return;
+  const includeRelayB = relayB && relayBCol && !relayBCol.classList.contains('d-none');
+  const payload = { relay_a: relayA.value };
+  if (includeRelayB) payload.relay_b = relayB.value;
+  const prev = {
+    relay_a: CURRENT_DEVICE.relay_roles?.relay_a,
+    relay_b: CURRENT_DEVICE.relay_roles?.relay_b
+  };
+  relaySaving = true;
+  setRelayStatus('Saving…');
+  relayA.disabled = true;
+  if (includeRelayB && relayB) relayB.disabled = true;
+  try {
+    const res = await apiPost(actionUrl, { action:'set_device_relays', entry_id: ENTRY_ID, payload });
+    const returned = res && res.relay_roles && typeof res.relay_roles === 'object' ? res.relay_roles : payload;
+    CURRENT_DEVICE.relay_roles = {
+      relay_a: relayValueNormalized(returned.relay_a, prev.relay_a || 'door'),
+      relay_b: includeRelayB ? relayValueNormalized(returned.relay_b, prev.relay_b || 'none') : 'none'
+    };
+    CURRENT_DEVICE.alarm_capable = res && 'alarm_capable' in res
+      ? !!res.alarm_capable
+      : computeAlarmCapable(CURRENT_DEVICE);
+    relayA.value = CURRENT_DEVICE.relay_roles.relay_a;
+    if (includeRelayB && relayB) relayB.value = CURRENT_DEVICE.relay_roles.relay_b;
+    updateRelayHelper();
+    setRelayStatus('Saved ✓', 'success');
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    relayA.value = relayValueNormalized(prev.relay_a, 'door');
+    if (includeRelayB && relayB) relayB.value = relayValueNormalized(prev.relay_b, 'none');
+    CURRENT_DEVICE.relay_roles = {
+      relay_a: relayValueNormalized(prev.relay_a, 'door'),
+      relay_b: relayValueNormalized(prev.relay_b, 'none')
+    };
+    updateRelayHelper();
+    setRelayStatus('Save failed', 'error');
+    alert('Failed to update relay mapping: ' + (err && err.message ? err.message : err));
+  } finally {
+    relaySaving = false;
+    relayA.disabled = false;
+    if (includeRelayB && relayB) relayB.disabled = false;
+  }
+}
+
+async function handleExitToggleChange(){
+  if (exitSaving || !CURRENT_DEVICE) return;
+  const toggle = document.getElementById('exitDeviceToggle');
+  if (!toggle) return;
+  const desired = toggle.checked;
+  exitSaving = true;
+  toggle.disabled = true;
+  setRelayStatus('Saving…');
+  try {
+    const res = await apiPost(actionUrl, { action:'set_exit_device', entry_id: ENTRY_ID, payload: { enabled: desired } });
+    CURRENT_DEVICE.exit_device = res && 'exit_device' in res ? !!res.exit_device : desired;
+    setRelayStatus('Saved ✓', 'success');
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    toggle.checked = !desired;
+    CURRENT_DEVICE.exit_device = toggle.checked;
+    setRelayStatus('Save failed', 'error');
+    alert('Failed to update exit device setting: ' + (err && err.message ? err.message : err));
+  } finally {
+    exitSaving = false;
+    toggle.disabled = false;
+    updateRelayHelper();
+  }
+}
+
 /* API-ish helpers built atop /state and /action */
 async function getState(){ return apiGet(stateUrl); }
 async function getDevice(){
   const st = await getState();
   const dev = (st.devices || []).find(d => (d.entry_id || d.id) === ENTRY_ID);
   if (!dev) throw new Error('Device not found');
+  const roles = dev && typeof dev.relay_roles === 'object' ? dev.relay_roles : {};
+  dev.relay_roles = {
+    relay_a: relayValueNormalized(roles.relay_a, 'door'),
+    relay_b: relayValueNormalized(roles.relay_b, 'none')
+  };
+  dev.exit_device = !!dev.exit_device;
+  if (typeof dev.alarm_capable === 'boolean') dev.alarm_capable = !!dev.alarm_capable;
+  else dev.alarm_capable = computeAlarmCapable(dev);
   // Current groups: prefer sync_groups → groups → Default
   const curGroups = dev.sync_groups || dev.groups || ['Default'];
   // All groups if present at root; fallback
@@ -626,6 +852,20 @@ async function init(){
     document.getElementById('devName').textContent = dev.name || '—';
     document.getElementById('devType').textContent = dev.type || '—';
     document.getElementById('devIP').textContent   = dev.ip || '—';
+
+    CURRENT_DEVICE = {
+      ...dev,
+      relay_roles: {
+        relay_a: dev.relay_roles?.relay_a || 'door',
+        relay_b: dev.relay_roles?.relay_b || 'none'
+      },
+      exit_device: !!dev.exit_device,
+      alarm_capable: computeAlarmCapable(dev)
+    };
+    applyRelayUI(CURRENT_DEVICE);
+    document.getElementById('relayASelect')?.addEventListener('change', saveRelayRoles);
+    document.getElementById('relayBSelect')?.addEventListener('change', saveRelayRoles);
+    document.getElementById('exitDeviceToggle')?.addEventListener('change', handleExitToggleChange);
 
     const onlyDefault = Array.isArray(allGroups) && allGroups.length <= 1;
 

--- a/custom_components/AK_Access_ctrl/www/device_management-mob.html
+++ b/custom_components/AK_Access_ctrl/www/device_management-mob.html
@@ -1,0 +1,691 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Akuvox • Device Management</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  <style>
+    :root{
+      --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#9aa4b2;
+      --ok:#2ecc71; --warn:#ffc107; --bad:#ff4d4f; --info:#0dcaf0;
+    }
+    html,body{height:100%;}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
+    .page{min-height:100vh;display:flex;flex-direction:column;padding:1rem;gap:1rem;max-width:960px;margin:0 auto;}
+    header.page-header{display:flex;align-items:center;gap:0.75rem;}
+    header.page-header h1{flex:1;font-size:1.35rem;margin:0;}
+    header.page-header .btn{white-space:nowrap;}
+    .summary-grid{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
+    .summary-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.4rem;}
+    .summary-card .label{color:var(--muted);font-size:0.85rem;text-transform:uppercase;letter-spacing:0.08em;}
+    .summary-card .value{font-size:1.5rem;font-weight:600;}
+    .summary-card small{color:var(--muted);}
+    .device-list{display:flex;flex-direction:column;gap:1rem;}
+    .device-card{background:var(--card);border:1px solid var(--border);border-radius:1rem;padding:1rem;display:flex;flex-direction:column;gap:0.75rem;}
+    .device-header{display:flex;align-items:flex-start;gap:0.75rem;}
+    .device-name{font-size:1.1rem;font-weight:600;}
+    .device-type{color:var(--muted);font-size:0.9rem;}
+    .badge{border-radius:0.65rem;padding:0.25rem 0.65rem;font-size:0.75rem;font-weight:600;display:inline-flex;align-items:center;gap:0.35rem;}
+    .badge .status-dot{display:inline-block;width:0.55rem;height:0.55rem;border-radius:50%;background:currentColor;}
+    .badge-online{background:rgba(13,202,240,0.18);color:#6be7ff;}
+    .badge-offline{background:rgba(220,53,69,0.18);color:#ff7a8c;}
+    .badge-rebooting{background:rgba(111,66,193,0.18);color:#c49dff;}
+    .badge-in-sync{background:rgba(25,135,84,0.18);color:#5ef3a8;}
+    .badge-pending{background:rgba(255,193,7,0.18);color:#ffd86b;}
+    .badge-in-progress{background:rgba(13,202,240,0.18);color:#6be7ff;}
+    .badge-inactive{background:rgba(108,117,125,0.2);color:#c2c9d1;}
+    .status-stack{margin-left:auto;display:flex;flex-direction:column;gap:0.35rem;align-items:flex-end;}
+    .device-meta{display:grid;gap:0.4rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));color:var(--muted);font-size:0.92rem;}
+    .device-meta i{margin-right:0.4rem;color:#70819f;}
+    .device-actions{display:flex;flex-wrap:wrap;gap:0.5rem;}
+    .chip{display:inline-flex;align-items:center;gap:0.35rem;background:#0f1f37;border:1px solid #243a61;border-radius:999px;padding:0.2rem 0.6rem;font-size:0.8rem;}
+    .group-row{display:flex;flex-wrap:wrap;gap:0.35rem;}
+    .empty-state{background:var(--card);border:1px dashed var(--border);border-radius:0.75rem;padding:1.5rem;text-align:center;color:var(--muted);}
+    .last-updated{color:var(--muted);font-size:0.85rem;text-align:right;}
+    @media (max-width:720px){
+      .page{padding:0.75rem;}
+      header.page-header{flex-wrap:wrap;}
+      header.page-header h1{flex-basis:100%;font-size:1.25rem;}
+      header.page-header .btn{flex:1 1 calc(50% - 0.5rem);}
+      .status-stack{width:100%;flex-direction:row;justify-content:flex-start;gap:0.5rem;margin-left:0;}
+      .device-header{flex-direction:column;}
+      .device-meta{grid-template-columns:1fr;}
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+  <header class="page-header">
+    <button class="btn btn-outline-light btn-sm" id="backBtn"><i class="bi bi-chevron-left"></i> Back</button>
+    <h1>Device Management</h1>
+    <button class="btn btn-outline-info btn-sm" id="refreshBtn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+  </header>
+  <section class="summary-grid" aria-label="Device summary">
+    <div class="summary-card">
+      <span class="label">Devices</span>
+      <span class="value" id="summaryDevices">—</span>
+      <small>Total configured panels</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Online</span>
+      <span class="value" id="summaryOnline">—</span>
+      <small>Currently reporting in</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Pending sync</span>
+      <span class="value" id="summaryPending">—</span>
+      <small>Awaiting credential updates</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Next sync</span>
+      <span class="value" id="summaryNext">—</span>
+      <small>Planned automatic run</small>
+    </div>
+  </section>
+  <div class="last-updated" id="lastUpdated"></div>
+  <section class="device-list" id="deviceList" aria-live="polite"></section>
+</div>
+<script>
+(function captureToken(){
+  try {
+    const params = new URLSearchParams(location.search);
+    const token = params.get('token');
+    if (token) sessionStorage.setItem('akuvox_ll_token', token);
+  } catch (err) {}
+})();
+
+function persistTokens(access, refresh) {
+  if (!access) return null;
+  const payload = { access_token: access };
+  if (refresh) payload.refresh_token = refresh;
+  try { sessionStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  try { localStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  return access;
+}
+
+function extractTokenFromAuth(auth) {
+  if (!auth || typeof auth !== 'object') return null;
+  const access = auth.accessToken
+    || auth.access_token
+    || auth?.token?.access_token
+    || auth?.data?.access_token
+    || null;
+  const refresh = auth.refreshToken
+    || auth.refresh_token
+    || auth?.token?.refresh_token
+    || auth?.data?.refresh_token
+    || null;
+  if (access) {
+    return persistTokens(access, refresh);
+  }
+  return null;
+}
+
+function scanTokenStorage(storage) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem('hassTokens');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {
+        if (typeof raw === 'string' && raw.trim()) {
+          return persistTokens(raw.trim());
+        }
+      }
+    }
+    for (const key of Object.keys(storage)) {
+      if (!/auth|token|hass/i.test(key)) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {}
+    }
+  } catch (err) {}
+  return null;
+}
+
+function tokenFromWindow(win) {
+  if (!win) return null;
+  let token = null;
+  token = scanTokenStorage(win.sessionStorage) || scanTokenStorage(win.localStorage);
+  if (token) return token;
+  token = extractTokenFromAuth(win.hassAuth)
+    || extractTokenFromAuth(win.auth)
+    || extractTokenFromAuth(win.AK_AC_HA_AUTH)
+    || null;
+  if (token) return token;
+  try {
+    const conn = win.hassConnection;
+    if (conn && typeof conn.then === 'function') {
+      conn.then((resolved) => {
+        try {
+          extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+        } catch (err) {}
+      }).catch(() => {});
+    } else if (conn) {
+      token = extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      if (token) return token;
+    }
+  } catch (err) {}
+  return null;
+}
+
+function walkAuthWindows(start) {
+  const visited = new Set();
+  let current = start;
+  while (current && !visited.has(current)) {
+    const token = tokenFromWindow(current);
+    if (token) return token;
+    visited.add(current);
+    let next = null;
+    try { next = current.parent; } catch (err) { next = null; }
+    if (next && next !== current && !visited.has(next)) { current = next; continue; }
+    try { next = current.opener; } catch (err) { next = null; }
+    if (next && next !== current && !visited.has(next)) { current = next; continue; }
+    break;
+  }
+  return null;
+}
+
+(function bootstrapAuthWatchers() {
+  const seen = new WeakSet();
+  function attach(win) {
+    if (!win || seen.has(win)) return;
+    seen.add(win);
+    try { extractTokenFromAuth(win.hassAuth || win.auth || win.AK_AC_HA_AUTH); } catch (err) {}
+    try {
+      const conn = win.hassConnection;
+      if (conn && typeof conn.then === 'function') {
+        conn.then((resolved) => {
+          try {
+            extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+          } catch (err) {}
+        }).catch(() => {});
+      } else if (conn) {
+        extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      }
+    } catch (err) {}
+    try { if (win.parent && win.parent !== win) attach(win.parent); } catch (err) {}
+    try { if (win.opener) attach(win.opener); } catch (err) {}
+  }
+  attach(window);
+})();
+
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search) {
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value) {
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      try { window.parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig() {
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+  const sources = [
+    () => { try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; } },
+    () => { try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; } },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+  return '';
+}
+
+rememberAuthSig(currentAuthSig());
+
+function findHaToken() {
+  const sources = [
+    () => { try { return sessionStorage.getItem('hassTokens'); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem('hassTokens'); } catch (err) { return null; } },
+    () => { try { return sessionStorage.getItem('akuvox_ll_token'); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem('akuvox_ll_token'); } catch (err) { return null; } },
+    () => { try { return window.AK_AC_HA_AUTH || null; } catch (err) { return null; } },
+    () => { try { return window.AK_AC_HA_TOKEN || null; } catch (err) { return null; } },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_HA_AUTH
+            || parent.AK_AC_HA_TOKEN
+            || (parent.sessionStorage && parent.sessionStorage.getItem('akuvox_ll_token'))
+            || (parent.localStorage && parent.localStorage.getItem('akuvox_ll_token'));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+  for (const getter of sources) {
+    const raw = getter();
+    if (!raw) continue;
+    try {
+      if (typeof raw === 'string') {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed) || parsed.access_token || parsed.token;
+        if (token) return token;
+      } else if (typeof raw === 'object') {
+        const token = extractTokenFromAuth(raw);
+        if (token) return token;
+      }
+    } catch (err) {
+      if (typeof raw === 'string' && raw.trim()) return raw.trim();
+    }
+  }
+  return walkAuthWindows(window);
+}
+
+const REJECTED_TOKENS = new Set();
+
+async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
+  const originalHeaders = { ...(options.headers || {}) };
+  let bearer = allowRetry ? findHaToken() : null;
+  let usedBearer = !!bearer;
+  const headers = { ...originalHeaders };
+  if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
+  const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
+  if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
+    REJECTED_TOKENS.add(bearer);
+    const retryToken = findHaToken();
+    if (retryToken && retryToken !== bearer) {
+      return fetchWithAuth(url, { ...options, headers: originalHeaders }, { allowRetry: true });
+    }
+    return fetchWithAuth(url, { ...options, headers: originalHeaders }, { allowRetry: false });
+  }
+  return response;
+}
+
+function buildError(res, text) {
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err) {
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+async function apiGet(url) {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function apiPost(url, body) {
+  const res = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body || {})
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function callService(domain, service, data = {}) {
+  const url = `/api/services/${encodeURIComponent(domain)}/${encodeURIComponent(service)}`;
+  const res = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json().catch(() => ({}));
+}
+
+const SIGNED_PATHS = (function collectSignedPaths(){
+  const result = {};
+  const merge = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') return;
+    for (const [key, value] of Object.entries(candidate)) {
+      if (typeof value === 'string' && value) result[key] = value;
+    }
+  };
+  const read = (storage) => {
+    if (!storage) return;
+    try {
+      const raw = storage.getItem('akuvox_signed_paths');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        merge(parsed);
+      }
+    } catch (err) {}
+  };
+  try { merge(window.AK_AC_SIGNED_PATHS); } catch (err) {}
+  try { read(typeof sessionStorage !== 'undefined' ? sessionStorage : null); } catch (err) {}
+  try { read(typeof localStorage !== 'undefined' ? localStorage : null); } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      merge(window.parent.AK_AC_SIGNED_PATHS);
+      read(window.parent.sessionStorage);
+      read(window.parent.localStorage);
+    }
+  } catch (err) {}
+  return result;
+})();
+
+function signedPath(key, fallback){
+  if (SIGNED_PATHS && typeof SIGNED_PATHS[key] === 'string' && SIGNED_PATHS[key]) {
+    return SIGNED_PATHS[key];
+  }
+  return fallback;
+}
+
+const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
+const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
+const UI_ROOT   = '/akuvox-ac';
+
+function buildHref(slug, params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
+  const query = search.toString();
+  const clean = String(slug || '').replace(/_/g, '-');
+  return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
+}
+
+function requestParentNav(view, params = {}, options = {}) {
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = {
+        type: 'akuvox-nav',
+        view: String(view || ''),
+        slug: String(view || ''),
+        params
+      };
+      if (options.updateHistory === false) msg.updateHistory = false;
+      if (options.replaceState) msg.replaceState = true;
+      if (options.mobileStage) msg.mobileStage = options.mobileStage;
+      if (options.preserveGroups) msg.preserveMobileGroups = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return true;
+    }
+  } catch (err) {}
+  return false;
+}
+
+function openInApp(view, params = {}, options = {}) {
+  const href = buildHref(view, params);
+  const delivered = requestParentNav(view, params, options);
+  if (!delivered) {
+    window.location.href = href;
+  }
+  return delivered;
+}
+
+function redirectToUnauthorized(params = {}) {
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    href = buildHref('unauthorized', targetParams);
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      Object.entries(targetParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') search.set(key, value);
+      });
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  } catch (err) {}
+  if (!delivered) {
+    try { window.location.replace(href); } catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err) {
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
+function goBack(){
+  requestParentNav('index', { section: 'devices' }, { replaceState: true, mobileStage: 'nav' });
+}
+
+document.getElementById('backBtn').addEventListener('click', (ev) => { ev.preventDefault(); goBack(); });
+document.getElementById('refreshBtn').addEventListener('click', (ev) => { ev.preventDefault(); refresh(); });
+
+function escapeHtml(value){
+  const lookup = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return String(value ?? '').replace(/[&<>"']/g, ch => lookup[ch] ?? ch);
+}
+
+function badge(label, type){
+  const kind = String(type || '').toLowerCase();
+  const cls = kind === 'online' ? 'badge-online'
+    : kind === 'offline' ? 'badge-offline'
+    : kind === 'rebooting' ? 'badge-rebooting'
+    : kind === 'in_sync' ? 'badge-in-sync'
+    : kind === 'in_progress' ? 'badge-in-progress'
+    : kind === 'pending' ? 'badge-pending'
+    : 'badge-inactive';
+  const text = escapeHtml(label ?? '—');
+  return `<span class="badge ${cls}"><span class="status-dot"></span>${text}</span>`;
+}
+
+function safeDeviceName(d){
+  return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
+}
+
+function renderSummary(devices, kpis){
+  const total = devices.length;
+  const online = devices.filter(d => d.status === 'online').length;
+  const pending = devices.filter(d => d.status !== 'offline' && d.sync_status !== 'in_sync').length;
+  const next = kpis?.next_sync || kpis?.auto_sync_time || '—';
+  document.getElementById('summaryDevices').textContent = String(total);
+  document.getElementById('summaryOnline').textContent = String(online);
+  document.getElementById('summaryPending').textContent = String(pending);
+  document.getElementById('summaryNext').textContent = next || '—';
+}
+
+function renderDevices(devices){
+  const host = document.getElementById('deviceList');
+  host.innerHTML = '';
+  if (!devices.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<i class="bi bi-hdd-network"></i> <div class="mt-2">No devices found.</div>';
+    host.appendChild(empty);
+    return;
+  }
+  devices.forEach(device => {
+    const statusKey = String(device.status || (device.online === false ? 'offline' : 'online')).toLowerCase();
+    const syncKey = String(device.sync_status || '').toLowerCase();
+    const isOnline = statusKey === 'online';
+    let statusBadge;
+    if (statusKey === 'rebooting') statusBadge = badge('Rebooting', 'rebooting');
+    else if (statusKey === 'online') statusBadge = badge('Online', 'online');
+    else if (statusKey === 'offline') statusBadge = badge('Offline', 'offline');
+    else statusBadge = badge(statusKey || 'Unknown', 'inactive');
+
+    let syncBadge;
+    if (statusKey === 'offline') syncBadge = badge('Unavailable', 'inactive');
+    else if (syncKey === 'in_sync') syncBadge = badge('In Sync', 'in_sync');
+    else if (syncKey === 'in_progress') syncBadge = badge('In Progress', 'in_progress');
+    else syncBadge = badge('Pending', 'pending');
+
+    const groups = (device.sync_groups || []).length
+      ? (device.sync_groups || []).map(g => `<span class="chip">${escapeHtml(g)}</span>`).join(' ')
+      : '<span class="text-muted">Default</span>';
+    const card = document.createElement('article');
+    card.className = 'device-card';
+    const lastSync = device.last_sync || '—';
+    const ip = device.ip || '—';
+    const entryId = device.entry_id || device.id || '';
+
+    card.innerHTML = `
+      <div class="device-header">
+        <div>
+          <div class="device-name">${escapeHtml(safeDeviceName(device))}</div>
+          <div class="device-type">${escapeHtml(device.type || 'Unknown')}</div>
+        </div>
+        <div class="status-stack">
+          ${statusBadge}
+          ${syncBadge}
+        </div>
+      </div>
+      <div class="device-meta">
+        <div><i class="bi bi-ethernet"></i>IP: <span class="small-monospace">${escapeHtml(ip)}</span></div>
+        <div><i class="bi bi-clock-history"></i>Last sync: ${escapeHtml(lastSync)}</div>
+        <div class="group-row"><i class="bi bi-people"></i>Groups: ${groups}</div>
+      </div>
+      <div class="device-actions">
+        <button class="btn btn-outline-light btn-sm" data-action="sync" data-id="${escapeHtml(entryId)}" ${!isOnline ? 'disabled' : ''}><i class="bi bi-arrow-repeat"></i> Sync now</button>
+        <button class="btn btn-outline-light btn-sm" data-manage="${escapeHtml(entryId)}"><i class="bi bi-gear"></i> Manage</button>
+        <button class="btn btn-outline-danger btn-sm" data-action="reboot" data-id="${escapeHtml(entryId)}" ${!isOnline ? 'disabled' : ''}><i class="bi bi-power"></i> Reboot</button>
+      </div>
+    `;
+    host.appendChild(card);
+  });
+
+  host.querySelectorAll('[data-manage]').forEach(btn => {
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const id = btn.dataset.manage || '';
+      openInApp('device-edit', id ? { id } : {});
+    });
+  });
+
+  host.querySelectorAll('button[data-action]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const action = btn.dataset.action;
+      const entryId = btn.dataset.id;
+      if (!entryId) return;
+      try {
+        if (action === 'sync') {
+          await apiPost(actionUrl, { action: 'sync_now', entry_id: entryId });
+        } else if (action === 'reboot') {
+          await apiPost(actionUrl, { action: 'reboot_device', entry_id: entryId });
+        }
+      } catch (err) {
+        try {
+          if (action === 'sync') {
+            await callService('akuvox_ac', 'sync_now', { entry_id: entryId });
+          } else {
+            await callService('akuvox_ac', 'reboot_device', { entry_id: entryId });
+          }
+        } catch (fallbackErr) {
+          alert(`Action failed: ${escapeHtml(fallbackErr.message || fallbackErr)}`);
+        }
+      }
+      refresh();
+    });
+  });
+}
+
+async function refresh(){
+  try {
+    document.getElementById('refreshBtn').setAttribute('disabled', 'disabled');
+    const state = await apiGet(stateUrl);
+    const devices = (state.devices || []).map(d => ({
+      entry_id: d.entry_id || d.id || '',
+      name: safeDeviceName(d),
+      type: d.type,
+      ip: d.ip,
+      status: (d.status || (d.online === false ? 'offline' : 'online')).toString().toLowerCase(),
+      sync_status: (d.sync_status || '').toString().toLowerCase(),
+      last_sync: d.last_sync || '—',
+      sync_groups: d.sync_groups || d.groups || ['Default'],
+      online: d.online !== false
+    }));
+    renderSummary(devices, state.kpis || {});
+    renderDevices(devices);
+    const ts = new Date();
+    document.getElementById('lastUpdated').textContent = `Updated ${ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  } catch (err) {
+    console.error('Failed to load devices', err);
+    if (handleAuthError(err)) return;
+    const host = document.getElementById('deviceList');
+    host.innerHTML = `<div class="empty-state text-danger">Failed to load devices: ${escapeHtml(err.message || err)}</div>`;
+  } finally {
+    document.getElementById('refreshBtn').removeAttribute('disabled');
+  }
+}
+
+refresh();
+</script>
+</body>
+</html>

--- a/custom_components/AK_Access_ctrl/www/event_history-mob.html
+++ b/custom_components/AK_Access_ctrl/www/event_history-mob.html
@@ -1,0 +1,638 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Akuvox • Event History</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  <style>
+    :root{
+      --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#9aa4b2;
+      --ok:#2ecc71; --warn:#ffc107; --bad:#ff4d4f; --info:#0dcaf0;
+    }
+    html,body{height:100%;}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
+    .page{min-height:100vh;display:flex;flex-direction:column;padding:1rem;gap:1rem;max-width:960px;margin:0 auto;}
+    header.page-header{display:flex;align-items:center;gap:0.75rem;}
+    header.page-header h1{flex:1;font-size:1.35rem;margin:0;}
+    header.page-header .btn{white-space:nowrap;}
+    .summary-grid{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
+    .summary-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.4rem;}
+    .summary-card .label{color:var(--muted);font-size:0.85rem;text-transform:uppercase;letter-spacing:0.08em;}
+    .summary-card .value{font-size:1.5rem;font-weight:600;}
+    .summary-card small{color:var(--muted);}
+    .event-feed{display:flex;flex-direction:column;gap:0.75rem;}
+    .event-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.45rem;}
+    .event-title{font-weight:600;font-size:1rem;display:flex;align-items:center;gap:0.5rem;}
+    .event-title .pill{display:inline-flex;align-items:center;gap:0.35rem;border-radius:999px;padding:0.2rem 0.55rem;font-size:0.75rem;font-weight:600;}
+    .event-title.ok .pill{background:rgba(46,204,113,0.18);color:#5ef3a8;}
+    .event-title.warn .pill{background:rgba(255,193,7,0.18);color:#ffd86b;}
+    .event-title.bad .pill{background:rgba(255,77,79,0.18);color:#ff9aa3;}
+    .event-title.dim .pill{background:rgba(112,129,159,0.25);color:#c5cede;}
+    .event-meta{color:var(--muted);font-size:0.9rem;display:flex;flex-wrap:wrap;gap:0.5rem;}
+    .event-meta span{display:inline-flex;align-items:center;gap:0.3rem;}
+    .event-meta i{color:#7d8ca8;}
+    .empty-state{background:var(--card);border:1px dashed var(--border);border-radius:0.75rem;padding:1.5rem;text-align:center;color:var(--muted);}
+    .last-updated{color:var(--muted);font-size:0.85rem;text-align:right;}
+    @media (max-width:720px){
+      .page{padding:0.75rem;}
+      header.page-header{flex-wrap:wrap;}
+      header.page-header h1{flex-basis:100%;font-size:1.25rem;}
+      header.page-header .btn{flex:1 1 calc(50% - 0.5rem);}
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+  <header class="page-header">
+    <button class="btn btn-outline-light btn-sm" id="backBtn"><i class="bi bi-chevron-left"></i> Back</button>
+    <h1>Event History</h1>
+    <button class="btn btn-outline-info btn-sm" id="refreshBtn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+  </header>
+  <section class="summary-grid" aria-label="Event summary">
+    <div class="summary-card">
+      <span class="label">Events</span>
+      <span class="value" id="summaryEvents">—</span>
+      <small>Entries captured from devices</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Last event</span>
+      <span class="value" id="summaryLatest">—</span>
+      <small>Most recent timestamp</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Alerts</span>
+      <span class="value" id="summaryAlerts">—</span>
+      <small>Events requiring attention</small>
+    </div>
+  </section>
+  <div class="last-updated" id="lastUpdated"></div>
+  <section class="event-feed" id="eventList" aria-live="polite"></section>
+</div>
+<script>
+(function captureToken(){
+  try {
+    const params = new URLSearchParams(location.search);
+    const token = params.get('token');
+    if (token) sessionStorage.setItem('akuvox_ll_token', token);
+  } catch (err) {}
+})();
+
+function persistTokens(access, refresh) {
+  if (!access) return null;
+  const payload = { access_token: access };
+  if (refresh) payload.refresh_token = refresh;
+  try { sessionStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  try { localStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  return access;
+}
+
+function extractTokenFromAuth(auth) {
+  if (!auth || typeof auth !== 'object') return null;
+  const access = auth.accessToken
+    || auth.access_token
+    || auth?.token?.access_token
+    || auth?.data?.access_token
+    || null;
+  const refresh = auth.refreshToken
+    || auth.refresh_token
+    || auth?.token?.refresh_token
+    || auth?.data?.refresh_token
+    || null;
+  if (access) {
+    return persistTokens(access, refresh);
+  }
+  return null;
+}
+
+function scanTokenStorage(storage) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem('hassTokens');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {
+        if (typeof raw === 'string' && raw.trim()) {
+          return persistTokens(raw.trim());
+        }
+      }
+    }
+    for (const key of Object.keys(storage)) {
+      if (!/auth|token|hass/i.test(key)) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {}
+    }
+  } catch (err) {}
+  return null;
+}
+
+function tokenFromWindow(win) {
+  if (!win) return null;
+  let token = null;
+  token = scanTokenStorage(win.sessionStorage) || scanTokenStorage(win.localStorage);
+  if (token) return token;
+  token = extractTokenFromAuth(win.hassAuth)
+    || extractTokenFromAuth(win.auth)
+    || extractTokenFromAuth(win.AK_AC_HA_AUTH)
+    || null;
+  if (token) return token;
+  try {
+    const conn = win.hassConnection;
+    if (conn && typeof conn.then === 'function') {
+      conn.then((resolved) => {
+        try {
+          extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+        } catch (err) {}
+      }).catch(() => {});
+    } else if (conn) {
+      token = extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      if (token) return token;
+    }
+  } catch (err) {}
+  return null;
+}
+
+function walkAuthWindows(start) {
+  const visited = new Set();
+  let current = start;
+  while (current && !visited.has(current)) {
+    const token = tokenFromWindow(current);
+    if (token) return token;
+    visited.add(current);
+    let next = null;
+    try { next = current.parent; } catch (err) { next = null; }
+    if (next && next !== current && !visited.has(next)) { current = next; continue; }
+    try { next = current.opener; } catch (err) { next = null; }
+    if (next && next !== current && !visited.has(next)) { current = next; continue; }
+    break;
+  }
+  return null;
+}
+
+(function bootstrapAuthWatchers() {
+  const seen = new WeakSet();
+  function attach(win) {
+    if (!win || seen.has(win)) return;
+    seen.add(win);
+    try { extractTokenFromAuth(win.hassAuth || win.auth || win.AK_AC_HA_AUTH); } catch (err) {}
+    try {
+      const conn = win.hassConnection;
+      if (conn && typeof conn.then === 'function') {
+        conn.then((resolved) => {
+          try {
+            extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+          } catch (err) {}
+        }).catch(() => {});
+      } else if (conn) {
+        extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      }
+    } catch (err) {}
+    try { if (win.parent && win.parent !== win) attach(win.parent); } catch (err) {}
+    try { if (win.opener) attach(win.opener); } catch (err) {}
+  }
+  attach(window);
+})();
+
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search) {
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value) {
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      try { window.parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig() {
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+  const sources = [
+    () => { try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; } },
+    () => { try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; } },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+  return '';
+}
+
+rememberAuthSig(currentAuthSig());
+
+function findHaToken() {
+  const sources = [
+    () => { try { return sessionStorage.getItem('hassTokens'); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem('hassTokens'); } catch (err) { return null; } },
+    () => { try { return sessionStorage.getItem('akuvox_ll_token'); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem('akuvox_ll_token'); } catch (err) { return null; } },
+    () => { try { return window.AK_AC_HA_AUTH || null; } catch (err) { return null; } },
+    () => { try { return window.AK_AC_HA_TOKEN || null; } catch (err) { return null; } },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_HA_AUTH
+            || parent.AK_AC_HA_TOKEN
+            || (parent.sessionStorage && parent.sessionStorage.getItem('akuvox_ll_token'))
+            || (parent.localStorage && parent.localStorage.getItem('akuvox_ll_token'));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+  for (const getter of sources) {
+    const raw = getter();
+    if (!raw) continue;
+    try {
+      if (typeof raw === 'string') {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed) || parsed.access_token || parsed.token;
+        if (token) return token;
+      } else if (typeof raw === 'object') {
+        const token = extractTokenFromAuth(raw);
+        if (token) return token;
+      }
+    } catch (err) {
+      if (typeof raw === 'string' && raw.trim()) return raw.trim();
+    }
+  }
+  return walkAuthWindows(window);
+}
+
+const REJECTED_TOKENS = new Set();
+
+async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
+  const originalHeaders = { ...(options.headers || {}) };
+  let bearer = allowRetry ? findHaToken() : null;
+  let usedBearer = !!bearer;
+  const headers = { ...originalHeaders };
+  if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
+  const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
+  if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
+    REJECTED_TOKENS.add(bearer);
+    const retryToken = findHaToken();
+    if (retryToken && retryToken !== bearer) {
+      return fetchWithAuth(url, { ...options, headers: originalHeaders }, { allowRetry: true });
+    }
+    return fetchWithAuth(url, { ...options, headers: originalHeaders }, { allowRetry: false });
+  }
+  return response;
+}
+
+function buildError(res, text) {
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err) {
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+async function apiGet(url) {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function apiPost(url, body) {
+  const res = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body || {})
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function callService(domain, service, data = {}) {
+  const url = `/api/services/${encodeURIComponent(domain)}/${encodeURIComponent(service)}`;
+  const res = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json().catch(() => ({}));
+}
+
+const SIGNED_PATHS = (function collectSignedPaths(){
+  const result = {};
+  const merge = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') return;
+    for (const [key, value] of Object.entries(candidate)) {
+      if (typeof value === 'string' && value) result[key] = value;
+    }
+  };
+  const read = (storage) => {
+    if (!storage) return;
+    try {
+      const raw = storage.getItem('akuvox_signed_paths');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        merge(parsed);
+      }
+    } catch (err) {}
+  };
+  try { merge(window.AK_AC_SIGNED_PATHS); } catch (err) {}
+  try { read(typeof sessionStorage !== 'undefined' ? sessionStorage : null); } catch (err) {}
+  try { read(typeof localStorage !== 'undefined' ? localStorage : null); } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      merge(window.parent.AK_AC_SIGNED_PATHS);
+      read(window.parent.sessionStorage);
+      read(window.parent.localStorage);
+    }
+  } catch (err) {}
+  return result;
+})();
+
+function signedPath(key, fallback){
+  if (SIGNED_PATHS && typeof SIGNED_PATHS[key] === 'string' && SIGNED_PATHS[key]) {
+    return SIGNED_PATHS[key];
+  }
+  return fallback;
+}
+
+const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
+const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
+const UI_ROOT   = '/akuvox-ac';
+
+function buildHref(slug, params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
+  const query = search.toString();
+  const clean = String(slug || '').replace(/_/g, '-');
+  return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
+}
+
+function requestParentNav(view, params = {}, options = {}) {
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = {
+        type: 'akuvox-nav',
+        view: String(view || ''),
+        slug: String(view || ''),
+        params
+      };
+      if (options.updateHistory === false) msg.updateHistory = false;
+      if (options.replaceState) msg.replaceState = true;
+      if (options.mobileStage) msg.mobileStage = options.mobileStage;
+      if (options.preserveGroups) msg.preserveMobileGroups = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return true;
+    }
+  } catch (err) {}
+  return false;
+}
+
+function openInApp(view, params = {}, options = {}) {
+  const href = buildHref(view, params);
+  const delivered = requestParentNav(view, params, options);
+  if (!delivered) {
+    window.location.href = href;
+  }
+  return delivered;
+}
+
+function redirectToUnauthorized(params = {}) {
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    href = buildHref('unauthorized', targetParams);
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      Object.entries(targetParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') search.set(key, value);
+      });
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  } catch (err) {}
+  if (!delivered) {
+    try { window.location.replace(href); } catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err) {
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
+function goBack(){
+  requestParentNav('index', { section: 'events' }, { replaceState: true, mobileStage: 'nav' });
+}
+
+document.getElementById('backBtn').addEventListener('click', (ev) => { ev.preventDefault(); goBack(); });
+document.getElementById('refreshBtn').addEventListener('click', (ev) => { ev.preventDefault(); refresh(); });
+
+function escapeHtml(value){
+  const lookup = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return String(value ?? '').replace(/[&<>"']/g, ch => lookup[ch] ?? ch);
+}
+
+function classifyEvent(txt){
+  const s = String(txt || '').toLowerCase();
+  if (s.includes('denied') || s.includes('went offline') || s.includes('alarm') || s.includes('failed')) return 'bad';
+  if (s.includes('warning') || s.includes('reboot') || s.includes('pending') || s.includes('sync requested')) return 'warn';
+  if (s.includes('came online') || s.includes('sync succeeded') || s.includes('created')) return 'ok';
+  return 'dim';
+}
+
+function formatWhen(ts){
+  if (!ts) return '—';
+  let d = ts instanceof Date ? ts : new Date(ts);
+  if (isNaN(d.getTime())) {
+    try { const clean = String(ts).split('.')[0] + 'Z'; d = new Date(clean); }
+    catch { return String(ts); }
+  }
+  if (isNaN(d.getTime())) return String(ts);
+  return d.toLocaleString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function gatherEvents(devices){
+  const events = [];
+  (devices || []).forEach(device => {
+    (device.events || []).forEach(evt => {
+      let ts = evt.timestamp || evt.Time || evt.time || evt.ts || '';
+      let date = new Date(ts);
+      if (isNaN(date.getTime()) && ts) {
+        try { ts = String(ts).split('.')[0] + 'Z'; date = new Date(ts); } catch {}
+      }
+      events.push({
+        ...evt,
+        _device: safeDeviceName(device),
+        _ts: date.getTime() || 0,
+        _when: date
+      });
+    });
+  });
+  events.sort((a,b) => (b._ts || 0) - (a._ts || 0));
+  return events;
+}
+
+function safeDeviceName(d){
+  return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
+}
+
+function renderSummary(events){
+  const total = events.length;
+  const latest = events[0]? formatWhen(events[0]._when || events[0].timestamp) : '—';
+  const alerts = events.filter(e => {
+    const severity = classifyEvent(e.Event || e.Result || e.action || e.Message || '');
+    return severity === 'bad';
+  }).length;
+  document.getElementById('summaryEvents').textContent = String(total);
+  document.getElementById('summaryLatest').textContent = latest || '—';
+  document.getElementById('summaryAlerts').textContent = String(alerts);
+}
+
+function renderEvents(events){
+  const host = document.getElementById('eventList');
+  host.innerHTML = '';
+  if (!events.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<i class="bi bi-clock-history"></i> <div class="mt-2">No events to display.</div>';
+    host.appendChild(empty);
+    return;
+  }
+  events.forEach(evt => {
+    const titleRaw = evt.Event || evt.Result || evt.action || evt.Message || 'Event';
+    const severity = classifyEvent(titleRaw);
+    const pillText = severity === 'bad' ? 'Alert'
+      : severity === 'warn' ? 'Notice'
+      : severity === 'ok' ? 'Info'
+      : 'Log';
+    const when = formatWhen(evt._when || evt.timestamp || evt.Time);
+    const user = evt.User || evt.user || evt.Name || evt.NameID || '';
+    const method = evt.Method || evt.method || evt.AccessMode || '';
+    const device = evt._device || evt.Device || evt.device || '';
+
+    const card = document.createElement('article');
+    card.className = 'event-card';
+    card.innerHTML = `
+      <div class="event-title ${severity}">
+        <span class="pill">${pillText}</span>
+        <span>${escapeHtml(titleRaw)}</span>
+      </div>
+      <div class="event-meta">
+        <span><i class="bi bi-hdd-network"></i>${escapeHtml(device || '—')}</span>
+        <span><i class="bi bi-person"></i>${escapeHtml(user || '—')}</span>
+        <span><i class="bi bi-clock"></i>${escapeHtml(when)}</span>
+        ${method ? `<span><i class="bi bi-key"></i>${escapeHtml(method)}</span>` : ''}
+      </div>
+    `;
+    host.appendChild(card);
+  });
+}
+
+async function refresh(){
+  try {
+    document.getElementById('refreshBtn').setAttribute('disabled', 'disabled');
+    const state = await apiGet(stateUrl);
+    const devices = state.devices || [];
+    const events = gatherEvents(devices);
+    renderSummary(events);
+    renderEvents(events);
+    const ts = new Date();
+    document.getElementById('lastUpdated').textContent = `Updated ${ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  } catch (err) {
+    console.error('Failed to load events', err);
+    if (handleAuthError(err)) return;
+    const host = document.getElementById('eventList');
+    host.innerHTML = `<div class="empty-state text-danger">Failed to load events: ${escapeHtml(err.message || err)}</div>`;
+  } finally {
+    document.getElementById('refreshBtn').removeAttribute('disabled');
+  }
+}
+
+refresh();
+</script>
+</body>
+</html>

--- a/custom_components/AK_Access_ctrl/www/head-mob.html
+++ b/custom_components/AK_Access_ctrl/www/head-mob.html
@@ -355,10 +355,10 @@
         <i class="bi bi-people-fill"></i>
       </button>
       <div class="mobile-subgrid">
-        <button class="mobile-tile sub" type="button" data-view="index" data-section="users">
+        <button class="mobile-tile sub" type="button" data-view="user-overview">
           <div class="tile-text">
             <span class="tile-title">User overview</span>
-            <small>See device sync and assigned groups</small>
+            <small>Review sync status and assigned groups</small>
           </div>
           <i class="bi bi-layout-text-window-reverse"></i>
         </button>
@@ -368,13 +368,6 @@
             <small>Create a new access profile</small>
           </div>
           <i class="bi bi-person-plus-fill"></i>
-        </button>
-        <button class="mobile-tile sub" type="button" data-view="users" data-mode="edit">
-          <div class="tile-text">
-            <span class="tile-title">Edit user</span>
-            <small>Pick someone to update or revoke access</small>
-          </div>
-          <i class="bi bi-person-check-fill"></i>
         </button>
       </div>
     </div>
@@ -410,17 +403,17 @@
         </button>
       </div>
     </div>
-    <button class="mobile-tile" type="button" data-view="index" data-section="devices">
+    <button class="mobile-tile" type="button" data-view="device-management">
       <div class="tile-text">
         <span class="tile-title">Device management</span>
-        <small>Check health, reboot or sync panels</small>
+        <small>Check health, sync or reboot panels</small>
       </div>
       <i class="bi bi-hdd-network"></i>
     </button>
-    <button class="mobile-tile" type="button" data-view="index" data-section="events">
+    <button class="mobile-tile" type="button" data-view="event-history">
       <div class="tile-text">
         <span class="tile-title">Event history</span>
-        <small>See the latest entries and alarms</small>
+        <small>Review the latest entries and alarms</small>
       </div>
       <i class="bi bi-clock-history"></i>
     </button>
@@ -1258,6 +1251,11 @@ window.addEventListener('message', (event) => {
   if (data.type !== 'akuvox-nav') return;
   const view = normalizeView(data.view || data.slug || data.target || DEFAULT_VIEW);
   const params = data.params || {};
+  if (isMobileMode && data.mobileStage) {
+    const preserve = data.preserveMobileGroups === true || data.preserveGroups === true;
+    const stage = String(data.mobileStage).toLowerCase() === 'nav' ? 'nav' : 'content';
+    setMobileStage(stage, { preserveGroups: preserve });
+  }
   const opts = {
     updateHistory: data.updateHistory !== false,
     replaceState: !!data.replaceState

--- a/custom_components/AK_Access_ctrl/www/index-mob.html
+++ b/custom_components/AK_Access_ctrl/www/index-mob.html
@@ -682,8 +682,8 @@ function renderDevices(devs){
       <td>${syncBadge}</td>
       <td>${last}</td>
       <td>${syncBtn}</td>
-      <td>${rebootBtn}</td>
       <td>${editBtn}</td>
+      <td>${rebootBtn}</td>
     </tr>`;
   }).join('');
 
@@ -1440,7 +1440,7 @@ setInterval(refresh, 5000);
             <thead>
               <tr>
                 <th>Name</th><th>Type</th><th>IP</th><th>Status</th><th>Sync</th><th>Last Sync</th>
-                <th>Sync</th><th>Reboot</th><th>Edit</th>
+                <th>Sync</th><th>Edit</th><th>Reboot</th>
               </tr>
             </thead>
             <tbody id="tblDevices"><tr><td colspan="9" class="text-muted">Loading…</td></tr></tbody>

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -707,8 +707,8 @@ function renderDevices(devs){
       <td>${syncBadge}</td>
       <td>${last}</td>
       <td>${syncBtn}</td>
-      <td>${rebootBtn}</td>
       <td>${editBtn}</td>
+      <td>${rebootBtn}</td>
     </tr>`;
   }).join('');
 
@@ -1546,7 +1546,7 @@ setInterval(refresh, 5000);
             <thead>
               <tr>
                 <th>Name</th><th>Type</th><th>IP</th><th>Status</th><th>Sync</th><th>Last Sync</th>
-                <th>Sync</th><th>Reboot</th><th>Edit</th>
+                <th>Sync</th><th>Edit</th><th>Reboot</th>
               </tr>
             </thead>
             <tbody id="tblDevices"><tr><td colspan="9" class="text-muted">Loading…</td></tr></tbody>

--- a/custom_components/AK_Access_ctrl/www/settings-mob.html
+++ b/custom_components/AK_Access_ctrl/www/settings-mob.html
@@ -493,25 +493,15 @@ const API_SETTINGS = signedPath('settings', '/api/akuvox_ac/ui/settings');
 const API_PHONES   = signedPath('phones', '/api/akuvox_ac/ui/phones');
 const API_ACTION   = signedPath('action', '/api/akuvox_ac/ui/action');
 
-const RELAY_ROLE_LABELS = {
-  none: 'Not used',
-  door: 'Door Relay',
-  alarm: 'Alarm Relay',
-  door_alarm: 'Door and Alarm Relay'
-};
-const RELAY_ROLE_ORDER = ['none', 'door', 'alarm', 'door_alarm'];
-
 let SETTINGS_DATA = { integrity_interval_minutes: null, auto_sync_delay_minutes: 30, alerts: { targets: {} }, registry_users: [], capabilities: { alarm_relay: false } };
 let PHONES = [];
 let USERS = [];
-let DEVICES = [];
 let ALERT_TARGETS = {};
 let alertsSaving = false;
 let integritySaving = false;
 let integritySavedTimer = null;
 let autoSyncSaving = false;
 let autoSyncSavedTimer = null;
-const DEVICE_STATUS_TIMERS = new Map();
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const SCHEDULE_DAY_ORDER = [
   { key: 'mon', label: 'Monday' },
@@ -698,242 +688,6 @@ function ensureTargetDefaults(target){
 function escapeSelector(value){
   if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
   return String(value || '').replace(/([\W])/g, '\\$1');
-}
-
-function relayValueNormalized(value, fallback = 'door'){
-  const raw = (value ?? '').toString().trim().toLowerCase();
-  if (!raw) return fallback;
-  const clean = raw.replace(/[\s-]+/g, '_');
-  if (RELAY_ROLE_ORDER.includes(clean)) return clean;
-  if (clean === 'not_used' || clean === 'unused' || clean === 'none') return 'none';
-  if (clean === 'door' || clean === 'door_relay') return 'door';
-  if (clean === 'alarm' || clean === 'alarm_relay') return 'alarm';
-  if (clean === 'door_and_alarm' || clean === 'door_alarm_relay' || clean === 'doorandalarm') return 'door_alarm';
-  return fallback;
-}
-
-function deviceById(entryId){
-  return DEVICES.find(d => d.entry_id === entryId);
-}
-
-function populateRelaySelect(select, value){
-  if (!select) return;
-  const normalized = relayValueNormalized(value, 'door');
-  select.innerHTML = '';
-  RELAY_ROLE_ORDER.forEach(role => {
-    const opt = document.createElement('option');
-    opt.value = role;
-    opt.textContent = RELAY_ROLE_LABELS[role] || role;
-    select.appendChild(opt);
-  });
-  if (RELAY_ROLE_ORDER.includes(normalized)) {
-    select.value = normalized;
-  } else {
-    select.value = 'door';
-  }
-}
-
-function applyDeviceValues(card, device){
-  if (!card || !device) return;
-  const roles = device.relay_roles && typeof device.relay_roles === 'object' ? device.relay_roles : {};
-  populateRelaySelect(card.querySelector('select[data-relay="relay_a"]'), roles.relay_a);
-  const relayB = card.querySelector('select[data-relay="relay_b"]');
-  if (relayB) populateRelaySelect(relayB, roles.relay_b);
-  const exitToggle = card.querySelector('input[data-exit-toggle]');
-  if (exitToggle) exitToggle.checked = !!device.exit_device;
-}
-
-function clearDeviceStatusTimers(){
-  DEVICE_STATUS_TIMERS.forEach(timer => clearTimeout(timer));
-  DEVICE_STATUS_TIMERS.clear();
-}
-
-function setDeviceStatus(entryId, text, tone = 'muted'){
-  const selector = `[data-device="${escapeSelector(entryId)}"] [data-device-status]`;
-  const status = document.querySelector(selector);
-  if (!status) return;
-  if (DEVICE_STATUS_TIMERS.has(entryId)){
-    clearTimeout(DEVICE_STATUS_TIMERS.get(entryId));
-    DEVICE_STATUS_TIMERS.delete(entryId);
-  }
-  if (!text){
-    status.textContent = '';
-    status.className = 'small muted mt-2';
-    return;
-  }
-  let cls = 'small mt-2';
-  if (tone === 'error') cls += ' text-danger';
-  else if (tone === 'success') cls += ' text-success';
-  else cls += ' muted';
-  status.className = cls;
-  status.textContent = text;
-  if (tone === 'success'){
-    const timer = setTimeout(() => {
-      const node = document.querySelector(selector);
-      if (node){
-        node.textContent = '';
-        node.className = 'small muted mt-2';
-      }
-      DEVICE_STATUS_TIMERS.delete(entryId);
-    }, 4000);
-    DEVICE_STATUS_TIMERS.set(entryId, timer);
-  }
-}
-
-function updateRelaySummary(){
-  const summary = document.getElementById('deviceRelaySummary');
-  if (!summary) return;
-  const anyAlarm = DEVICES.some(dev => {
-    if (typeof dev.alarm_capable === 'boolean') return dev.alarm_capable;
-    const roles = dev.relay_roles || {};
-    const aVal = relayValueNormalized(roles.relay_a, 'door');
-    const bVal = relayValueNormalized(roles.relay_b, 'none');
-    return aVal === 'alarm' || aVal === 'door_alarm' || bVal === 'alarm' || bVal === 'door_alarm';
-  });
-  SETTINGS_DATA.capabilities = SETTINGS_DATA.capabilities || {};
-  SETTINGS_DATA.capabilities.alarm_relay = anyAlarm;
-  if (!DEVICES.length){
-    summary.textContent = 'No devices have been added yet.';
-    summary.className = 'small muted mt-2';
-    return;
-  }
-  if (anyAlarm){
-    summary.textContent = 'Key Holder can be enabled for users because an alarm-capable relay is configured.';
-    summary.className = 'small text-success mt-2';
-  } else {
-    summary.textContent = 'Set a relay to Alarm or Door and Alarm to enable the Key Holder option when editing users.';
-    summary.className = 'small muted mt-2';
-  }
-}
-
-function renderDeviceOptions(){
-  const container = document.getElementById('deviceOptions');
-  if (!container) return;
-  clearDeviceStatusTimers();
-  container.innerHTML = '';
-  if (!DEVICES.length){
-    const empty = document.createElement('div');
-    empty.className = 'muted';
-    empty.textContent = 'No devices available yet.';
-    container.appendChild(empty);
-    updateRelaySummary();
-    return;
-  }
-  const sorted = [...DEVICES].sort((a,b) => (a.name || '').localeCompare(b.name || ''));
-  sorted.forEach(device => {
-    const card = document.createElement('div');
-    card.className = 'device-option';
-    card.setAttribute('data-device', device.entry_id);
-    const typeLabel = device.type || 'Device';
-    const isKeypad = String(device.type || '').toLowerCase() === 'keypad';
-    const ipHtml = device.ip ? `<span class="device-meta">IP: ${device.ip}</span>` : '';
-    const keypadNote = isKeypad ? '<div class="form-text muted mt-1">Keypads expose Relay A only.</div>' : '';
-    card.innerHTML = `
-      <div class="device-header">
-        <div>
-          <div class="fw-semibold">${device.name || 'Device'}</div>
-          <div class="device-meta">${typeLabel}</div>
-        </div>
-        ${ipHtml}
-      </div>
-      <div class="row g-3 mt-2">
-        <div class="col-sm-6 col-lg-4">
-          <label class="form-label">Relay A action</label>
-          <select class="form-select" data-relay="relay_a"></select>
-        </div>
-        ${isKeypad ? '' : `
-        <div class="col-sm-6 col-lg-4">
-          <label class="form-label">Relay B action</label>
-          <select class="form-select" data-relay="relay_b"></select>
-        </div>`}
-      </div>
-      ${keypadNote}
-      <div class="form-check mt-3">
-        <input class="form-check-input" type="checkbox" data-exit-toggle ${device.exit_device ? 'checked' : ''}>
-        <label class="form-check-label">Treat as exit device (bypass user schedules)</label>
-      </div>
-      <div class="small muted mt-2" data-device-status=""></div>
-    `;
-    container.appendChild(card);
-    applyDeviceValues(card, device);
-    setDeviceStatus(device.entry_id, '');
-  });
-  updateRelaySummary();
-}
-
-async function handleRelaySelectChange(select){
-  const card = select.closest('[data-device]');
-  if (!card) return;
-  const entryId = card.getAttribute('data-device');
-  if (!entryId) return;
-  const selects = Array.from(card.querySelectorAll('select[data-relay]'));
-  const payload = {};
-  selects.forEach(sel => {
-    const key = sel.getAttribute('data-relay');
-    if (key) payload[key] = sel.value;
-  });
-  setDeviceStatus(entryId, 'Saving…');
-  selects.forEach(sel => { sel.disabled = true; sel.classList.add('disabled'); });
-  try {
-    const res = await apiPost(API_ACTION, { action: 'set_device_relays', entry_id: entryId, payload });
-    const device = deviceById(entryId);
-    if (device){
-      if (res && res.relay_roles){
-        device.relay_roles = { ...res.relay_roles };
-      } else {
-        device.relay_roles = device.relay_roles || {};
-        Object.entries(payload).forEach(([key, value]) => {
-          device.relay_roles[key] = relayValueNormalized(value, device.relay_roles[key]);
-        });
-      }
-      if (res && 'alarm_capable' in res){
-        device.alarm_capable = !!res.alarm_capable;
-      } else {
-        const roles = device.relay_roles || {};
-        device.alarm_capable = ['alarm', 'door_alarm'].includes(relayValueNormalized(roles.relay_a, 'door'))
-          || ['alarm', 'door_alarm'].includes(relayValueNormalized(roles.relay_b, 'none'));
-      }
-    }
-    if (res && 'device_alarm_any' in res){
-      SETTINGS_DATA.capabilities = SETTINGS_DATA.capabilities || {};
-      SETTINGS_DATA.capabilities.alarm_relay = !!res.device_alarm_any;
-    }
-    setDeviceStatus(entryId, 'Saved ✓', 'success');
-  } catch (err) {
-    if (handleAuthError(err)) return;
-    setDeviceStatus(entryId, 'Save failed', 'error');
-    const device = deviceById(entryId);
-    if (device) applyDeviceValues(card, device);
-    alert('Failed to update relay mapping: ' + (err && err.message ? err.message : err));
-  } finally {
-    selects.forEach(sel => { sel.disabled = false; sel.classList.remove('disabled'); });
-    updateRelaySummary();
-  }
-}
-
-async function handleExitToggleChange(input){
-  const card = input.closest('[data-device]');
-  if (!card) return;
-  const entryId = card.getAttribute('data-device');
-  if (!entryId) return;
-  const checked = input.checked;
-  setDeviceStatus(entryId, 'Saving…');
-  input.disabled = true;
-  try {
-    const res = await apiPost(API_ACTION, { action: 'set_exit_device', entry_id: entryId, payload: { enabled: checked } });
-    const device = deviceById(entryId);
-    if (device) device.exit_device = res && 'exit_device' in res ? !!res.exit_device : checked;
-    setDeviceStatus(entryId, 'Saved ✓', 'success');
-  } catch (err) {
-    if (handleAuthError(err)) return;
-    setDeviceStatus(entryId, 'Save failed', 'error');
-    input.checked = !checked;
-    const device = deviceById(entryId);
-    if (device) device.exit_device = input.checked;
-    alert('Failed to update exit device setting: ' + (err && err.message ? err.message : err));
-  } finally {
-    input.disabled = false;
-  }
 }
 
 function renderIntegrity(){
@@ -1527,24 +1281,9 @@ async function loadData(){
       USERS = Array.isArray(SETTINGS_DATA.registry_users) ? SETTINGS_DATA.registry_users : [];
       ALERT_TARGETS = (SETTINGS_DATA.alerts && SETTINGS_DATA.alerts.targets) ? { ...SETTINGS_DATA.alerts.targets } : {};
       Object.keys(ALERT_TARGETS).forEach(ensureTargetDefaults);
-      const rawDevices = Array.isArray(settingsResp?.devices) ? settingsResp.devices : [];
-      DEVICES = rawDevices.map(dev => {
-        const clone = { ...dev };
-        const roles = dev && typeof dev.relay_roles === 'object' ? dev.relay_roles : {};
-        clone.relay_roles = {
-          relay_a: relayValueNormalized(roles.relay_a, 'door'),
-          relay_b: relayValueNormalized(roles.relay_b, 'none'),
-        };
-        clone.exit_device = !!dev.exit_device;
-        clone.alarm_capable = typeof dev.alarm_capable === 'boolean'
-          ? dev.alarm_capable
-          : ['alarm', 'door_alarm'].includes(clone.relay_roles.relay_a) || ['alarm', 'door_alarm'].includes(clone.relay_roles.relay_b);
-        return clone;
-      });
       SETTINGS_DATA.capabilities = settingsResp?.capabilities && typeof settingsResp.capabilities === 'object'
         ? { ...settingsResp.capabilities }
         : { alarm_relay: false };
-      renderDeviceOptions();
       const rawSchedules = settingsResp?.schedules;
     if (rawSchedules && typeof rawSchedules === 'object'){
       SCHEDULES = {};
@@ -1576,17 +1315,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('openDiagnosticsBtn')?.addEventListener('click', (e) => {
     e.preventDefault();
     openInApp('diagnostics');
-  });
-
-  const deviceOptions = document.getElementById('deviceOptions');
-  deviceOptions?.addEventListener('change', async (ev) => {
-    const target = ev.target;
-    if (!(target instanceof Element)) return;
-    if (target.matches('select[data-relay]')) {
-      await handleRelaySelectChange(target);
-    } else if (target.matches('input[data-exit-toggle]')) {
-      await handleExitToggleChange(target);
-    }
   });
 
   const autoSyncInput = document.getElementById('autoSyncDelayInput');
@@ -1729,15 +1457,6 @@ document.addEventListener('DOMContentLoaded', () => {
         <div id="integritySavedOverlay" class="saved-overlay">Saved</div>
       </div>
       <div id="integrityStatus" class="visually-hidden small mt-2"></div>
-    </div>
-  </div>
-
-  <div class="card mt-3">
-    <div class="card-header">Device Relay Mapping</div>
-    <div class="card-body">
-      <p class="muted small">Choose how each relay behaves and mark interior stations as exit devices. The Key Holder option is available when any relay is set to Alarm or Door and Alarm.</p>
-      <div id="deviceOptions"></div>
-      <div id="deviceRelaySummary" class="small muted mt-2"></div>
     </div>
   </div>
 

--- a/custom_components/AK_Access_ctrl/www/settings.html
+++ b/custom_components/AK_Access_ctrl/www/settings.html
@@ -493,25 +493,15 @@ const API_SETTINGS = signedPath('settings', '/api/akuvox_ac/ui/settings');
 const API_PHONES   = signedPath('phones', '/api/akuvox_ac/ui/phones');
 const API_ACTION   = signedPath('action', '/api/akuvox_ac/ui/action');
 
-const RELAY_ROLE_LABELS = {
-  none: 'Not used',
-  door: 'Door Relay',
-  alarm: 'Alarm Relay',
-  door_alarm: 'Door and Alarm Relay'
-};
-const RELAY_ROLE_ORDER = ['none', 'door', 'alarm', 'door_alarm'];
-
 let SETTINGS_DATA = { integrity_interval_minutes: null, auto_sync_delay_minutes: 30, alerts: { targets: {} }, registry_users: [], capabilities: { alarm_relay: false } };
 let PHONES = [];
 let USERS = [];
-let DEVICES = [];
 let ALERT_TARGETS = {};
 let alertsSaving = false;
 let integritySaving = false;
 let integritySavedTimer = null;
 let autoSyncSaving = false;
 let autoSyncSavedTimer = null;
-const DEVICE_STATUS_TIMERS = new Map();
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const SCHEDULE_DAY_ORDER = [
   { key: 'mon', label: 'Monday' },
@@ -698,242 +688,6 @@ function ensureTargetDefaults(target){
 function escapeSelector(value){
   if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
   return String(value || '').replace(/([\W])/g, '\\$1');
-}
-
-function relayValueNormalized(value, fallback = 'door'){
-  const raw = (value ?? '').toString().trim().toLowerCase();
-  if (!raw) return fallback;
-  const clean = raw.replace(/[\s-]+/g, '_');
-  if (RELAY_ROLE_ORDER.includes(clean)) return clean;
-  if (clean === 'not_used' || clean === 'unused' || clean === 'none') return 'none';
-  if (clean === 'door' || clean === 'door_relay') return 'door';
-  if (clean === 'alarm' || clean === 'alarm_relay') return 'alarm';
-  if (clean === 'door_and_alarm' || clean === 'door_alarm_relay' || clean === 'doorandalarm') return 'door_alarm';
-  return fallback;
-}
-
-function deviceById(entryId){
-  return DEVICES.find(d => d.entry_id === entryId);
-}
-
-function populateRelaySelect(select, value){
-  if (!select) return;
-  const normalized = relayValueNormalized(value, 'door');
-  select.innerHTML = '';
-  RELAY_ROLE_ORDER.forEach(role => {
-    const opt = document.createElement('option');
-    opt.value = role;
-    opt.textContent = RELAY_ROLE_LABELS[role] || role;
-    select.appendChild(opt);
-  });
-  if (RELAY_ROLE_ORDER.includes(normalized)) {
-    select.value = normalized;
-  } else {
-    select.value = 'door';
-  }
-}
-
-function applyDeviceValues(card, device){
-  if (!card || !device) return;
-  const roles = device.relay_roles && typeof device.relay_roles === 'object' ? device.relay_roles : {};
-  populateRelaySelect(card.querySelector('select[data-relay="relay_a"]'), roles.relay_a);
-  const relayB = card.querySelector('select[data-relay="relay_b"]');
-  if (relayB) populateRelaySelect(relayB, roles.relay_b);
-  const exitToggle = card.querySelector('input[data-exit-toggle]');
-  if (exitToggle) exitToggle.checked = !!device.exit_device;
-}
-
-function clearDeviceStatusTimers(){
-  DEVICE_STATUS_TIMERS.forEach(timer => clearTimeout(timer));
-  DEVICE_STATUS_TIMERS.clear();
-}
-
-function setDeviceStatus(entryId, text, tone = 'muted'){
-  const selector = `[data-device="${escapeSelector(entryId)}"] [data-device-status]`;
-  const status = document.querySelector(selector);
-  if (!status) return;
-  if (DEVICE_STATUS_TIMERS.has(entryId)){
-    clearTimeout(DEVICE_STATUS_TIMERS.get(entryId));
-    DEVICE_STATUS_TIMERS.delete(entryId);
-  }
-  if (!text){
-    status.textContent = '';
-    status.className = 'small muted mt-2';
-    return;
-  }
-  let cls = 'small mt-2';
-  if (tone === 'error') cls += ' text-danger';
-  else if (tone === 'success') cls += ' text-success';
-  else cls += ' muted';
-  status.className = cls;
-  status.textContent = text;
-  if (tone === 'success'){
-    const timer = setTimeout(() => {
-      const node = document.querySelector(selector);
-      if (node){
-        node.textContent = '';
-        node.className = 'small muted mt-2';
-      }
-      DEVICE_STATUS_TIMERS.delete(entryId);
-    }, 4000);
-    DEVICE_STATUS_TIMERS.set(entryId, timer);
-  }
-}
-
-function updateRelaySummary(){
-  const summary = document.getElementById('deviceRelaySummary');
-  if (!summary) return;
-  const anyAlarm = DEVICES.some(dev => {
-    if (typeof dev.alarm_capable === 'boolean') return dev.alarm_capable;
-    const roles = dev.relay_roles || {};
-    const aVal = relayValueNormalized(roles.relay_a, 'door');
-    const bVal = relayValueNormalized(roles.relay_b, 'none');
-    return aVal === 'alarm' || aVal === 'door_alarm' || bVal === 'alarm' || bVal === 'door_alarm';
-  });
-  SETTINGS_DATA.capabilities = SETTINGS_DATA.capabilities || {};
-  SETTINGS_DATA.capabilities.alarm_relay = anyAlarm;
-  if (!DEVICES.length){
-    summary.textContent = 'No devices have been added yet.';
-    summary.className = 'small muted mt-2';
-    return;
-  }
-  if (anyAlarm){
-    summary.textContent = 'Key Holder can be enabled for users because an alarm-capable relay is configured.';
-    summary.className = 'small text-success mt-2';
-  } else {
-    summary.textContent = 'Set a relay to Alarm or Door and Alarm to enable the Key Holder option when editing users.';
-    summary.className = 'small muted mt-2';
-  }
-}
-
-function renderDeviceOptions(){
-  const container = document.getElementById('deviceOptions');
-  if (!container) return;
-  clearDeviceStatusTimers();
-  container.innerHTML = '';
-  if (!DEVICES.length){
-    const empty = document.createElement('div');
-    empty.className = 'muted';
-    empty.textContent = 'No devices available yet.';
-    container.appendChild(empty);
-    updateRelaySummary();
-    return;
-  }
-  const sorted = [...DEVICES].sort((a,b) => (a.name || '').localeCompare(b.name || ''));
-  sorted.forEach(device => {
-    const card = document.createElement('div');
-    card.className = 'device-option';
-    card.setAttribute('data-device', device.entry_id);
-    const typeLabel = device.type || 'Device';
-    const isKeypad = String(device.type || '').toLowerCase() === 'keypad';
-    const ipHtml = device.ip ? `<span class="device-meta">IP: ${device.ip}</span>` : '';
-    const keypadNote = isKeypad ? '<div class="form-text muted mt-1">Keypads expose Relay A only.</div>' : '';
-    card.innerHTML = `
-      <div class="device-header">
-        <div>
-          <div class="fw-semibold">${device.name || 'Device'}</div>
-          <div class="device-meta">${typeLabel}</div>
-        </div>
-        ${ipHtml}
-      </div>
-      <div class="row g-3 mt-2">
-        <div class="col-sm-6 col-lg-4">
-          <label class="form-label">Relay A action</label>
-          <select class="form-select" data-relay="relay_a"></select>
-        </div>
-        ${isKeypad ? '' : `
-        <div class="col-sm-6 col-lg-4">
-          <label class="form-label">Relay B action</label>
-          <select class="form-select" data-relay="relay_b"></select>
-        </div>`}
-      </div>
-      ${keypadNote}
-      <div class="form-check mt-3">
-        <input class="form-check-input" type="checkbox" data-exit-toggle ${device.exit_device ? 'checked' : ''}>
-        <label class="form-check-label">Treat as exit device (bypass user schedules)</label>
-      </div>
-      <div class="small muted mt-2" data-device-status=""></div>
-    `;
-    container.appendChild(card);
-    applyDeviceValues(card, device);
-    setDeviceStatus(device.entry_id, '');
-  });
-  updateRelaySummary();
-}
-
-async function handleRelaySelectChange(select){
-  const card = select.closest('[data-device]');
-  if (!card) return;
-  const entryId = card.getAttribute('data-device');
-  if (!entryId) return;
-  const selects = Array.from(card.querySelectorAll('select[data-relay]'));
-  const payload = {};
-  selects.forEach(sel => {
-    const key = sel.getAttribute('data-relay');
-    if (key) payload[key] = sel.value;
-  });
-  setDeviceStatus(entryId, 'Saving…');
-  selects.forEach(sel => { sel.disabled = true; sel.classList.add('disabled'); });
-  try {
-    const res = await apiPost(API_ACTION, { action: 'set_device_relays', entry_id: entryId, payload });
-    const device = deviceById(entryId);
-    if (device){
-      if (res && res.relay_roles){
-        device.relay_roles = { ...res.relay_roles };
-      } else {
-        device.relay_roles = device.relay_roles || {};
-        Object.entries(payload).forEach(([key, value]) => {
-          device.relay_roles[key] = relayValueNormalized(value, device.relay_roles[key]);
-        });
-      }
-      if (res && 'alarm_capable' in res){
-        device.alarm_capable = !!res.alarm_capable;
-      } else {
-        const roles = device.relay_roles || {};
-        device.alarm_capable = ['alarm', 'door_alarm'].includes(relayValueNormalized(roles.relay_a, 'door'))
-          || ['alarm', 'door_alarm'].includes(relayValueNormalized(roles.relay_b, 'none'));
-      }
-    }
-    if (res && 'device_alarm_any' in res){
-      SETTINGS_DATA.capabilities = SETTINGS_DATA.capabilities || {};
-      SETTINGS_DATA.capabilities.alarm_relay = !!res.device_alarm_any;
-    }
-    setDeviceStatus(entryId, 'Saved ✓', 'success');
-  } catch (err) {
-    if (handleAuthError(err)) return;
-    setDeviceStatus(entryId, 'Save failed', 'error');
-    const device = deviceById(entryId);
-    if (device) applyDeviceValues(card, device);
-    alert('Failed to update relay mapping: ' + (err && err.message ? err.message : err));
-  } finally {
-    selects.forEach(sel => { sel.disabled = false; sel.classList.remove('disabled'); });
-    updateRelaySummary();
-  }
-}
-
-async function handleExitToggleChange(input){
-  const card = input.closest('[data-device]');
-  if (!card) return;
-  const entryId = card.getAttribute('data-device');
-  if (!entryId) return;
-  const checked = input.checked;
-  setDeviceStatus(entryId, 'Saving…');
-  input.disabled = true;
-  try {
-    const res = await apiPost(API_ACTION, { action: 'set_exit_device', entry_id: entryId, payload: { enabled: checked } });
-    const device = deviceById(entryId);
-    if (device) device.exit_device = res && 'exit_device' in res ? !!res.exit_device : checked;
-    setDeviceStatus(entryId, 'Saved ✓', 'success');
-  } catch (err) {
-    if (handleAuthError(err)) return;
-    setDeviceStatus(entryId, 'Save failed', 'error');
-    input.checked = !checked;
-    const device = deviceById(entryId);
-    if (device) device.exit_device = input.checked;
-    alert('Failed to update exit device setting: ' + (err && err.message ? err.message : err));
-  } finally {
-    input.disabled = false;
-  }
 }
 
 function renderIntegrity(){
@@ -1527,24 +1281,9 @@ async function loadData(){
       USERS = Array.isArray(SETTINGS_DATA.registry_users) ? SETTINGS_DATA.registry_users : [];
       ALERT_TARGETS = (SETTINGS_DATA.alerts && SETTINGS_DATA.alerts.targets) ? { ...SETTINGS_DATA.alerts.targets } : {};
       Object.keys(ALERT_TARGETS).forEach(ensureTargetDefaults);
-      const rawDevices = Array.isArray(settingsResp?.devices) ? settingsResp.devices : [];
-      DEVICES = rawDevices.map(dev => {
-        const clone = { ...dev };
-        const roles = dev && typeof dev.relay_roles === 'object' ? dev.relay_roles : {};
-        clone.relay_roles = {
-          relay_a: relayValueNormalized(roles.relay_a, 'door'),
-          relay_b: relayValueNormalized(roles.relay_b, 'none'),
-        };
-        clone.exit_device = !!dev.exit_device;
-        clone.alarm_capable = typeof dev.alarm_capable === 'boolean'
-          ? dev.alarm_capable
-          : ['alarm', 'door_alarm'].includes(clone.relay_roles.relay_a) || ['alarm', 'door_alarm'].includes(clone.relay_roles.relay_b);
-        return clone;
-      });
       SETTINGS_DATA.capabilities = settingsResp?.capabilities && typeof settingsResp.capabilities === 'object'
         ? { ...settingsResp.capabilities }
         : { alarm_relay: false };
-      renderDeviceOptions();
       const rawSchedules = settingsResp?.schedules;
     if (rawSchedules && typeof rawSchedules === 'object'){
       SCHEDULES = {};
@@ -1576,17 +1315,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('openDiagnosticsBtn')?.addEventListener('click', (e) => {
     e.preventDefault();
     openInApp('diagnostics');
-  });
-
-  const deviceOptions = document.getElementById('deviceOptions');
-  deviceOptions?.addEventListener('change', async (ev) => {
-    const target = ev.target;
-    if (!(target instanceof Element)) return;
-    if (target.matches('select[data-relay]')) {
-      await handleRelaySelectChange(target);
-    } else if (target.matches('input[data-exit-toggle]')) {
-      await handleExitToggleChange(target);
-    }
   });
 
   const autoSyncInput = document.getElementById('autoSyncDelayInput');
@@ -1729,15 +1457,6 @@ document.addEventListener('DOMContentLoaded', () => {
         <div id="integritySavedOverlay" class="saved-overlay">Saved</div>
       </div>
       <div id="integrityStatus" class="visually-hidden small mt-2"></div>
-    </div>
-  </div>
-
-  <div class="card mt-3">
-    <div class="card-header">Device Relay Mapping</div>
-    <div class="card-body">
-      <p class="muted small">Choose how each relay behaves and mark interior stations as exit devices. The Key Holder option is available when any relay is set to Alarm or Door and Alarm.</p>
-      <div id="deviceOptions"></div>
-      <div id="deviceRelaySummary" class="small muted mt-2"></div>
     </div>
   </div>
 

--- a/custom_components/AK_Access_ctrl/www/user_overview-mob.html
+++ b/custom_components/AK_Access_ctrl/www/user_overview-mob.html
@@ -1,0 +1,922 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Akuvox • User Overview</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  <style>
+    :root{
+      --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#9aa4b2;
+      --ok:#2ecc71; --warn:#ffc107; --bad:#ff4d4f; --dim:#6c7a92;
+    }
+    html,body{height:100%;}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
+    .page{min-height:100vh;display:flex;flex-direction:column;padding:1rem;gap:1rem;max-width:960px;margin:0 auto;}
+    header.page-header{display:flex;align-items:center;gap:0.75rem;}
+    header.page-header h1{flex:1;font-size:1.35rem;margin:0;}
+    header.page-header .btn{white-space:nowrap;}
+    .summary-grid{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
+    .summary-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.4rem;}
+    .summary-card .label{color:var(--muted);font-size:0.85rem;text-transform:uppercase;letter-spacing:0.08em;}
+    .summary-card .value{font-size:1.5rem;font-weight:600;}
+    .summary-card small{color:var(--muted);}
+    .user-list{display:flex;flex-direction:column;gap:1rem;}
+    .user-card{background:var(--card);border:1px solid var(--border);border-radius:1rem;padding:1rem;display:flex;flex-direction:column;gap:0.75rem;}
+    .user-header{display:flex;gap:0.75rem;align-items:flex-start;}
+    .user-name{font-size:1.1rem;font-weight:600;}
+    .user-id{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.85rem;color:var(--muted);}
+    .status-stack{margin-left:auto;display:flex;flex-direction:column;gap:0.35rem;align-items:flex-end;}
+    .chip{display:inline-flex;align-items:center;gap:0.35rem;background:#0f1f37;border:1px solid #243a61;border-radius:999px;padding:0.2rem 0.6rem;font-size:0.8rem;}
+    .user-groups{display:flex;flex-wrap:wrap;gap:0.35rem;}
+    .user-meta{display:flex;flex-direction:column;gap:0.35rem;color:var(--muted);font-size:0.92rem;}
+    .user-meta i{margin-right:0.4rem;color:var(--dim);}
+    .user-actions{display:flex;flex-wrap:wrap;gap:0.5rem;}
+    .badge{border-radius:0.65rem;padding:0.25rem 0.65rem;font-size:0.75rem;font-weight:600;display:inline-flex;align-items:center;gap:0.35rem;}
+    .badge .status-dot{display:inline-block;width:0.55rem;height:0.55rem;border-radius:50%;background:currentColor;}
+    .badge-in-sync{background:rgba(25,135,84,0.18);color:#5ef3a8;}
+    .badge-pending{background:rgba(255,193,7,0.18);color:#ffd86b;}
+    .badge-offline{background:rgba(220,53,69,0.18);color:#ff7a8c;}
+    .badge-inactive{background:rgba(108,117,125,0.2);color:#c2c9d1;}
+    .badge-online{background:rgba(13,202,240,0.18);color:#6be7ff;}
+    .badge-rebooting{background:rgba(111,66,193,0.18);color:#c49dff;}
+    .empty-state{background:var(--card);border:1px dashed var(--border);border-radius:0.75rem;padding:1.5rem;text-align:center;color:var(--muted);}
+    .last-updated{color:var(--muted);font-size:0.85rem;text-align:right;}
+    @media (max-width:720px){
+      .page{padding:0.75rem;}
+      header.page-header{flex-wrap:wrap;}
+      header.page-header h1{flex-basis:100%;font-size:1.25rem;}
+      header.page-header .btn{flex:1 1 calc(50% - 0.5rem);}
+      .summary-card .value{font-size:1.35rem;}
+      .status-stack{width:100%;flex-direction:row;justify-content:flex-start;gap:0.5rem;margin-left:0;}
+      .user-header{flex-direction:column;}
+    }
+  </style>
+</head>
+<body>
+<div class="page">
+  <header class="page-header">
+    <button class="btn btn-outline-light btn-sm" id="backBtn"><i class="bi bi-chevron-left"></i> Back</button>
+    <h1>User Overview</h1>
+    <button class="btn btn-outline-info btn-sm" id="refreshBtn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+  </header>
+  <section class="summary-grid" aria-label="User summary">
+    <div class="summary-card">
+      <span class="label">Users</span>
+      <span class="value" id="summaryUsers">—</span>
+      <small>Total managed profiles</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Pending sync</span>
+      <span class="value" id="summaryPending">—</span>
+      <small>Awaiting device updates</small>
+    </div>
+    <div class="summary-card">
+      <span class="label">Face profiles</span>
+      <span class="value" id="summaryFaces">—</span>
+      <small>Active facial credentials</small>
+    </div>
+  </section>
+  <div class="last-updated" id="lastUpdated"></div>
+  <section class="user-list" id="userList" aria-live="polite"></section>
+</div>
+<script>
+(function captureToken(){
+  try {
+    const params = new URLSearchParams(location.search);
+    const token = params.get('token');
+    if (token) sessionStorage.setItem('akuvox_ll_token', token);
+  } catch (err) {}
+})();
+
+function persistTokens(access, refresh) {
+  if (!access) return null;
+  const payload = { access_token: access };
+  if (refresh) payload.refresh_token = refresh;
+  try { sessionStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  try { localStorage.setItem('hassTokens', JSON.stringify(payload)); } catch (err) {}
+  return access;
+}
+
+function extractTokenFromAuth(auth) {
+  if (!auth || typeof auth !== 'object') return null;
+  const access = auth.accessToken
+    || auth.access_token
+    || auth?.token?.access_token
+    || auth?.data?.access_token
+    || null;
+  const refresh = auth.refreshToken
+    || auth.refresh_token
+    || auth?.token?.refresh_token
+    || auth?.data?.refresh_token
+    || null;
+  if (access) {
+    return persistTokens(access, refresh);
+  }
+  return null;
+}
+
+function scanTokenStorage(storage) {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem('hassTokens');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {
+        if (typeof raw === 'string' && raw.trim()) {
+          return persistTokens(raw.trim());
+        }
+      }
+    }
+    for (const key of Object.keys(storage)) {
+      if (!/auth|token|hass/i.test(key)) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        const token = extractTokenFromAuth(parsed);
+        if (token) return token;
+      } catch (err) {}
+    }
+  } catch (err) {}
+  return null;
+}
+
+function tokenFromWindow(win) {
+  if (!win) return null;
+  let token = null;
+  token = scanTokenStorage(win.sessionStorage) || scanTokenStorage(win.localStorage);
+  if (token) return token;
+  token = extractTokenFromAuth(win.hassAuth)
+    || extractTokenFromAuth(win.auth)
+    || extractTokenFromAuth(win.AK_AC_HA_AUTH)
+    || null;
+  if (token) return token;
+  try {
+    const conn = win.hassConnection;
+    if (conn && typeof conn.then === 'function') {
+      conn.then((resolved) => {
+        try {
+          extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+        } catch (err) {}
+      }).catch(() => {});
+    } else if (conn) {
+      token = extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      if (token) return token;
+    }
+  } catch (err) {}
+  return null;
+}
+
+function walkAuthWindows(start) {
+  const visited = new Set();
+  let current = start;
+  while (current && !visited.has(current)) {
+    const token = tokenFromWindow(current);
+    if (token) return token;
+    visited.add(current);
+    let next = null;
+    try { next = current.parent; } catch (err) { next = null; }
+    if (next && next !== current && !visited.has(next)) { current = next; continue; }
+    try { next = current.opener; } catch (err) { next = null; }
+    if (next && next !== current && !visited.has(next)) { current = next; continue; }
+    break;
+  }
+  return null;
+}
+
+(function bootstrapAuthWatchers() {
+  const seen = new WeakSet();
+  function attach(win) {
+    if (!win || seen.has(win)) return;
+    seen.add(win);
+    try { extractTokenFromAuth(win.hassAuth || win.auth || win.AK_AC_HA_AUTH); } catch (err) {}
+    try {
+      const conn = win.hassConnection;
+      if (conn && typeof conn.then === 'function') {
+        conn.then((resolved) => {
+          try {
+            extractTokenFromAuth(resolved?.auth || resolved?.options?.auth || resolved);
+          } catch (err) {}
+        }).catch(() => {});
+      } else if (conn) {
+        extractTokenFromAuth(conn?.auth || conn?.options?.auth || conn);
+      }
+    } catch (err) {}
+    try { if (win.parent && win.parent !== win) attach(win.parent); } catch (err) {}
+    try { if (win.opener) attach(win.opener); } catch (err) {}
+  }
+  attach(window);
+})();
+
+const AUTH_SIG_KEY = 'akuvox_auth_sig';
+
+function readAuthSigFrom(search = location.search) {
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get('authSig');
+    return value || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function rememberAuthSig(value) {
+  if (!value) return;
+  try { sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+  try { window.AK_AC_AUTH_SIG = value; } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      try { window.parent.sessionStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.localStorage.setItem(AUTH_SIG_KEY, value); } catch (err) {}
+      try { window.parent.AK_AC_AUTH_SIG = value; } catch (err) {}
+    }
+  } catch (err) {}
+}
+
+function currentAuthSig() {
+  const fromUrl = readAuthSigFrom();
+  if (fromUrl) {
+    rememberAuthSig(fromUrl);
+    return fromUrl;
+  }
+  const sources = [
+    () => { try { return sessionStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem(AUTH_SIG_KEY); } catch (err) { return null; } },
+    () => { try { return window.AK_AC_AUTH_SIG || null; } catch (err) { return null; } },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_AUTH_SIG
+            || (parent.sessionStorage && parent.sessionStorage.getItem(AUTH_SIG_KEY))
+            || (parent.localStorage && parent.localStorage.getItem(AUTH_SIG_KEY));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+  for (const getter of sources) {
+    const value = getter();
+    if (value) {
+      rememberAuthSig(value);
+      return value;
+    }
+  }
+  return '';
+}
+
+rememberAuthSig(currentAuthSig());
+
+function findHaToken() {
+  const sources = [
+    () => { try { return sessionStorage.getItem('hassTokens'); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem('hassTokens'); } catch (err) { return null; } },
+    () => { try { return sessionStorage.getItem('akuvox_ll_token'); } catch (err) { return null; } },
+    () => { try { return localStorage.getItem('akuvox_ll_token'); } catch (err) { return null; } },
+    () => { try { return window.AK_AC_HA_AUTH || null; } catch (err) { return null; } },
+    () => { try { return window.AK_AC_HA_TOKEN || null; } catch (err) { return null; } },
+    () => {
+      try {
+        if (window.parent && window.parent !== window) {
+          const parent = window.parent;
+          return parent.AK_AC_HA_AUTH
+            || parent.AK_AC_HA_TOKEN
+            || (parent.sessionStorage && parent.sessionStorage.getItem('akuvox_ll_token'))
+            || (parent.localStorage && parent.localStorage.getItem('akuvox_ll_token'));
+        }
+      } catch (err) {}
+      return null;
+    }
+  ];
+  for (const getter of sources) {
+    const raw = getter();
+    if (!raw) continue;
+    try {
+      if (typeof raw === 'string') {
+        const parsed = JSON.parse(raw);
+        const token = extractTokenFromAuth(parsed) || parsed.access_token || parsed.token;
+        if (token) return token;
+      } else if (typeof raw === 'object') {
+        const token = extractTokenFromAuth(raw);
+        if (token) return token;
+      }
+    } catch (err) {
+      if (typeof raw === 'string' && raw.trim()) return raw.trim();
+    }
+  }
+  return walkAuthWindows(window);
+}
+
+const REJECTED_TOKENS = new Set();
+
+async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
+  const originalHeaders = { ...(options.headers || {}) };
+  let bearer = allowRetry ? findHaToken() : null;
+  let usedBearer = !!bearer;
+  const headers = { ...originalHeaders };
+  if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
+  const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
+  if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
+    REJECTED_TOKENS.add(bearer);
+    const retryToken = findHaToken();
+    if (retryToken && retryToken !== bearer) {
+      return fetchWithAuth(url, { ...options, headers: originalHeaders }, { allowRetry: true });
+    }
+    return fetchWithAuth(url, { ...options, headers: originalHeaders }, { allowRetry: false });
+  }
+  return response;
+}
+
+function buildError(res, text) {
+  const message = `${res.status}: ${text || res.statusText || 'Request failed'}`;
+  const err = new Error(message);
+  err.status = res.status;
+  err.body = text;
+  return err;
+}
+
+function isAuthError(err) {
+  if (!err) return false;
+  if (err.status === 401 || err.status === 403) return true;
+  const msg = String(err.message || err || '').toLowerCase();
+  return msg.includes('401') || msg.includes('403') || msg.includes('unauthor');
+}
+
+async function apiGet(url) {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function apiPost(url, body) {
+  const res = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body || {})
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json();
+}
+
+async function callService(domain, service, data = {}) {
+  const url = `/api/services/${encodeURIComponent(domain)}/${encodeURIComponent(service)}`;
+  const res = await fetchWithAuth(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const err = buildError(res, text);
+    handleAuthError(err);
+    throw err;
+  }
+  return res.json().catch(() => ({}));
+}
+
+const SIGNED_PATHS = (function collectSignedPaths(){
+  const result = {};
+  const merge = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') return;
+    for (const [key, value] of Object.entries(candidate)) {
+      if (typeof value === 'string' && value) result[key] = value;
+    }
+  };
+  const read = (storage) => {
+    if (!storage) return;
+    try {
+      const raw = storage.getItem('akuvox_signed_paths');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        merge(parsed);
+      }
+    } catch (err) {}
+  };
+  try { merge(window.AK_AC_SIGNED_PATHS); } catch (err) {}
+  try { read(typeof sessionStorage !== 'undefined' ? sessionStorage : null); } catch (err) {}
+  try { read(typeof localStorage !== 'undefined' ? localStorage : null); } catch (err) {}
+  try {
+    if (window.parent && window.parent !== window) {
+      merge(window.parent.AK_AC_SIGNED_PATHS);
+      read(window.parent.sessionStorage);
+      read(window.parent.localStorage);
+    }
+  } catch (err) {}
+  return result;
+})();
+
+function signedPath(key, fallback){
+  if (SIGNED_PATHS && typeof SIGNED_PATHS[key] === 'string' && SIGNED_PATHS[key]) {
+    return SIGNED_PATHS[key];
+  }
+  return fallback;
+}
+
+const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
+const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
+const UI_ROOT   = '/akuvox-ac';
+
+function buildHref(slug, params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) search.set('token', token);
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
+  const query = search.toString();
+  const clean = String(slug || '').replace(/_/g, '-');
+  return `${UI_ROOT}/${clean}${query ? `?${query}` : ''}`;
+}
+
+function requestParentNav(view, params = {}, options = {}) {
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = {
+        type: 'akuvox-nav',
+        view: String(view || ''),
+        slug: String(view || ''),
+        params
+      };
+      if (options.updateHistory === false) msg.updateHistory = false;
+      if (options.replaceState) msg.replaceState = true;
+      if (options.mobileStage) msg.mobileStage = options.mobileStage;
+      if (options.preserveGroups) msg.preserveMobileGroups = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return true;
+    }
+  } catch (err) {}
+  return false;
+}
+
+function openInApp(view, params = {}, options = {}) {
+  const href = buildHref(view, params);
+  const delivered = requestParentNav(view, params, options);
+  if (!delivered) {
+    window.location.href = href;
+  }
+  return delivered;
+}
+
+function redirectToUnauthorized(params = {}) {
+  try {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (path.endsWith('/unauthorized') || path.endsWith('/unauthorized.html')) {
+      return true;
+    }
+  } catch (err) {}
+  const targetParams = params && typeof params === 'object' ? params : {};
+  let href = '/akuvox-ac/unauthorized';
+  try {
+    href = buildHref('unauthorized', targetParams);
+  } catch (err) {
+    try {
+      const search = new URLSearchParams();
+      Object.entries(targetParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') search.set(key, value);
+      });
+      const token = sessionStorage.getItem('akuvox_ll_token');
+      if (token && !search.has('token')) search.set('token', token);
+      const authSig = currentAuthSig();
+      if (authSig && !search.has('authSig')) search.set('authSig', authSig);
+      const query = search.toString();
+      if (query) href = `/akuvox-ac/unauthorized?${query}`;
+    } catch (err2) {}
+  }
+  let delivered = false;
+  try {
+    delivered = requestParentNav('unauthorized', targetParams, { replaceState: true });
+  } catch (err) {}
+  if (!delivered) {
+    try { window.location.replace(href); } catch (err) { window.location.href = href; }
+  }
+  return true;
+}
+
+function handleAuthError(err) {
+  if (!isAuthError(err)) return false;
+  redirectToUnauthorized();
+  return true;
+}
+
+function goBack(){
+  requestParentNav('index', { section: 'users' }, { replaceState: true, mobileStage: 'nav', preserveGroups: true });
+}
+
+document.getElementById('backBtn').addEventListener('click', (ev) => { ev.preventDefault(); goBack(); });
+document.getElementById('refreshBtn').addEventListener('click', (ev) => { ev.preventDefault(); refresh(); });
+
+function escapeHtml(value){
+  const lookup = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return String(value ?? '').replace(/[&<>"']/g, ch => lookup[ch] ?? ch);
+}
+
+function badge(label, type){
+  const kind = String(type || '').toLowerCase();
+  const cls = kind === 'in_sync' || kind === 'allowed' ? 'badge-in-sync'
+    : kind === 'pending' ? 'badge-pending'
+    : kind === 'denied' || kind === 'offline' ? 'badge-offline'
+    : kind === 'inactive' ? 'badge-inactive'
+    : kind === 'online' ? 'badge-online'
+    : kind === 'rebooting' ? 'badge-rebooting'
+    : 'badge-in-sync';
+  const text = escapeHtml(label ?? '—');
+  return `<span class="badge ${cls}"><span class="status-dot"></span>${text}</span>`;
+}
+
+function normalizeGroupsList(groups){
+  if (Array.isArray(groups)) {
+    return groups.length ? groups.map(g => String(g)) : ['Default'];
+  }
+  if (groups === null || groups === undefined || groups === '') {
+    return ['Default'];
+  }
+  return [String(groups)];
+}
+
+function groupsIntersect(a, b){
+  const set = new Set((b || []).map(g => String(g).toLowerCase()));
+  return (a || []).some(g => set.has(String(g).toLowerCase()));
+}
+
+function safeDeviceName(d){
+  return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
+}
+
+function idMatchesFilter(id){
+  return /^HA\d{3}$/.test(id) || /^User0000\d{2}$/.test(id);
+}
+
+const FACE_URL_FIELDS = ['face_url','faceUrl','FaceUrl','FaceURL'];
+const FACE_STATUS_FIELDS = [
+  'face_active','faceActive','FaceActive','face','Face','face_status','FaceStatus',
+  'faceEnabled','FaceEnabled','face_enable','FaceEnable','faceRecognition','FaceRecognition',
+  'has_face','hasFace','HasFace'
+];
+const FACE_STATE_FIELDS = ['face_status','faceStatus','FaceStatus'];
+
+function normalizeFaceFlag(value){
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value > 0;
+  if (typeof value === 'string'){
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const lower = trimmed.toLowerCase();
+    if (['1','true','yes','y','on','active','enabled','present','available'].includes(lower)) return true;
+    if (['0','false','no','n','off','inactive','disabled','absent','missing'].includes(lower)) return false;
+  }
+  return null;
+}
+
+function extractFaceStatus(record){
+  if (!record || typeof record !== 'object') return '';
+  for (const key of FACE_STATE_FIELDS){
+    if (!(key in record)) continue;
+    const raw = record[key];
+    if (typeof raw === 'string'){
+      const trimmed = raw.trim();
+      if (trimmed) return trimmed.toLowerCase();
+    }
+  }
+  return '';
+}
+
+function extractFaceUrl(record){
+  if (!record || typeof record !== 'object') return '';
+  for (const key of FACE_URL_FIELDS){
+    const raw = record[key];
+    if (typeof raw === 'string' && raw.trim()){
+      return raw.trim();
+    }
+  }
+  return '';
+}
+
+function computeFaceActive(record){
+  if (!record || typeof record !== 'object') return false;
+  for (const key of FACE_STATUS_FIELDS){
+    if (!(key in record)) continue;
+    const normalized = normalizeFaceFlag(record[key]);
+    if (normalized !== null) return normalized;
+  }
+  const url = extractFaceUrl(record);
+  if (url){
+    const status = String(record.status || record.Status || '').trim().toLowerCase();
+    if (status === 'pending') return false;
+    return true;
+  }
+  return false;
+}
+
+function compileUsers(devices, registryUsers){
+  const normalizedDevices = (devices || []).map(d => ({
+    entryId: String(d.entry_id || d.id || ''),
+    groups: normalizeGroupsList(d.sync_groups || []),
+    participates: d.participate_in_sync !== false,
+    online: d.online !== false,
+    syncStatus: String(d.sync_status || '').toLowerCase()
+  }));
+  const by = new Map();
+
+  (registryUsers || []).forEach(r => {
+    const key = String(r.id || r.UserID || r.ID || '');
+    if (!key) return;
+    const groups = normalizeGroupsList(r.groups || []);
+    const statusHint = extractFaceStatus(r);
+    by.set(key, {
+      id: key,
+      name: r.name || key,
+      groups,
+      access: 'Pending',
+      isCloud: false,
+      last: r.last_access || '—',
+      presentOnDevice: false,
+      fromRegistry: true,
+      status: r.status || 'active',
+      schedule_name: r.schedule_name || '24/7 Access',
+      schedule_id: r.schedule_id || '',
+      access_level: r.access_level || '',
+      key_holder: !!r.key_holder,
+      face_url: extractFaceUrl(r),
+      face_status: statusHint,
+      face_synced_at: r.face_synced_at || '',
+      face_active: typeof r.face_active === 'boolean'
+        ? r.face_active
+        : (statusHint === 'active' ? true : computeFaceActive(r)),
+      _seenOn: new Set(),
+      _denied: false
+    });
+  });
+
+  (devices || []).forEach(d => {
+    const entryId = String(d.entry_id || d.id || '');
+    const deviceGroups = normalizeGroupsList(d.sync_groups || []);
+    (d._users || d.users || []).forEach(u => {
+      const key = String(u.UserID || u.ID || u.Name || '');
+      if (!key) return;
+      const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
+      const accessAllowed = !(String(u.WebRelay) === '0' || u.AccessEnabled === false);
+      const last = u.LastAccess || u.last_access || '—';
+      const deviceFaceUrl = extractFaceUrl(u);
+      const deviceFaceActive = computeFaceActive(u);
+
+      if (!by.has(key)) {
+        by.set(key, {
+          id: key,
+          name: u.Name || key,
+          groups: normalizeGroupsList(u.Groups || u.groups || deviceGroups),
+          access: accessAllowed ? 'Allowed' : 'Denied',
+          isCloud,
+          last,
+          presentOnDevice: true,
+          fromRegistry: false,
+          status: u.Status || u.status || '',
+          schedule_name: u.ScheduleName || u.schedule_name || '24/7 Access',
+          schedule_id: u.ScheduleID || u.schedule_id || '',
+          access_level: u.AccessLevel || u.access_level || '',
+          key_holder: !!u.KeyHolder,
+          face_url: deviceFaceUrl,
+          face_status: deviceFaceActive ? 'active' : '',
+          face_active: deviceFaceActive,
+          _seenOn: new Set(entryId ? [entryId] : [])
+        });
+        return;
+      }
+
+      const cur = by.get(key);
+      cur.isCloud = cur.isCloud || isCloud;
+      cur.presentOnDevice = true;
+      if (!cur.groups || cur.groups.length === 0) {
+        cur.groups = normalizeGroupsList(u.Groups || u.groups || deviceGroups);
+      }
+      cur.last = last || cur.last;
+      if (cur.fromRegistry && cur._seenOn instanceof Set && entryId) {
+        cur._seenOn.add(entryId);
+      }
+      if (cur.fromRegistry && !accessAllowed) {
+        cur._denied = true;
+      } else if (!cur.fromRegistry) {
+        cur.access = accessAllowed ? 'Allowed' : 'Denied';
+      }
+      if (!cur.face_url && deviceFaceUrl) {
+        cur.face_url = deviceFaceUrl;
+      }
+      if (cur.fromRegistry) {
+        if (deviceFaceActive) {
+          cur._deviceFaceActive = true;
+        }
+      } else {
+        if (typeof cur.face_active !== 'boolean') {
+          cur.face_active = deviceFaceActive;
+        } else if (!cur.face_active && deviceFaceActive) {
+          cur.face_active = true;
+        }
+        const statusCurrent = String(cur.face_status || '').trim().toLowerCase();
+        if (!statusCurrent) {
+          cur.face_status = deviceFaceActive ? 'active' : '';
+        } else if (statusCurrent !== 'active' && deviceFaceActive) {
+          cur.face_status = 'active';
+        }
+      }
+      by.set(key, cur);
+    });
+  });
+
+  const list = Array.from(by.values()).map(item => {
+    if (!item.fromRegistry) {
+      return { ...item, deviceSummary: { required: 0, ready: 0, pending: 0, verified: item.presentOnDevice, seen: item._seenOn?.size || 0 } };
+    }
+    const seenIds = Array.from(item._seenOn instanceof Set ? item._seenOn : []);
+    const shouldHost = normalizedDevices.filter(dev =>
+      dev.participates &&
+      dev.online &&
+      groupsIntersect(item.groups, dev.groups)
+    );
+    const requiredIds = shouldHost.map(dev => dev.entryId).filter(id => !!id);
+    const pendingDevices = shouldHost.filter(dev => dev.syncStatus !== 'in_sync');
+    const readyDevices = shouldHost.filter(dev => dev.syncStatus === 'in_sync');
+    const allVerified = readyDevices.length
+      ? readyDevices.every(dev => seenIds.includes(dev.entryId))
+      : !requiredIds.length;
+    const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
+    const baseLower = String(baseLabel).toLowerCase();
+    let accessText;
+    if (item._denied && baseLower !== 'no access') {
+      accessText = 'Denied';
+    } else if (String(item.status || '').toLowerCase() === 'pending') {
+      accessText = 'Pending';
+    } else if (pendingDevices.length) {
+      accessText = 'Pending';
+    } else if (!requiredIds.length || allVerified) {
+      accessText = baseLabel;
+    } else {
+      accessText = 'Pending';
+    }
+    const { _seenOn, _denied, _deviceFaceActive, ...rest } = item;
+    const statusLower = String(rest.face_status || '').trim().toLowerCase();
+    let faceStatusFinal = statusLower;
+    let faceActiveFinal;
+
+    if (faceStatusFinal === 'active') {
+      faceActiveFinal = true;
+    } else if (faceStatusFinal === 'pending') {
+      faceActiveFinal = false;
+    } else {
+      if (typeof rest.face_active === 'boolean') {
+        faceActiveFinal = rest.face_active;
+      } else if (_deviceFaceActive) {
+        faceActiveFinal = true;
+      } else {
+        faceActiveFinal = computeFaceActive(rest);
+      }
+      faceStatusFinal = faceActiveFinal ? 'active' : '';
+    }
+
+    return {
+      ...rest,
+      access: accessText,
+      presentOnDevice: item.presentOnDevice || (readyDevices.length > 0 && allVerified),
+      face_active: !!faceActiveFinal,
+      face_status: faceStatusFinal,
+      deviceSummary: {
+        required: requiredIds.length,
+        ready: readyDevices.length,
+        pending: pendingDevices.length,
+        verified: allVerified,
+        seen: seenIds.length
+      }
+    };
+  });
+
+  return list
+    .filter(u => u.isCloud || idMatchesFilter(u.id))
+    .sort((a,b) => String(a.name||'').localeCompare(String(b.name||''), undefined, { sensitivity: 'base' }));
+}
+
+function renderSummary(kpis, users){
+  const total = Number(kpis?.users ?? users.length ?? 0);
+  const pending = Number(kpis?.pending ?? 0);
+  const faces = users.reduce((acc, u) => acc + (u.face_active ? 1 : 0), 0);
+  document.getElementById('summaryUsers').textContent = Number.isFinite(total) ? String(total) : '—';
+  document.getElementById('summaryPending').textContent = Number.isFinite(pending) ? String(pending) : '—';
+  document.getElementById('summaryFaces').textContent = String(faces);
+}
+
+function renderUsers(list){
+  const host = document.getElementById('userList');
+  host.innerHTML = '';
+  if (!list.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<i class="bi bi-people"></i> <div class="mt-2">No users to display.</div>';
+    host.appendChild(empty);
+    return;
+  }
+  list.forEach(u => {
+    const card = document.createElement('article');
+    card.className = 'user-card';
+    const accessLower = String(u.access || '').toLowerCase();
+    let accessBadge;
+    if (!u.access || accessLower === 'pending') accessBadge = badge('Pending', 'pending');
+    else if (accessLower === 'denied') accessBadge = badge('Denied', 'offline');
+    else accessBadge = badge(u.access, 'in_sync');
+
+    const faceStatusLower = String(u.face_status || '').toLowerCase();
+    let faceBadge;
+    if (faceStatusLower === 'active' || (faceStatusLower === '' && u.face_active)) {
+      faceBadge = badge('Face active', 'in_sync');
+    } else if (faceStatusLower === 'pending') {
+      faceBadge = badge('Face pending', 'pending');
+    } else {
+      faceBadge = badge('Face inactive', 'inactive');
+    }
+
+    const chips = (u.groups || []).map(g => `<span class="chip">${escapeHtml(g)}</span>`).join(' ');
+    const schedule = escapeHtml(u.schedule_name || u.access_level || '—');
+    const coverage = u.deviceSummary || { required: 0, ready: 0, pending: 0, verified: false };
+    let coverageText;
+    if (!coverage.required) {
+      coverageText = u.presentOnDevice ? 'Synced to assigned devices' : 'No active device assignments';
+    } else {
+      const base = `${coverage.ready}/${coverage.required} devices ready`;
+      coverageText = coverage.pending ? `${base} • ${coverage.pending} pending` : base;
+    }
+    const seenNote = coverage.required && coverage.seen
+      ? `Seen on ${coverage.seen} device${coverage.seen === 1 ? '' : 's'}`
+      : '';
+
+    const actions = (!u.isCloud && idMatchesFilter(u.id))
+      ? `<button class="btn btn-sm btn-outline-light" data-edit-user="${escapeHtml(u.id)}"><i class="bi bi-pencil"></i> Manage</button>`
+      : '';
+
+    card.innerHTML = `
+      <div class="user-header">
+        <div>
+          <div class="user-name">${escapeHtml(u.name)}</div>
+          <div class="user-id">${escapeHtml(u.id)}</div>
+        </div>
+        <div class="status-stack">
+          ${accessBadge}
+          ${faceBadge}
+        </div>
+      </div>
+      <div class="user-groups">${chips || '<span class="text-muted">No groups</span>'}</div>
+      <div class="user-meta">
+        <div><i class="bi bi-clock-history"></i>Last access: ${escapeHtml(u.last || '—')}</div>
+        <div><i class="bi bi-calendar2-week"></i>Schedule: ${schedule}</div>
+        <div><i class="bi bi-hdd-network"></i>${escapeHtml(coverageText)}${seenNote ? ` • ${escapeHtml(seenNote)}` : ''}</div>
+      </div>
+      ${actions ? `<div class="user-actions">${actions}</div>` : ''}
+    `;
+    host.appendChild(card);
+  });
+
+  host.querySelectorAll('[data-edit-user]').forEach(btn => {
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const id = btn.dataset.editUser || '';
+      openInApp('users', id ? { id } : {});
+    });
+  });
+}
+
+async function refresh(){
+  try {
+    document.getElementById('refreshBtn').setAttribute('disabled', 'disabled');
+    const state = await apiGet(stateUrl);
+    const devices = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
+    const list = compileUsers(devices, state.registry_users || []);
+    renderSummary(state.kpis || {}, list);
+    renderUsers(list);
+    const ts = new Date();
+    document.getElementById('lastUpdated').textContent = `Updated ${ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  } catch (err) {
+    console.error('Failed to load users', err);
+    if (handleAuthError(err)) return;
+    const host = document.getElementById('userList');
+    host.innerHTML = `<div class="empty-state text-danger">Failed to load users: ${escapeHtml(err.message || err)}</div>`;
+  } finally {
+    document.getElementById('refreshBtn').removeAttribute('disabled');
+  }
+}
+
+refresh();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a faceIntegration helper on the Akuvox API client so the integration can mirror the device web UI when uploading templates
- base64 encode uploaded images, merge them with profile metadata, and push them to each configured device as soon as the UI upload completes
- keep the existing face URL bookkeeping and sync queue triggers while tolerating failures per device

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68d1347a257c832caa1e8a3952d5e5c9