### PR TITLE
Hide contacts when phone prompt disabled and expand mobile actions

### DIFF
--- a/custom_components/AK_Access_ctrl/www/index-mob.html
+++ b/custom_components/AK_Access_ctrl/www/index-mob.html
@@ -543,7 +543,16 @@ function signedPath(key, fallback) {
 const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
 const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
 const $ = (sel) => document.querySelector(sel);
+const DEFAULT_CREDENTIAL_PROMPTS = { code: true, token: true, anpr: false, face: true, phone: true };
+let CREDENTIAL_PROMPTS = { ...DEFAULT_CREDENTIAL_PROMPTS };
+let CONTACTS_ENABLED = true;
 let activeUserTab = 'users';
+try {
+  const tabParam = new URLSearchParams(location.search).get('tab');
+  if (typeof tabParam === 'string' && tabParam.toLowerCase() === 'contacts') {
+    activeUserTab = 'contacts';
+  }
+} catch (err) {}
 
 function parseIsoDate(value){
   const text = String(value || '').trim();
@@ -563,6 +572,19 @@ function parseIsoDate(value){
     return null;
   }
   return candidate;
+}
+
+function sanitizeCredentialPrompts(raw){
+  const base = { ...DEFAULT_CREDENTIAL_PROMPTS };
+  if (raw && typeof raw === 'object'){
+    Object.keys(DEFAULT_CREDENTIAL_PROMPTS).forEach((key) => {
+      if (typeof raw[key] === 'boolean') base[key] = raw[key];
+    });
+  }
+  if (!base.code && !base.token && !base.face && !base.anpr && !base.phone){
+    base.code = true;
+  }
+  return base;
 }
 
 function computeAccessState(startStr, endStr){
@@ -1157,6 +1179,11 @@ function renderUsers(devs, registryUsers){
 function renderContacts(registryUsers){
   const tableBody = document.getElementById('tblContacts');
   if (!tableBody) return;
+  if (!CONTACTS_ENABLED){
+    tableBody.innerHTML = '<tr><td colspan="4" class="text-muted">Contacts disabled</td></tr>';
+    setUserTab(activeUserTab);
+    return;
+  }
   const map = new Map();
   (registryUsers || []).forEach(entry => {
     if (!entry || typeof entry !== 'object') return;
@@ -1225,28 +1252,37 @@ function renderContacts(registryUsers){
 }
 
 function setUserTab(tab){
-  const normalized = tab === 'contacts' ? 'contacts' : 'users';
+  const contactsAllowed = CONTACTS_ENABLED;
+  const normalized = contactsAllowed && tab === 'contacts' ? 'contacts' : 'users';
   activeUserTab = normalized;
   document.querySelectorAll('[data-user-tab]').forEach(btn => {
     if (!btn || typeof btn.dataset.userTab !== 'string') return;
     const target = btn.dataset.userTab === 'contacts' ? 'contacts' : 'users';
+    if (target === 'contacts') {
+      btn.style.display = contactsAllowed ? '' : 'none';
+    }
     if (target === normalized) btn.classList.add('active');
     else btn.classList.remove('active');
   });
   const usersWrap = document.getElementById('usersTableWrap');
   if (usersWrap) usersWrap.style.display = normalized === 'users' ? '' : 'none';
   const contactsWrap = document.getElementById('contactsTableWrap');
-  if (contactsWrap) contactsWrap.style.display = normalized === 'contacts' ? '' : 'none';
+  if (contactsWrap) contactsWrap.style.display = contactsAllowed && normalized === 'contacts' ? '' : 'none';
   const addUserBtn = document.getElementById('btnAddUser');
   if (addUserBtn) addUserBtn.style.display = normalized === 'users' ? '' : 'none';
   const addContactBtn = document.getElementById('btnAddContact');
-  if (addContactBtn) addContactBtn.style.display = normalized === 'contacts' ? '' : 'none';
+  if (addContactBtn) addContactBtn.style.display = contactsAllowed && normalized === 'contacts' ? '' : 'none';
 }
 
 /* ===== Fetch + render ===== */
 async function refresh(){
   try{
     const state = await apiGet(stateUrl);
+    CREDENTIAL_PROMPTS = sanitizeCredentialPrompts(state?.credential_prompts);
+    CONTACTS_ENABLED = !!CREDENTIAL_PROMPTS.phone;
+    if (!CONTACTS_ENABLED && activeUserTab === 'contacts') {
+      activeUserTab = 'users';
+    }
     renderKPIs(state.kpis || {devices:0, users:0, pending:0});
     const devs = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
     renderDevices(devs);

--- a/custom_components/AK_Access_ctrl/www/index.html
+++ b/custom_components/AK_Access_ctrl/www/index.html
@@ -571,9 +571,19 @@ const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
 const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
 const $ = (sel) => document.querySelector(sel);
 
+const DEFAULT_CREDENTIAL_PROMPTS = { code: true, token: true, anpr: false, face: true, phone: true };
+let CREDENTIAL_PROMPTS = { ...DEFAULT_CREDENTIAL_PROMPTS };
+let CONTACTS_ENABLED = true;
+
 let eventFilterMode = 'all';
 let cachedEvents = [];
 let activeUserTab = 'users';
+try {
+  const tabParam = new URLSearchParams(location.search).get('tab');
+  if (typeof tabParam === 'string' && tabParam.toLowerCase() === 'contacts') {
+    activeUserTab = 'contacts';
+  }
+} catch (err) {}
 
 window.addEventListener('DOMContentLoaded', () => {
   const select = document.getElementById('eventFilter');
@@ -603,6 +613,19 @@ function parseIsoDate(value){
     return null;
   }
   return candidate;
+}
+
+function sanitizeCredentialPrompts(raw){
+  const base = { ...DEFAULT_CREDENTIAL_PROMPTS };
+  if (raw && typeof raw === 'object'){
+    Object.keys(DEFAULT_CREDENTIAL_PROMPTS).forEach((key) => {
+      if (typeof raw[key] === 'boolean') base[key] = raw[key];
+    });
+  }
+  if (!base.code && !base.token && !base.face && !base.anpr && !base.phone){
+    base.code = true;
+  }
+  return base;
 }
 
 function computeAccessState(startStr, endStr){
@@ -1397,6 +1420,11 @@ function renderUsers(devs, registryUsers){
 function renderContacts(registryUsers){
   const tableBody = document.getElementById('tblContacts');
   if (!tableBody) return;
+  if (!CONTACTS_ENABLED){
+    tableBody.innerHTML = '<tr><td colspan="4" class="text-muted">Contacts disabled</td></tr>';
+    setUserTab(activeUserTab);
+    return;
+  }
   const map = new Map();
   (registryUsers || []).forEach(entry => {
     if (!entry || typeof entry !== 'object') return;
@@ -1465,28 +1493,37 @@ function renderContacts(registryUsers){
 }
 
 function setUserTab(tab){
-  const normalized = tab === 'contacts' ? 'contacts' : 'users';
+  const contactsAllowed = CONTACTS_ENABLED;
+  const normalized = contactsAllowed && tab === 'contacts' ? 'contacts' : 'users';
   activeUserTab = normalized;
   document.querySelectorAll('[data-user-tab]').forEach(btn => {
     if (!btn || typeof btn.dataset.userTab !== 'string') return;
     const target = btn.dataset.userTab === 'contacts' ? 'contacts' : 'users';
+    if (target === 'contacts') {
+      btn.style.display = contactsAllowed ? '' : 'none';
+    }
     if (target === normalized) btn.classList.add('active');
     else btn.classList.remove('active');
   });
   const usersWrap = document.getElementById('usersTableWrap');
   if (usersWrap) usersWrap.style.display = normalized === 'users' ? '' : 'none';
   const contactsWrap = document.getElementById('contactsTableWrap');
-  if (contactsWrap) contactsWrap.style.display = normalized === 'contacts' ? '' : 'none';
+  if (contactsWrap) contactsWrap.style.display = contactsAllowed && normalized === 'contacts' ? '' : 'none';
   const addUserBtn = document.getElementById('btnAddUser');
   if (addUserBtn) addUserBtn.style.display = normalized === 'users' ? '' : 'none';
   const addContactBtn = document.getElementById('btnAddContact');
-  if (addContactBtn) addContactBtn.style.display = normalized === 'contacts' ? '' : 'none';
+  if (addContactBtn) addContactBtn.style.display = contactsAllowed && normalized === 'contacts' ? '' : 'none';
 }
 
 /* ===== Fetch + render ===== */
 async function refresh(){
   try{
     const state = await apiGet(stateUrl);
+    CREDENTIAL_PROMPTS = sanitizeCredentialPrompts(state?.credential_prompts);
+    CONTACTS_ENABLED = !!CREDENTIAL_PROMPTS.phone;
+    if (!CONTACTS_ENABLED && activeUserTab === 'contacts') {
+      activeUserTab = 'users';
+    }
     renderKPIs(state.kpis || {devices:0, users:0, pending:0});
     const devs = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
     renderDevices(devs);

--- a/custom_components/AK_Access_ctrl/www/user_overview-mob.html
+++ b/custom_components/AK_Access_ctrl/www/user_overview-mob.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Akuvox • User Overview</title>
+  <title>Akuvox • User Management</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
@@ -14,8 +14,9 @@
     html,body{height:100%;}
     body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
     .page{min-height:100vh;display:flex;flex-direction:column;padding:1rem;gap:1rem;max-width:960px;margin:0 auto;}
-    header.page-header{display:flex;align-items:center;gap:0.75rem;}
+    header.page-header{display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;}
     header.page-header h1{flex:1;font-size:1.35rem;margin:0;}
+    header.page-header .header-actions{display:flex;gap:0.5rem;flex-wrap:wrap;justify-content:flex-end;flex:1 1 auto;}
     header.page-header .btn{white-space:nowrap;}
     .summary-grid{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
     .summary-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.4rem;}
@@ -45,8 +46,8 @@
     .last-updated{color:var(--muted);font-size:0.85rem;text-align:right;}
     @media (max-width:720px){
       .page{padding:0.75rem;}
-      header.page-header{flex-wrap:wrap;}
       header.page-header h1{flex-basis:100%;font-size:1.25rem;}
+      header.page-header .header-actions{width:100%;justify-content:flex-start;}
       header.page-header .btn{flex:1 1 calc(50% - 0.5rem);}
       .summary-card .value{font-size:1.35rem;}
       .status-stack{width:100%;flex-direction:row;justify-content:flex-start;gap:0.5rem;margin-left:0;}
@@ -57,8 +58,13 @@
 <body>
 <div class="page">
   <header class="page-header">
-    <h1>User Overview</h1>
-    <button class="btn btn-outline-info btn-sm" id="refreshBtn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+    <h1>User Management</h1>
+    <div class="header-actions">
+      <button class="btn btn-outline-info btn-sm" id="refreshBtn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+      <a class="btn btn-primary btn-sm" id="btnMobileAddUser" href="#"><i class="bi bi-person-plus"></i> Add User</a>
+      <a class="btn btn-outline-light btn-sm" id="btnMobileContactManagement" href="#"><i class="bi bi-people"></i> Contact Management</a>
+      <a class="btn btn-success btn-sm" id="btnMobileNewContact" href="#"><i class="bi bi-person-lines-fill"></i> New Contact</a>
+    </div>
   </header>
   <section class="summary-grid" aria-label="User summary">
     <div class="summary-card">
@@ -428,6 +434,9 @@ function signedPath(key, fallback){
 const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
 const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
 const UI_ROOT   = '/akuvox-ac';
+const DEFAULT_CREDENTIAL_PROMPTS = { code: true, token: true, anpr: false, face: true, phone: true };
+let CREDENTIAL_PROMPTS = { ...DEFAULT_CREDENTIAL_PROMPTS };
+let CONTACTS_ENABLED = true;
 
 function buildHref(slug, params = {}) {
   const search = new URLSearchParams();
@@ -514,7 +523,48 @@ function handleAuthError(err) {
   return true;
 }
 
-document.getElementById('refreshBtn').addEventListener('click', (ev) => { ev.preventDefault(); refresh(); });
+const refreshBtn = document.getElementById('refreshBtn');
+if (refreshBtn) {
+  refreshBtn.addEventListener('click', (ev) => { ev.preventDefault(); refresh(); });
+}
+
+const mobileAddUser = document.getElementById('btnMobileAddUser');
+if (mobileAddUser) {
+  mobileAddUser.href = buildHref('users');
+  mobileAddUser.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openInApp('users');
+  });
+}
+
+const mobileContactMgmt = document.getElementById('btnMobileContactManagement');
+if (mobileContactMgmt) {
+  mobileContactMgmt.href = buildHref('index', { tab: 'contacts' });
+  mobileContactMgmt.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openInApp('index', { tab: 'contacts' });
+  });
+}
+
+const mobileNewContact = document.getElementById('btnMobileNewContact');
+if (mobileNewContact) {
+  mobileNewContact.href = buildHref('users', { mode: 'contact' });
+  mobileNewContact.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openInApp('users', { mode: 'contact' });
+  });
+}
+
+function updateContactButtons(){
+  const show = !!CONTACTS_ENABLED;
+  const controls = [mobileContactMgmt, mobileNewContact];
+  controls.forEach((btn) => {
+    if (!btn) return;
+    btn.style.display = show ? '' : 'none';
+  });
+}
+
+updateContactButtons();
 
 function escapeHtml(value){
   const lookup = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
@@ -539,6 +589,19 @@ function parseIsoDate(value){
     return null;
   }
   return candidate;
+}
+
+function sanitizeCredentialPrompts(raw){
+  const base = { ...DEFAULT_CREDENTIAL_PROMPTS };
+  if (raw && typeof raw === 'object'){
+    Object.keys(DEFAULT_CREDENTIAL_PROMPTS).forEach((key) => {
+      if (typeof raw[key] === 'boolean') base[key] = raw[key];
+    });
+  }
+  if (!base.code && !base.token && !base.face && !base.anpr && !base.phone){
+    base.code = true;
+  }
+  return base;
 }
 
 function computeAccessState(startStr, endStr){
@@ -986,6 +1049,9 @@ async function refresh(){
   try {
     document.getElementById('refreshBtn').setAttribute('disabled', 'disabled');
     const state = await apiGet(stateUrl);
+    CREDENTIAL_PROMPTS = sanitizeCredentialPrompts(state?.credential_prompts);
+    CONTACTS_ENABLED = !!CREDENTIAL_PROMPTS.phone;
+    updateContactButtons();
     const devices = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
     const list = compileUsers(devices, state.registry_users || []);
     renderSummary(state.kpis || {}, list);

--- a/custom_components/AK_Access_ctrl/www/users-mob.html
+++ b/custom_components/AK_Access_ctrl/www/users-mob.html
@@ -947,7 +947,7 @@ function applyCredentialPrompts(){
   }
   const phoneRow = document.getElementById('phoneRow');
   if (phoneRow){
-    phoneRow.style.display = CREDENTIAL_PROMPTS.phone || CONTACT_MODE ? '' : 'none';
+    phoneRow.style.display = CREDENTIAL_PROMPTS.phone ? '' : 'none';
   }
   const faceSection = document.getElementById('faceSection');
   if (faceSection){
@@ -1106,7 +1106,8 @@ async function load(){
     const params = new URLSearchParams(location.search);
     const id = (params.get('id') || '').trim();
     const modeParam = (params.get('mode') || '').toLowerCase();
-    CONTACT_MODE = modeParam === 'contact';
+    const phonePromptEnabled = !!CREDENTIAL_PROMPTS.phone;
+    CONTACT_MODE = phonePromptEnabled && modeParam === 'contact';
     const startInEditMode = modeParam === 'edit';
     if (CONTACT_MODE) {
       CREDENTIAL_PROMPTS = sanitizeCredentialPrompts({
@@ -1400,9 +1401,11 @@ async function save(){
       CURRENT.pin = pinValue;
     }
 
-    if (prompts.phone || CONTACT_MODE){
-      const phoneValue = document.getElementById('phone').value.trim();
-      payload.phone = phoneValue || undefined;
+    const phoneInput = document.getElementById('phone');
+    const phoneValue = phoneInput ? phoneInput.value.trim() : '';
+    const hadPhone = !!(CURRENT && typeof CURRENT.phone === 'string' && CURRENT.phone.trim());
+    if (prompts.phone || CONTACT_MODE || phoneValue || hadPhone){
+      payload.phone = phoneValue;
       CURRENT.phone = phoneValue;
     }
 

--- a/custom_components/AK_Access_ctrl/www/users.html
+++ b/custom_components/AK_Access_ctrl/www/users.html
@@ -947,7 +947,7 @@ function applyCredentialPrompts(){
   }
   const phoneRow = document.getElementById('phoneRow');
   if (phoneRow){
-    phoneRow.style.display = CREDENTIAL_PROMPTS.phone || CONTACT_MODE ? '' : 'none';
+    phoneRow.style.display = CREDENTIAL_PROMPTS.phone ? '' : 'none';
   }
   const faceSection = document.getElementById('faceSection');
   if (faceSection){
@@ -1106,7 +1106,8 @@ async function load(){
     const params = new URLSearchParams(location.search);
     const id = (params.get('id') || '').trim();
     const modeParam = (params.get('mode') || '').toLowerCase();
-    CONTACT_MODE = modeParam === 'contact';
+    const phonePromptEnabled = !!CREDENTIAL_PROMPTS.phone;
+    CONTACT_MODE = phonePromptEnabled && modeParam === 'contact';
     const startInEditMode = modeParam === 'edit';
     if (CONTACT_MODE) {
       CREDENTIAL_PROMPTS = sanitizeCredentialPrompts({
@@ -1400,9 +1401,11 @@ async function save(){
       CURRENT.pin = pinValue;
     }
 
-    if (prompts.phone || CONTACT_MODE){
-      const phoneValue = document.getElementById('phone').value.trim();
-      payload.phone = phoneValue || undefined;
+    const phoneInput = document.getElementById('phone');
+    const phoneValue = phoneInput ? phoneInput.value.trim() : '';
+    const hadPhone = !!(CURRENT && typeof CURRENT.phone === 'string' && CURRENT.phone.trim());
+    if (prompts.phone || CONTACT_MODE || phoneValue || hadPhone){
+      payload.phone = phoneValue;
       CURRENT.phone = phoneValue;
     }
 


### PR DESCRIPTION
## Summary
- hide the phone number field and contact mode when the phone credential prompt is disabled
- gate the contacts tab, add-contact button, and contact table behind the phone prompt on desktop and mobile dashboards
- refresh the mobile user overview header with management, contact management, and new contact shortcuts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04c5f4ac4832cbd8eaf053b77654b