### PR TITLE
fix: restore dashboard history rendering when access events are object-wrapped

### DIFF
--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1372,6 +1372,19 @@ function renderEvents(devs, aggregated){
   listEl.innerHTML = html || '<li class="event-item"><span class="event-title dim">No recent events</span></li>';
 }
 
+function extractAccessEventsCollection(payload){
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== 'object') return [];
+
+  const candidateKeys = ['events', 'items', 'results', 'history', 'data'];
+  for (const key of candidateKeys){
+    const value = payload[key];
+    if (Array.isArray(value)) return value;
+  }
+
+  return [];
+}
+
 /* ===== Users ===== */
 function idMatchesFilter(id){
   return /^HA-?\d+$/i.test(id) || /^TMP-?\d+$/i.test(id) || /^User\d+$/i.test(id);
@@ -1929,8 +1942,9 @@ async function refresh(){
     CREDENTIAL_PROMPTS = sanitizeCredentialPrompts(state?.credential_prompts);
     renderKPIs(state.kpis || {devices:0, users:0, pending:0});
     const devs = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
+    const accessEvents = extractAccessEventsCollection(state?.access_events);
     renderDevices(devs);
-    renderEvents(devs, state.access_events || []);
+    renderEvents(devs, accessEvents);
     if (cachedEvents.length > 0) {
       eventHistoryInitialized = true;
     }
@@ -1997,7 +2011,7 @@ async function requestEventHistoryRefresh(){
 async function maybeRequestEventHistory(state){
   if (eventHistoryInitialized) return;
 
-  const aggregated = Array.isArray(state?.access_events) ? state.access_events : [];
+  const aggregated = extractAccessEventsCollection(state?.access_events);
   const deviceEventsAvailable = Array.isArray(state?.devices)
     && state.devices.some(dev => Array.isArray(dev?.events) && dev.events.length > 0);
 

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1456,6 +1456,19 @@ function renderEvents(devs, aggregated){
   applyEventFilter();
 }
 
+function extractAccessEventsCollection(payload){
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== 'object') return [];
+
+  const candidateKeys = ['events', 'items', 'results', 'history', 'data'];
+  for (const key of candidateKeys){
+    const value = payload[key];
+    if (Array.isArray(value)) return value;
+  }
+
+  return [];
+}
+
 /* ===== Users ===== */
 function idMatchesFilter(id){
   return /^HA-?\d+$/i.test(id) || /^TMP-?\d+$/i.test(id) || /^User\d+$/i.test(id);
@@ -2154,8 +2167,9 @@ async function refresh(){
     CREDENTIAL_PROMPTS = sanitizeCredentialPrompts(state?.credential_prompts);
     renderKPIs(state.kpis || {devices:0, users:0, pending:0});
     const devs = (state.devices || []).map(d => ({ ...d, _users: d._users || d.users || [] }));
+    const accessEvents = extractAccessEventsCollection(state?.access_events);
     renderDevices(devs);
-    renderEvents(devs, state.access_events || []);
+    renderEvents(devs, accessEvents);
     if (cachedEvents.length > 0) {
       eventHistoryInitialized = true;
     }
@@ -2247,7 +2261,7 @@ async function updateAccessEvents(){
 async function maybeRequestEventHistory(state){
   if (eventHistoryInitialized) return;
 
-  const aggregated = Array.isArray(state?.access_events) ? state.access_events : [];
+  const aggregated = extractAccessEventsCollection(state?.access_events);
   const deviceEventsAvailable = Array.isArray(state?.devices)
     && state.devices.some(dev => Array.isArray(dev?.events) && dev.events.length > 0);
 


### PR DESCRIPTION
### Motivation
- The dashboard Event History could appear empty when the backend returned `access_events` wrapped in an object (e.g. `{ events: [...] }`) even though per-user "Last Access" values were updating. 
- The change aims to make the UI resilient to multiple payload shapes so history rendering and auto-refresh logic work reliably.

### Description
- Add a helper `extractAccessEventsCollection(payload)` that normalizes `access_events` to an array by accepting a raw array or extracting known array keys (`events`, `items`, `results`, `history`, `data`).
- Use the extractor in the desktop view (`custom_components/akuvox_ac/www/index.html`) so `renderEvents` and `maybeRequestEventHistory` get a normalized events array.
- Apply the same fix to the mobile view (`custom_components/akuvox_ac/www/index-mob.html`) to keep behavior consistent across both UIs.
- Release impact: patch.

### Testing
- Ran `pytest -q custom_components/akuvox_ac/tests/test_coordinator_events.py`, which failed to run due to an environment import problem (ImportError: cannot import name `UTC` from `datetime`), so unit tests could not be executed successfully in this runtime.
- Verified the changes apply to both desktop and mobile HTML assets and updated event-initialization checks to rely on the normalized collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b3c4d6fc832caa4ad324fb927a42)