### PR TITLE
Add event sync controls and sensors

### DIFF
--- a/custom_components/AK_Access_ctrl/binary_sensor.py
+++ b/custom_components/AK_Access_ctrl/binary_sensor.py
@@ -1,9 +1,105 @@
 from __future__ import annotations
 
+from typing import Any, Dict
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-# Minimal stub – no entities yet.
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
-    return
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    data = hass.data[DOMAIN][entry.entry_id]
+    coord = data["coordinator"]
+
+    entities: list[BinarySensorEntity] = [
+        AkuvoxGrantedAccessBinarySensor(coord, entry),
+        AkuvoxGrantedAccessKeyHolderBinarySensor(coord, entry),
+        AkuvoxDeniedAccessBinarySensor(coord, entry),
+    ]
+    async_add_entities(entities)
+
+
+class _Base(BinarySensorEntity):
+    _attr_should_poll = False
+
+    def __init__(self, coord, entry: ConfigEntry):
+        self._coord = coord
+        self._entry = entry
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": coord.device_name,
+            "manufacturer": "Akuvox",
+            "model": coord.health.get("device_type") or "Device",
+        }
+        coord.async_add_listener(self._coord_updated)
+
+    def _coord_updated(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        state = getattr(self._coord, "event_state", {}) or {}
+        return {
+            "last_user": state.get("last_user_name"),
+            "last_user_id": state.get("last_user_id"),
+            "last_event_type": state.get("last_event_type"),
+            "last_event_summary": state.get("last_event_summary"),
+            "last_event_timestamp": state.get("last_event_timestamp"),
+            "last_event_key_holder": state.get("last_event_key_holder"),
+        }
+
+
+class AkuvoxGrantedAccessBinarySensor(_Base):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Granted Access"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_granted_access"
+
+    @property
+    def is_on(self) -> bool:
+        state = getattr(self._coord, "event_state", {}) or {}
+        return bool(state.get("granted_active"))
+
+
+class AkuvoxGrantedAccessKeyHolderBinarySensor(_Base):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Granted Access Key Holder"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_granted_access_key_holder"
+
+    @property
+    def is_on(self) -> bool:
+        state = getattr(self._coord, "event_state", {}) or {}
+        return bool(state.get("granted_key_holder_active"))
+
+
+class AkuvoxDeniedAccessBinarySensor(_Base):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Denied Access"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_denied_access"
+
+    @property
+    def is_on(self) -> bool:
+        state = getattr(self._coord, "event_state", {}) or {}
+        return bool(state.get("denied_active"))

--- a/custom_components/AK_Access_ctrl/button.py
+++ b/custom_components/AK_Access_ctrl/button.py
@@ -1,9 +1,77 @@
 from __future__ import annotations
 
+from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-# Minimal stub – no entities yet. Keeps loader happy.
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
-    return
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    data = hass.data[DOMAIN][entry.entry_id]
+    coord = data["coordinator"]
+
+    entities: list[ButtonEntity] = [
+        AkuvoxAccessPermittedButton(coord, entry),
+        AkuvoxAccessDeniedButton(coord, entry),
+        AkuvoxCallEndButton(coord, entry),
+    ]
+    async_add_entities(entities)
+
+
+class _Base(ButtonEntity):
+    _attr_should_poll = False
+
+    def __init__(self, coord, entry: ConfigEntry):
+        self._coord = coord
+        self._entry = entry
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": coord.device_name,
+            "manufacturer": "Akuvox",
+            "model": coord.health.get("device_type") or "Device",
+        }
+
+
+class AkuvoxAccessPermittedButton(_Base):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Access Permitted"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_access_permitted"
+
+    async def async_press(self) -> None:
+        await self._coord.async_refresh_access_history()
+
+
+class AkuvoxAccessDeniedButton(_Base):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Access Denied"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_access_denied"
+
+    async def async_press(self) -> None:
+        await self._coord.async_refresh_access_history()
+
+
+class AkuvoxCallEndButton(_Base):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Call End"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_call_end"
+
+    async def async_press(self) -> None:
+        await self._coord.async_refresh_inbound_call_history()

--- a/custom_components/AK_Access_ctrl/sensor.py
+++ b/custom_components/AK_Access_ctrl/sensor.py
@@ -18,6 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         AkuvoxLastSyncSensor(coord, entry),
         AkuvoxUsersCountSensor(coord, entry),
         AkuvoxEventsCountSensor(coord, entry),
+        AkuvoxLastAccessUserSensor(coord, entry),
     ]
     async_add_entities(entities, update_before_add=True)
 
@@ -113,3 +114,29 @@ class AkuvoxEventsCountSensor(_Base, SensorEntity):
     @property
     def native_value(self):
         return len(self._coord.events or [])
+
+
+class AkuvoxLastAccessUserSensor(_Base, SensorEntity):
+    @property
+    def name(self) -> str:
+        return f"{self._coord.device_name} Last Access User"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._entry.entry_id}_last_access_user"
+
+    @property
+    def native_value(self):
+        state = getattr(self._coord, "event_state", {}) or {}
+        return state.get("last_user_name")
+
+    @property
+    def extra_state_attributes(self):
+        state = getattr(self._coord, "event_state", {}) or {}
+        return {
+            "user_id": state.get("last_user_id"),
+            "event_type": state.get("last_event_type"),
+            "event_summary": state.get("last_event_summary"),
+            "event_timestamp": state.get("last_event_timestamp"),
+            "key_holder": state.get("last_event_key_holder"),
+        }

--- a/custom_components/AK_Access_ctrl/services.yaml
+++ b/custom_components/AK_Access_ctrl/services.yaml
@@ -99,6 +99,11 @@ upload_face:
 
 refresh_events:
   name: Refresh device events
+  fields:
+    entry_id:
+      required: false
+      selector:
+        text:
 
 reboot_device:
   name: Reboot device

--- a/custom_components/AK_Access_ctrl/www/index-mob.html
+++ b/custom_components/AK_Access_ctrl/www/index-mob.html
@@ -662,6 +662,41 @@ function groupsIntersect(a, b){
   return (a || []).some(g => set.has(String(g).toLowerCase()));
 }
 
+function canonicalString(value){
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value.trim();
+  try {
+    return String(value).trim();
+  } catch (err) {
+    return '';
+  }
+}
+
+function deviceUserKey(record){
+  if (!record || typeof record !== 'object') return '';
+  const source = canonicalString(record.Source || record.source).toLowerCase();
+  const userId = canonicalString(record.UserID || record.user_id);
+  if (userId) return userId;
+
+  const contactId = canonicalString(record.ContactID || record.contact_id);
+  const phone = canonicalString(record.PhoneNum || record.phone || record.Phone);
+  const card = canonicalString(record.CardCode || record.card_code);
+  const name = canonicalString(record.Name || record.name);
+
+  if (source === 'cloud') {
+    if (contactId) return `cloud:${contactId}`;
+    if (phone) return `cloud:phone:${phone}`;
+    if (card) return `cloud:card:${card}`;
+    if (name) return `cloud:name:${name.toLowerCase()}`;
+  }
+
+  const deviceId = canonicalString(record.ID || record.id);
+  if (deviceId) return deviceId;
+  if (contactId) return contactId;
+  if (name) return name;
+  return '';
+}
+
 function safeDeviceName(d){
   // prefer the most intentional field from backend
   return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
@@ -910,7 +945,7 @@ function renderUsers(devs, registryUsers){
     const entryId = String(d.entry_id || d.id || '');
     const deviceGroups = normalizeGroupsList(d.sync_groups || []);
     (d._users || d.users || []).forEach(u => {
-      const key = String(u.UserID || u.ID || u.Name || '');
+      const key = deviceUserKey(u);
       if (!key) return;
       const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
       const accessAllowed = !(String(u.WebRelay) === '0' || u.AccessEnabled === false);
@@ -995,7 +1030,7 @@ function renderUsers(devs, registryUsers){
     const notStarted = item.access_in_future || accessState.notStarted;
     const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
     const baseLower = String(baseLabel).toLowerCase();
-    let accessText;
+    let accessText = 'Pending';
     if (expired) {
       accessText = 'Expired';
     } else if (item._denied && baseLower !== 'no access') {
@@ -1004,10 +1039,10 @@ function renderUsers(devs, registryUsers){
       accessText = 'Pending';
     } else if (pendingDevices.length) {
       accessText = 'Pending';
-    } else if (!requiredIds.length || allVerified) {
-      accessText = baseLabel;
-    } else {
-      accessText = 'Pending';
+    } else if (!requiredIds.length) {
+      accessText = baseLower === 'no access' ? 'No Access' : 'Allowed';
+    } else if (allVerified) {
+      accessText = baseLower === 'no access' ? 'No Access' : 'Allowed';
     }
     const { _seenOn, _denied, _deviceFaceActive, ...rest } = item;
     const statusLower = String(rest.face_status || '').trim().toLowerCase();

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -687,6 +687,41 @@ function groupsIntersect(a, b){
   return (a || []).some(g => set.has(String(g).toLowerCase()));
 }
 
+function canonicalString(value){
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value.trim();
+  try {
+    return String(value).trim();
+  } catch (err) {
+    return '';
+  }
+}
+
+function deviceUserKey(record){
+  if (!record || typeof record !== 'object') return '';
+  const source = canonicalString(record.Source || record.source).toLowerCase();
+  const userId = canonicalString(record.UserID || record.user_id);
+  if (userId) return userId;
+
+  const contactId = canonicalString(record.ContactID || record.contact_id);
+  const phone = canonicalString(record.PhoneNum || record.phone || record.Phone);
+  const card = canonicalString(record.CardCode || record.card_code);
+  const name = canonicalString(record.Name || record.name);
+
+  if (source === 'cloud') {
+    if (contactId) return `cloud:${contactId}`;
+    if (phone) return `cloud:phone:${phone}`;
+    if (card) return `cloud:card:${card}`;
+    if (name) return `cloud:name:${name.toLowerCase()}`;
+  }
+
+  const deviceId = canonicalString(record.ID || record.id);
+  if (deviceId) return deviceId;
+  if (contactId) return contactId;
+  if (name) return name;
+  return '';
+}
+
 function safeDeviceName(d){
   // prefer the most intentional field from backend
   return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
@@ -1001,7 +1036,7 @@ function renderUsers(devs, registryUsers){
     const entryId = String(d.entry_id || d.id || '');
     const deviceGroups = normalizeGroupsList(d.sync_groups || []);
     (d._users || d.users || []).forEach(u => {
-      const key = String(u.UserID || u.ID || u.Name || '');
+      const key = deviceUserKey(u);
       if (!key) return;
       const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
       const accessAllowed = !(String(u.WebRelay) === '0' || u.AccessEnabled === false);
@@ -1095,7 +1130,7 @@ function renderUsers(devs, registryUsers){
     const notStarted = item.access_in_future || accessState.notStarted;
     const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
     const baseLower = String(baseLabel).toLowerCase();
-    let accessText;
+    let accessText = 'Pending';
     if (expired) {
       accessText = 'Expired';
     } else if (item._denied && baseLower !== 'no access') {
@@ -1104,10 +1139,10 @@ function renderUsers(devs, registryUsers){
       accessText = 'Pending';
     } else if (pendingDevices.length) {
       accessText = 'Pending';
-    } else if (!requiredIds.length || allVerified) {
-      accessText = baseLabel;
-    } else {
-      accessText = 'Pending';
+    } else if (!requiredIds.length) {
+      accessText = baseLower === 'no access' ? 'No Access' : 'Allowed';
+    } else if (allVerified) {
+      accessText = baseLower === 'no access' ? 'No Access' : 'Allowed';
     }
     const { _seenOn, _denied, _deviceFaceActive, ...rest } = item;
     const statusLower = String(rest.face_status || '').trim().toLowerCase();

--- a/custom_components/AK_Access_ctrl/www/user_overview-mob.html
+++ b/custom_components/AK_Access_ctrl/www/user_overview-mob.html
@@ -583,6 +583,41 @@ function groupsIntersect(a, b){
   return (a || []).some(g => set.has(String(g).toLowerCase()));
 }
 
+function canonicalString(value){
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value.trim();
+  try {
+    return String(value).trim();
+  } catch (err) {
+    return '';
+  }
+}
+
+function deviceUserKey(record){
+  if (!record || typeof record !== 'object') return '';
+  const source = canonicalString(record.Source || record.source).toLowerCase();
+  const userId = canonicalString(record.UserID || record.user_id);
+  if (userId) return userId;
+
+  const contactId = canonicalString(record.ContactID || record.contact_id);
+  const phone = canonicalString(record.PhoneNum || record.phone || record.Phone);
+  const card = canonicalString(record.CardCode || record.card_code);
+  const name = canonicalString(record.Name || record.name);
+
+  if (source === 'cloud') {
+    if (contactId) return `cloud:${contactId}`;
+    if (phone) return `cloud:phone:${phone}`;
+    if (card) return `cloud:card:${card}`;
+    if (name) return `cloud:name:${name.toLowerCase()}`;
+  }
+
+  const deviceId = canonicalString(record.ID || record.id);
+  if (deviceId) return deviceId;
+  if (contactId) return contactId;
+  if (name) return name;
+  return '';
+}
+
 function safeDeviceName(d){
   return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
 }
@@ -700,7 +735,7 @@ function compileUsers(devices, registryUsers){
     const entryId = String(d.entry_id || d.id || '');
     const deviceGroups = normalizeGroupsList(d.sync_groups || []);
     (d._users || d.users || []).forEach(u => {
-      const key = String(u.UserID || u.ID || u.Name || '');
+      const key = deviceUserKey(u);
       if (!key) return;
       const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
       const accessAllowed = !(String(u.WebRelay) === '0' || u.AccessEnabled === false);
@@ -791,7 +826,7 @@ function compileUsers(devices, registryUsers){
     const notStarted = item.access_in_future || accessState.notStarted;
     const baseLabel = item.access_level || item.schedule_name || '24/7 Access';
     const baseLower = String(baseLabel).toLowerCase();
-    let accessText;
+    let accessText = 'Pending';
     if (expired) {
       accessText = 'Expired';
     } else if (item._denied && baseLower !== 'no access') {
@@ -800,10 +835,10 @@ function compileUsers(devices, registryUsers){
       accessText = 'Pending';
     } else if (pendingDevices.length) {
       accessText = 'Pending';
-    } else if (!requiredIds.length || allVerified) {
-      accessText = baseLabel;
-    } else {
-      accessText = 'Pending';
+    } else if (!requiredIds.length) {
+      accessText = baseLower === 'no access' ? 'No Access' : 'Allowed';
+    } else if (allVerified) {
+      accessText = baseLower === 'no access' ? 'No Access' : 'Allowed';
     }
     const { _seenOn, _denied, _deviceFaceActive, ...rest } = item;
     const statusLower = String(rest.face_status || '').trim().toLowerCase();


### PR DESCRIPTION
## Summary
- add Home Assistant button entities to trigger access history and inbound call refreshes
- expose binary sensors and a last-access user sensor driven from coordinator event state
- extend the coordinator and services to track access event metadata and support manual refreshes
- ensure the user dashboards keep the access column Pending until sync completes and flip to Allowed once devices verify the user

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68d4166c4d34832cb6c64b1837308c38