### PR TITLE
Add user access window controls and expiration handling

### DIFF
--- a/custom_components/AK_Access_ctrl/services.yaml
+++ b/custom_components/AK_Access_ctrl/services.yaml
@@ -11,6 +11,14 @@ add_user:
       example: ["Front Gate", "Back Gate"]
       selector:
         object:
+    access_start:
+      required: false
+      selector:
+        date:
+    access_end:
+      required: false
+      selector:
+        date:
     relays:
       required: false
       example: "3"
@@ -56,6 +64,14 @@ edit_user:
       selector:
         select:
           options: ["0","1","2","3"]
+    access_start:
+      required: false
+      selector:
+        date:
+    access_end:
+      required: false
+      selector:
+        date:
     face_image_path:
       required: false
       selector:

--- a/custom_components/AK_Access_ctrl/www/index-mob.html
+++ b/custom_components/AK_Access_ctrl/www/index-mob.html
@@ -544,9 +544,43 @@ const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
 const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
 const $ = (sel) => document.querySelector(sel);
 
+function parseIsoDate(value){
+  const text = String(value || '').trim();
+  if (!text) return null;
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(text);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(candidate.getTime())
+    || candidate.getFullYear() !== year
+    || candidate.getMonth() !== month - 1
+    || candidate.getDate() !== day
+  ){
+    return null;
+  }
+  return candidate;
+}
+
+function computeAccessState(startStr, endStr){
+  const startDate = parseIsoDate(startStr);
+  const endDate = parseIsoDate(endStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    startDate,
+    endDate,
+    expired: !!(endDate && endDate <= today),
+    notStarted: !!(startDate && startDate > today)
+  };
+}
+
 function badge(text, kind, attrs = ''){
   const normalized = String(kind || '').toLowerCase();
   const k = normalized === 'online' ? 'badge-online'
+          : normalized === 'expired' ? 'badge-offline'
           : normalized === 'offline' ? 'badge-offline'
           : normalized === 'rebooting' ? 'badge-rebooting'
           : normalized === 'in_sync' ? 'badge-in-sync'
@@ -865,6 +899,10 @@ function renderUsers(devs, registryUsers){
       schedule_id: r.schedule_id || '',
       access_level: r.access_level || '',
       key_holder: !!r.key_holder,
+      access_start: r.access_start || '',
+      access_end: r.access_end || '',
+      access_expired: !!r.access_expired,
+      access_in_future: !!r.access_in_future,
       face_url: extractFaceUrl(r),
       face_status: statusHint,
       face_synced_at: r.face_synced_at || '',
@@ -960,10 +998,15 @@ function renderUsers(devs, registryUsers){
     const allVerified = readyDevices.length
       ? readyDevices.every(dev => seenIds.includes(dev.entryId))
       : !requiredIds.length;
+    const accessState = computeAccessState(item.access_start, item.access_end);
+    const expired = item.access_expired || accessState.expired;
+    const notStarted = item.access_in_future || accessState.notStarted;
     const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
     const baseLower = String(baseLabel).toLowerCase();
     let accessText;
-    if (item._denied && baseLower !== 'no access') {
+    if (expired) {
+      accessText = 'Expired';
+    } else if (item._denied && baseLower !== 'no access') {
       accessText = 'Denied';
     } else if (String(item.status || '').toLowerCase() === 'pending') {
       accessText = 'Pending';
@@ -996,6 +1039,8 @@ function renderUsers(devs, registryUsers){
     return {
       ...rest,
       access: accessText,
+      access_expired: expired,
+      access_in_future: notStarted,
       presentOnDevice: item.presentOnDevice || (readyDevices.length > 0 && allVerified),
       face_active: !!faceActiveFinal,
       face_status: faceStatusFinal
@@ -1019,6 +1064,7 @@ function renderUsers(devs, registryUsers){
     let accessBadge = '';
     if (!accessStr || accessLower === 'pending') accessBadge = badge('Pending', 'pending');
     else if (accessLower === 'denied') accessBadge = badge('Denied', 'offline');
+    else if (accessLower === 'expired') accessBadge = badge('Expired', 'expired');
     else accessBadge = badge(accessStr, 'in_sync');
     const faceStatusLower = String(u.face_status || '').toLowerCase();
     let faceBadge;

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -569,9 +569,43 @@ const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
 const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
 const $ = (sel) => document.querySelector(sel);
 
+function parseIsoDate(value){
+  const text = String(value || '').trim();
+  if (!text) return null;
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(text);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(candidate.getTime())
+    || candidate.getFullYear() !== year
+    || candidate.getMonth() !== month - 1
+    || candidate.getDate() !== day
+  ){
+    return null;
+  }
+  return candidate;
+}
+
+function computeAccessState(startStr, endStr){
+  const startDate = parseIsoDate(startStr);
+  const endDate = parseIsoDate(endStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    startDate,
+    endDate,
+    expired: !!(endDate && endDate <= today),
+    notStarted: !!(startDate && startDate > today)
+  };
+}
+
 function badge(text, kind, attrs = ''){
   const normalized = String(kind || '').toLowerCase();
   const k = normalized === 'online' ? 'badge-online'
+          : normalized === 'expired' ? 'badge-offline'
           : normalized === 'offline' ? 'badge-offline'
           : normalized === 'rebooting' ? 'badge-rebooting'
           : normalized === 'in_sync' ? 'badge-in-sync'
@@ -956,6 +990,10 @@ function renderUsers(devs, registryUsers){
       schedule_id: r.schedule_id || '',
       access_level: r.access_level || '',
       key_holder: !!r.key_holder,
+      access_start: r.access_start || '',
+      access_end: r.access_end || '',
+      access_expired: !!r.access_expired,
+      access_in_future: !!r.access_in_future,
       face_url: extractFaceUrl(r),
       face_status: statusHint,
       face_synced_at: r.face_synced_at || '',
@@ -1060,10 +1098,15 @@ function renderUsers(devs, registryUsers){
     const allVerified = readyDevices.length
       ? readyDevices.every(dev => seenIds.includes(dev.entryId))
       : !requiredIds.length;
+    const accessState = computeAccessState(item.access_start, item.access_end);
+    const expired = item.access_expired || accessState.expired;
+    const notStarted = item.access_in_future || accessState.notStarted;
     const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
     const baseLower = String(baseLabel).toLowerCase();
     let accessText;
-    if (item._denied && baseLower !== 'no access') {
+    if (expired) {
+      accessText = 'Expired';
+    } else if (item._denied && baseLower !== 'no access') {
       accessText = 'Denied';
     } else if (String(item.status || '').toLowerCase() === 'pending') {
       accessText = 'Pending';
@@ -1097,6 +1140,8 @@ function renderUsers(devs, registryUsers){
     return {
       ...rest,
       access: accessText,
+      access_expired: expired,
+      access_in_future: notStarted,
       presentOnDevice: item.presentOnDevice || (readyDevices.length > 0 && allVerified),
       face_active: !!faceActiveFinal,
       face_status: faceStatusFinal
@@ -1114,6 +1159,7 @@ function renderUsers(devs, registryUsers){
     let accessBadge = '';
     if (!accessStr || accessLower === 'pending') accessBadge = badge('Pending', 'pending');
     else if (accessLower === 'denied') accessBadge = badge('Denied', 'offline');
+    else if (accessLower === 'expired') accessBadge = badge('Expired', 'expired');
     else accessBadge = badge(accessStr, 'in_sync');
     const faceStatusLower = String(u.face_status || '').toLowerCase();
     let faceBadge;

--- a/custom_components/AK_Access_ctrl/www/user_overview-mob.html
+++ b/custom_components/AK_Access_ctrl/www/user_overview-mob.html
@@ -521,10 +521,44 @@ function escapeHtml(value){
   return String(value ?? '').replace(/[&<>"']/g, ch => lookup[ch] ?? ch);
 }
 
+function parseIsoDate(value){
+  const text = String(value || '').trim();
+  if (!text) return null;
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(text);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(candidate.getTime())
+    || candidate.getFullYear() !== year
+    || candidate.getMonth() !== month - 1
+    || candidate.getDate() !== day
+  ){
+    return null;
+  }
+  return candidate;
+}
+
+function computeAccessState(startStr, endStr){
+  const startDate = parseIsoDate(startStr);
+  const endDate = parseIsoDate(endStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    startDate,
+    endDate,
+    expired: !!(endDate && endDate <= today),
+    notStarted: !!(startDate && startDate > today)
+  };
+}
+
 function badge(label, type){
   const kind = String(type || '').toLowerCase();
   const cls = kind === 'in_sync' || kind === 'allowed' ? 'badge-in-sync'
     : kind === 'pending' ? 'badge-pending'
+    : kind === 'expired' ? 'badge-offline'
     : kind === 'denied' || kind === 'offline' ? 'badge-offline'
     : kind === 'inactive' ? 'badge-inactive'
     : kind === 'online' ? 'badge-online'
@@ -647,6 +681,10 @@ function compileUsers(devices, registryUsers){
       schedule_id: r.schedule_id || '',
       access_level: r.access_level || '',
       key_holder: !!r.key_holder,
+      access_start: r.access_start || '',
+      access_end: r.access_end || '',
+      access_expired: !!r.access_expired,
+      access_in_future: !!r.access_in_future,
       face_url: extractFaceUrl(r),
       face_status: statusHint,
       face_synced_at: r.face_synced_at || '',
@@ -748,10 +786,15 @@ function compileUsers(devices, registryUsers){
     const allVerified = readyDevices.length
       ? readyDevices.every(dev => seenIds.includes(dev.entryId))
       : !requiredIds.length;
+    const accessState = computeAccessState(item.access_start, item.access_end);
+    const expired = item.access_expired || accessState.expired;
+    const notStarted = item.access_in_future || accessState.notStarted;
     const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
     const baseLower = String(baseLabel).toLowerCase();
     let accessText;
-    if (item._denied && baseLower !== 'no access') {
+    if (expired) {
+      accessText = 'Expired';
+    } else if (item._denied && baseLower !== 'no access') {
       accessText = 'Denied';
     } else if (String(item.status || '').toLowerCase() === 'pending') {
       accessText = 'Pending';
@@ -785,6 +828,8 @@ function compileUsers(devices, registryUsers){
     return {
       ...rest,
       access: accessText,
+      access_expired: expired,
+      access_in_future: notStarted,
       presentOnDevice: item.presentOnDevice || (readyDevices.length > 0 && allVerified),
       face_active: !!faceActiveFinal,
       face_status: faceStatusFinal,
@@ -829,6 +874,7 @@ function renderUsers(list){
     let accessBadge;
     if (!u.access || accessLower === 'pending') accessBadge = badge('Pending', 'pending');
     else if (accessLower === 'denied') accessBadge = badge('Denied', 'offline');
+    else if (accessLower === 'expired') accessBadge = badge('Expired', 'expired');
     else accessBadge = badge(u.access, 'in_sync');
 
     const faceStatusLower = String(u.face_status || '').toLowerCase();

--- a/custom_components/AK_Access_ctrl/www/users-mob.html
+++ b/custom_components/AK_Access_ctrl/www/users-mob.html
@@ -738,6 +738,46 @@ function selectExistingUser(id, options = {}){
 // ---------- schedule id mapping helpers ----------
 let SCHED_MAP = []; // [{id:"1001", name:"24/7 Access", label:"24/7 Access"}, ...]
 
+function todayIso(){
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+function parseIsoDate(value){
+  const text = String(value || '').trim();
+  if (!text) return null;
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(text);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(candidate.getTime())
+    || candidate.getFullYear() !== year
+    || candidate.getMonth() !== month - 1
+    || candidate.getDate() !== day
+  ){
+    return null;
+  }
+  return candidate;
+}
+
+function computeAccessState(startStr, endStr){
+  const startDate = parseIsoDate(startStr);
+  const endDate = parseIsoDate(endStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    startDate,
+    endDate,
+    expired: !!(endDate && endDate <= today),
+    notStarted: !!(startDate && startDate > today)
+  };
+}
+
 function blankProfile(id = ''){
   return {
     id,
@@ -748,7 +788,11 @@ function blankProfile(id = ''){
     schedule_name: '24/7 Access',
     schedule_id: '1001',
     key_holder: false,
-    access_level: ''
+    access_level: '',
+    access_start: todayIso(),
+    access_end: '',
+    access_expired: false,
+    access_in_future: false,
   };
 }
 
@@ -944,6 +988,38 @@ function fillForm(){
   CURRENT.schedule_id = selectedId;
   CURRENT.schedule_name = nameForId(selectedId);
 
+  const startInput = document.getElementById('access_start');
+  if (startInput){
+    const normalizedStart = (CURRENT.access_start && String(CURRENT.access_start).trim())
+      ? String(CURRENT.access_start).trim()
+      : todayIso();
+    startInput.value = normalizedStart;
+    CURRENT.access_start = normalizedStart;
+    if (!startInput._expiryBound){
+      const handler = () => updateAccessExpirationUI();
+      startInput.addEventListener('change', handler);
+      startInput.addEventListener('input', handler);
+      startInput._expiryBound = true;
+    }
+  }
+
+  const endInput = document.getElementById('access_end');
+  if (endInput){
+    const normalizedEnd = (CURRENT.access_end && String(CURRENT.access_end).trim())
+      ? String(CURRENT.access_end).trim()
+      : '';
+    endInput.value = normalizedEnd;
+    CURRENT.access_end = normalizedEnd;
+    if (!endInput._expiryBound){
+      const handler = () => updateAccessExpirationUI();
+      endInput.addEventListener('change', handler);
+      endInput.addEventListener('input', handler);
+      endInput._expiryBound = true;
+    }
+  }
+
+  updateAccessExpirationUI();
+
   const keyInput = document.getElementById('key_holder');
   if (keyInput){
     keyInput.checked = ANY_ALARM_CAPABLE && !!CURRENT.key_holder;
@@ -957,6 +1033,74 @@ function fillForm(){
     } else {
       localHelp.innerHTML = `<span class="muted">ID reserve failed. You can still press <b>Save</b> to create a user, then return to upload a face.</span>`;
     }
+  }
+}
+
+function updateAccessExpirationUI(){
+  const startInput = document.getElementById('access_start');
+  const endInput = document.getElementById('access_end');
+  const notice = document.getElementById('accessExpiryNotice');
+  const reactivateRow = document.getElementById('accessReactivateRow');
+  if (!startInput || !endInput) return;
+
+  const startVal = String(startInput.value || '').trim();
+  const endVal = String(endInput.value || '').trim();
+  const state = computeAccessState(startVal, endVal);
+
+  if (CURRENT){
+    CURRENT.access_start = startVal || '';
+    CURRENT.access_end = endVal || '';
+    CURRENT.access_expired = !!state.expired;
+    CURRENT.access_in_future = !!state.notStarted;
+  }
+
+  if (state.expired){
+    if (notice){
+      const label = state.endDate ? state.endDate.toISOString().slice(0, 10) : '';
+      notice.textContent = label ? `Access expired on ${label}.` : 'Access expired.';
+      notice.className = 'mb-2 fw-semibold text-danger';
+      notice.style.display = '';
+    }
+    if (reactivateRow){
+      reactivateRow.style.display = 'flex';
+    }
+    return;
+  }
+
+  if (state.notStarted){
+    if (notice){
+      const label = state.startDate ? state.startDate.toISOString().slice(0, 10) : '';
+      notice.textContent = label ? `Access starts on ${label}.` : 'Access not yet active.';
+      notice.className = 'mb-2 fw-semibold text-warning';
+      notice.style.display = '';
+    }
+    if (reactivateRow){
+      reactivateRow.style.display = 'none';
+    }
+    return;
+  }
+
+  if (notice){
+    notice.style.display = 'none';
+  }
+  if (reactivateRow){
+    reactivateRow.style.display = 'none';
+  }
+}
+
+function reactivateAccess(evt){
+  if (evt) evt.preventDefault();
+  const startInput = document.getElementById('access_start');
+  const endInput = document.getElementById('access_end');
+  if (startInput){
+    startInput.value = todayIso();
+  }
+  if (endInput){
+    endInput.value = '';
+  }
+  updateAccessExpirationUI();
+  if (startInput){
+    startInput.focus();
   }
 }
 
@@ -1026,6 +1170,15 @@ async function save(){
       schedule_name: selectedScheduleName,      // for UI/state clarity
       key_holder: ANY_ALARM_CAPABLE ? document.getElementById('key_holder').checked : false,
     };
+
+    const accessStartInput = document.getElementById('access_start');
+    const accessEndInput = document.getElementById('access_end');
+    const accessStartVal = accessStartInput ? accessStartInput.value.trim() : '';
+    const accessEndVal = accessEndInput ? accessEndInput.value.trim() : '';
+    payload.access_start = accessStartVal || '';
+    payload.access_end = accessEndVal || '';
+    CURRENT.access_start = payload.access_start;
+    CURRENT.access_end = payload.access_end;
 
     // Save/update the profile against the reserved ID
     const saveRes = await fetchWithAuth(API_EDIT_USER, {
@@ -1165,6 +1318,24 @@ function showPanel(which){
       <label class="form-label">Access Schedule</label>
       <select id="schedule" class="form-select"></select>
       <div class="form-text muted">Need a new schedule? Open <b>Global Settings → Access Schedules</b> to build one, then come back and select it here.</div>
+    </div>
+
+    <div class="mb-3">
+      <div id="accessReactivateRow" class="mb-2" style="display:none;">
+        <button type="button" class="btn btn-outline-success btn-sm" onclick="reactivateAccess(event)"><i class="bi bi-arrow-counterclockwise me-1"></i>Reactivate access</button>
+      </div>
+      <div id="accessExpiryNotice" class="mb-2 fw-semibold text-danger" style="display:none;"></div>
+      <div class="row g-2">
+        <div class="col-md-6">
+          <label class="form-label">Access Start</label>
+          <input id="access_start" type="date" class="form-control" />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Access End</label>
+          <input id="access_end" type="date" class="form-control" />
+        </div>
+      </div>
+      <div class="form-text muted mt-2">The start date defaults to today. Leave the end date empty to keep the user active indefinitely.</div>
     </div>
 
     <div class="form-check mb-3" id="keyHolderRow">

--- a/custom_components/AK_Access_ctrl/www/users.html
+++ b/custom_components/AK_Access_ctrl/www/users.html
@@ -738,6 +738,46 @@ function selectExistingUser(id, options = {}){
 // ---------- schedule id mapping helpers ----------
 let SCHED_MAP = []; // [{id:"1001", name:"24/7 Access", label:"24/7 Access"}, ...]
 
+function todayIso(){
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+function parseIsoDate(value){
+  const text = String(value || '').trim();
+  if (!text) return null;
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(text);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(candidate.getTime())
+    || candidate.getFullYear() !== year
+    || candidate.getMonth() !== month - 1
+    || candidate.getDate() !== day
+  ){
+    return null;
+  }
+  return candidate;
+}
+
+function computeAccessState(startStr, endStr){
+  const startDate = parseIsoDate(startStr);
+  const endDate = parseIsoDate(endStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    startDate,
+    endDate,
+    expired: !!(endDate && endDate <= today),
+    notStarted: !!(startDate && startDate > today)
+  };
+}
+
 function blankProfile(id = ''){
   return {
     id,
@@ -748,7 +788,11 @@ function blankProfile(id = ''){
     schedule_name: '24/7 Access',
     schedule_id: '1001',
     key_holder: false,
-    access_level: ''
+    access_level: '',
+    access_start: todayIso(),
+    access_end: '',
+    access_expired: false,
+    access_in_future: false,
   };
 }
 
@@ -944,6 +988,38 @@ function fillForm(){
   CURRENT.schedule_id = selectedId;
   CURRENT.schedule_name = nameForId(selectedId);
 
+  const startInput = document.getElementById('access_start');
+  if (startInput){
+    const normalizedStart = (CURRENT.access_start && String(CURRENT.access_start).trim())
+      ? String(CURRENT.access_start).trim()
+      : todayIso();
+    startInput.value = normalizedStart;
+    CURRENT.access_start = normalizedStart;
+    if (!startInput._expiryBound){
+      const handler = () => updateAccessExpirationUI();
+      startInput.addEventListener('change', handler);
+      startInput.addEventListener('input', handler);
+      startInput._expiryBound = true;
+    }
+  }
+
+  const endInput = document.getElementById('access_end');
+  if (endInput){
+    const normalizedEnd = (CURRENT.access_end && String(CURRENT.access_end).trim())
+      ? String(CURRENT.access_end).trim()
+      : '';
+    endInput.value = normalizedEnd;
+    CURRENT.access_end = normalizedEnd;
+    if (!endInput._expiryBound){
+      const handler = () => updateAccessExpirationUI();
+      endInput.addEventListener('change', handler);
+      endInput.addEventListener('input', handler);
+      endInput._expiryBound = true;
+    }
+  }
+
+  updateAccessExpirationUI();
+
   const keyInput = document.getElementById('key_holder');
   if (keyInput){
     keyInput.checked = ANY_ALARM_CAPABLE && !!CURRENT.key_holder;
@@ -957,6 +1033,74 @@ function fillForm(){
     } else {
       localHelp.innerHTML = `<span class="muted">ID reserve failed. You can still press <b>Save</b> to create a user, then return to upload a face.</span>`;
     }
+  }
+}
+
+function updateAccessExpirationUI(){
+  const startInput = document.getElementById('access_start');
+  const endInput = document.getElementById('access_end');
+  const notice = document.getElementById('accessExpiryNotice');
+  const reactivateRow = document.getElementById('accessReactivateRow');
+  if (!startInput || !endInput) return;
+
+  const startVal = String(startInput.value || '').trim();
+  const endVal = String(endInput.value || '').trim();
+  const state = computeAccessState(startVal, endVal);
+
+  if (CURRENT){
+    CURRENT.access_start = startVal || '';
+    CURRENT.access_end = endVal || '';
+    CURRENT.access_expired = !!state.expired;
+    CURRENT.access_in_future = !!state.notStarted;
+  }
+
+  if (state.expired){
+    if (notice){
+      const label = state.endDate ? state.endDate.toISOString().slice(0, 10) : '';
+      notice.textContent = label ? `Access expired on ${label}.` : 'Access expired.';
+      notice.className = 'mb-2 fw-semibold text-danger';
+      notice.style.display = '';
+    }
+    if (reactivateRow){
+      reactivateRow.style.display = 'flex';
+    }
+    return;
+  }
+
+  if (state.notStarted){
+    if (notice){
+      const label = state.startDate ? state.startDate.toISOString().slice(0, 10) : '';
+      notice.textContent = label ? `Access starts on ${label}.` : 'Access not yet active.';
+      notice.className = 'mb-2 fw-semibold text-warning';
+      notice.style.display = '';
+    }
+    if (reactivateRow){
+      reactivateRow.style.display = 'none';
+    }
+    return;
+  }
+
+  if (notice){
+    notice.style.display = 'none';
+  }
+  if (reactivateRow){
+    reactivateRow.style.display = 'none';
+  }
+}
+
+function reactivateAccess(evt){
+  if (evt) evt.preventDefault();
+  const startInput = document.getElementById('access_start');
+  const endInput = document.getElementById('access_end');
+  if (startInput){
+    startInput.value = todayIso();
+  }
+  if (endInput){
+    endInput.value = '';
+  }
+  updateAccessExpirationUI();
+  if (startInput){
+    startInput.focus();
   }
 }
 
@@ -1026,6 +1170,15 @@ async function save(){
       schedule_name: selectedScheduleName,      // for UI/state clarity
       key_holder: ANY_ALARM_CAPABLE ? document.getElementById('key_holder').checked : false,
     };
+
+    const accessStartInput = document.getElementById('access_start');
+    const accessEndInput = document.getElementById('access_end');
+    const accessStartVal = accessStartInput ? accessStartInput.value.trim() : '';
+    const accessEndVal = accessEndInput ? accessEndInput.value.trim() : '';
+    payload.access_start = accessStartVal || '';
+    payload.access_end = accessEndVal || '';
+    CURRENT.access_start = payload.access_start;
+    CURRENT.access_end = payload.access_end;
 
     // Save/update the profile against the reserved ID
     const saveRes = await fetchWithAuth(API_EDIT_USER, {
@@ -1165,6 +1318,24 @@ function showPanel(which){
       <label class="form-label">Access Schedule</label>
       <select id="schedule" class="form-select"></select>
       <div class="form-text muted">Need a new schedule? Open <b>Global Settings → Access Schedules</b> to build one, then come back and select it here.</div>
+    </div>
+
+    <div class="mb-3">
+      <div id="accessReactivateRow" class="mb-2" style="display:none;">
+        <button type="button" class="btn btn-outline-success btn-sm" onclick="reactivateAccess(event)"><i class="bi bi-arrow-counterclockwise me-1"></i>Reactivate access</button>
+      </div>
+      <div id="accessExpiryNotice" class="mb-2 fw-semibold text-danger" style="display:none;"></div>
+      <div class="row g-2">
+        <div class="col-md-6">
+          <label class="form-label">Access Start</label>
+          <input id="access_start" type="date" class="form-control" />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Access End</label>
+          <input id="access_end" type="date" class="form-control" />
+        </div>
+      </div>
+      <div class="form-text muted mt-2">The start date defaults to today. Leave the end date empty to keep the user active indefinitely.</div>
     </div>
 
     <div class="form-check mb-3" id="keyHolderRow">


### PR DESCRIPTION
## Summary
- add access start/end date tracking to the user store, services, and UI state payloads
- expose access window controls in the user editor with reactivation workflow and default start date
- surface expired access badges across desktop and mobile dashboards and update service schemas for the new fields

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68d371bb02c4832cacb1dd8dfacd4c8f