### PR TITLE
Handle Akuvox UserId aliases and clean duplicate detection

### DIFF
--- a/custom_components/AK_Access_ctrl/http.py
+++ b/custom_components/AK_Access_ctrl/http.py
@@ -204,6 +204,7 @@ def _build_face_upload_payload(
     payload: Dict[str, Any] = dict(base)
 
     payload["UserID"] = str(user_id)
+    payload["UserId"] = str(user_id)
     payload["Name"] = str(profile.get("name") or payload.get("Name") or user_id)
 
     groups = profile.get("groups") if isinstance(profile.get("groups"), list) else []
@@ -1589,6 +1590,7 @@ def _face_flag_from_record(record: Mapping[str, Any]) -> Optional[bool]:
 def _user_key(record: Mapping[str, Any]) -> str:
     return str(
         record.get("UserID")
+        or record.get("UserId")
         or record.get("ID")
         or record.get("Name")
         or record.get("user_id")

--- a/custom_components/AK_Access_ctrl/www/app.js
+++ b/custom_components/AK_Access_ctrl/www/app.js
@@ -157,7 +157,7 @@ async function loadUsers() {
   const cloudUsers = [];
   for (const s of states) {
     if (!s.entity_id.startsWith("sensor.akuvox_user_")) continue;
-    const id = s.attributes?.user_id || s.attributes?.UserID || s.entity_id.replace("sensor.akuvox_user_", "");
+    const id = s.attributes?.user_id || s.attributes?.UserID || s.attributes?.UserId || s.entity_id.replace("sensor.akuvox_user_", "");
     const name = s.attributes?.name || s.attributes?.Name || s.state || id;
     const source = (s.attributes?.source || "").toLowerCase();
     const groups = s.attributes?.groups || [];

--- a/custom_components/AK_Access_ctrl/www/index-mob.html
+++ b/custom_components/AK_Access_ctrl/www/index-mob.html
@@ -675,7 +675,7 @@ function canonicalString(value){
 function deviceUserKey(record){
   if (!record || typeof record !== 'object') return '';
   const source = canonicalString(record.Source || record.source).toLowerCase();
-  const userId = canonicalString(record.UserID || record.user_id);
+  const userId = canonicalString(record.UserID || record.UserId || record.user_id);
   if (userId) return userId;
 
   const contactId = canonicalString(record.ContactID || record.contact_id);
@@ -908,7 +908,7 @@ function renderUsers(devs, registryUsers){
   const by = new Map();
 
   (registryUsers || []).forEach(r => {
-    const key = String(r.id || r.UserID || r.ID || '');
+    const key = String(r.id || r.UserID || r.UserId || r.ID || '');
     if (!key) return;
     const groups = normalizeGroupsList(r.groups || []);
     const statusHint = extractFaceStatus(r);

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -727,7 +727,7 @@ function normalizeHaUserId(value){
 function deviceUserKey(record){
   if (!record || typeof record !== 'object') return '';
   const source = canonicalString(record.Source || record.source).toLowerCase();
-  const userIdRaw = canonicalString(record.UserID || record.user_id);
+  const userIdRaw = canonicalString(record.UserID || record.UserId || record.user_id);
   const normalizedUserId = normalizeHaUserId(userIdRaw);
   if (normalizedUserId) return normalizedUserId;
   if (userIdRaw) return userIdRaw;
@@ -1107,7 +1107,7 @@ function renderUsers(devs, registryUsers){
   const by = new Map();
 
   (registryUsers || []).forEach(r => {
-    const key = String(r.id || r.UserID || r.ID || '');
+    const key = String(r.id || r.UserID || r.UserId || r.ID || '');
     if (!key) return;
     const groups = normalizeGroupsList(r.groups || []);
     const statusHint = extractFaceStatus(r);

--- a/custom_components/AK_Access_ctrl/www/user_overview-mob.html
+++ b/custom_components/AK_Access_ctrl/www/user_overview-mob.html
@@ -596,7 +596,7 @@ function canonicalString(value){
 function deviceUserKey(record){
   if (!record || typeof record !== 'object') return '';
   const source = canonicalString(record.Source || record.source).toLowerCase();
-  const userId = canonicalString(record.UserID || record.user_id);
+  const userId = canonicalString(record.UserID || record.UserId || record.user_id);
   if (userId) return userId;
 
   const contactId = canonicalString(record.ContactID || record.contact_id);
@@ -698,7 +698,7 @@ function compileUsers(devices, registryUsers){
   const by = new Map();
 
   (registryUsers || []).forEach(r => {
-    const key = String(r.id || r.UserID || r.ID || '');
+    const key = String(r.id || r.UserID || r.UserId || r.ID || '');
     if (!key) return;
     const groups = normalizeGroupsList(r.groups || []);
     const statusHint = extractFaceStatus(r);

--- a/custom_components/AK_Access_ctrl/www/users-mob.html
+++ b/custom_components/AK_Access_ctrl/www/users-mob.html
@@ -713,7 +713,7 @@ function selectExistingUser(id, options = {}){
   const targetId = String(id || '').trim();
   if (!targetId) return;
   const candidates = Array.isArray(REGISTRY) ? REGISTRY : [];
-  const existing = candidates.find(u => String(u.id || u.UserID || u.ID || '').trim() === targetId);
+  const existing = candidates.find(u => String(u.id || u.UserID || u.UserId || u.ID || '').trim() === targetId);
   if (!existing) {
     alert('Unable to find that user in Home Assistant.');
     return;
@@ -939,7 +939,7 @@ async function load(){
     let handledBySelect = false;
 
     if (id) {
-      const hasMatch = (REGISTRY || []).some(u => String(u.id || u.UserID || u.ID || '') === id);
+      const hasMatch = (REGISTRY || []).some(u => String(u.id || u.UserID || u.UserId || u.ID || '') === id);
       if (hasMatch) {
         selectExistingUser(id, { updateUrl: false });
         handledBySelect = true;

--- a/custom_components/AK_Access_ctrl/www/users.html
+++ b/custom_components/AK_Access_ctrl/www/users.html
@@ -713,7 +713,7 @@ function selectExistingUser(id, options = {}){
   const targetId = String(id || '').trim();
   if (!targetId) return;
   const candidates = Array.isArray(REGISTRY) ? REGISTRY : [];
-  const existing = candidates.find(u => String(u.id || u.UserID || u.ID || '').trim() === targetId);
+  const existing = candidates.find(u => String(u.id || u.UserID || u.UserId || u.ID || '').trim() === targetId);
   if (!existing) {
     alert('Unable to find that user in Home Assistant.');
     return;
@@ -939,7 +939,7 @@ async function load(){
     let handledBySelect = false;
 
     if (id) {
-      const hasMatch = (REGISTRY || []).some(u => String(u.id || u.UserID || u.ID || '') === id);
+      const hasMatch = (REGISTRY || []).some(u => String(u.id || u.UserID || u.UserId || u.ID || '') === id);
       if (hasMatch) {
         selectExistingUser(id, { updateUrl: false });
         handledBySelect = true;


### PR DESCRIPTION
## Summary
- normalize Akuvox user identifiers so UserID/UserId variants are handled consistently when syncing, deleting, and reconciling device state
- include the UserId alias in API payloads and face operations to satisfy firmwares that emit that casing
- teach the web UI and utility scripts to recognize UserId responses to prevent duplicate rows and allow deletions to match existing entries

## Testing
- python -m compileall custom_components/AK_Access_ctrl

------
https://chatgpt.com/codex/tasks/task_e_68db0c675590832c928cc92677f5f8ca