### PR TITLE
fix: harden dashboard token parsing to prevent invalid auth attempts

### DIFF
--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -491,6 +491,19 @@ let mobileStage = isMobileMode ? 'nav' : 'content';
 let knownToken = null;
 let tokenRefreshScheduled = false;
 
+const INVALID_TOKEN_LITERALS = new Set(['null', 'undefined', 'none', 'false', 'true', 'nan', '[object object]']);
+
+function normalizeTokenCandidate(value) {
+  if (typeof value !== 'string') return null;
+  const token = value.trim();
+  if (!token) return null;
+  const lowered = token.toLowerCase();
+  if (INVALID_TOKEN_LITERALS.has(lowered)) return null;
+  if (token.length < 20) return null;
+  if (!/^[A-Za-z0-9._~-]+$/.test(token)) return null;
+  return token;
+}
+
 function scheduleTokenRefresh(){
   if (tokenRefreshScheduled) return;
   tokenRefreshScheduled = true;
@@ -503,7 +516,7 @@ function scheduleTokenRefresh(){
 }
 
 function rememberToken(value) {
-  const token = typeof value === 'string' ? value.trim() : '';
+  const token = normalizeTokenCandidate(value);
   if (!token) return null;
   const changed = token !== knownToken;
   knownToken = token;
@@ -528,8 +541,11 @@ function getToken(){
     stored = null;
   }
   if (stored) {
-    knownToken = stored;
-    return stored;
+    const normalizedStored = normalizeTokenCandidate(stored);
+    if (normalizedStored) {
+      knownToken = normalizedStored;
+      return normalizedStored;
+    }
   }
   try {
     const local = localStorage.getItem('akuvox_ll_token');
@@ -604,9 +620,8 @@ function scanTokenStorage(storage) {
         const token = extractTokenFromAuth(parsed);
         if (token) return token;
       } catch (err) {
-        if (typeof raw === 'string' && raw.trim()) {
-          return persistTokens(raw.trim());
-        }
+        const fallback = normalizeTokenCandidate(raw);
+        if (fallback) return persistTokens(fallback);
       }
     }
     for (const key of Object.keys(storage)) {
@@ -624,8 +639,9 @@ function scanTokenStorage(storage) {
         const token = extractTokenFromAuth(parsed);
         if (token) return token;
       } catch (err) {
-        if (typeof rawValue === 'string' && rawValue.trim()) {
-          const token = persistTokens(rawValue.trim());
+        const fallback = normalizeTokenCandidate(rawValue);
+        if (fallback) {
+          const token = persistTokens(fallback);
           if (token) return token;
         }
       }

--- a/custom_components/akuvox_ac/www/head.html
+++ b/custom_components/akuvox_ac/www/head.html
@@ -467,6 +467,19 @@ let mobileStage = isMobileMode ? 'nav' : 'content';
 let knownToken = null;
 let tokenRefreshScheduled = false;
 
+const INVALID_TOKEN_LITERALS = new Set(['null', 'undefined', 'none', 'false', 'true', 'nan', '[object object]']);
+
+function normalizeTokenCandidate(value) {
+  if (typeof value !== 'string') return null;
+  const token = value.trim();
+  if (!token) return null;
+  const lowered = token.toLowerCase();
+  if (INVALID_TOKEN_LITERALS.has(lowered)) return null;
+  if (token.length < 20) return null;
+  if (!/^[A-Za-z0-9._~-]+$/.test(token)) return null;
+  return token;
+}
+
 function scheduleTokenRefresh(){
   if (tokenRefreshScheduled) return;
   tokenRefreshScheduled = true;
@@ -479,7 +492,7 @@ function scheduleTokenRefresh(){
 }
 
 function rememberToken(value) {
-  const token = typeof value === 'string' ? value.trim() : '';
+  const token = normalizeTokenCandidate(value);
   if (!token) return null;
   const changed = token !== knownToken;
   knownToken = token;
@@ -504,8 +517,11 @@ function getToken(){
     stored = null;
   }
   if (stored) {
-    knownToken = stored;
-    return stored;
+    const normalizedStored = normalizeTokenCandidate(stored);
+    if (normalizedStored) {
+      knownToken = normalizedStored;
+      return normalizedStored;
+    }
   }
   try {
     const local = localStorage.getItem('akuvox_ll_token');
@@ -580,9 +596,8 @@ function scanTokenStorage(storage) {
         const token = extractTokenFromAuth(parsed);
         if (token) return token;
       } catch (err) {
-        if (typeof raw === 'string' && raw.trim()) {
-          return persistTokens(raw.trim());
-        }
+        const fallback = normalizeTokenCandidate(raw);
+        if (fallback) return persistTokens(fallback);
       }
     }
     for (const key of Object.keys(storage)) {
@@ -600,8 +615,9 @@ function scanTokenStorage(storage) {
         const token = extractTokenFromAuth(parsed);
         if (token) return token;
       } catch (err) {
-        if (typeof rawValue === 'string' && rawValue.trim()) {
-          const token = persistTokens(rawValue.trim());
+        const fallback = normalizeTokenCandidate(rawValue);
+        if (fallback) {
+          const token = persistTokens(fallback);
           if (token) return token;
         }
       }


### PR DESCRIPTION
### Motivation
- The dashboard shell pages could treat arbitrary browser storage values as bearer tokens and send malformed `Authorization` headers, triggering Home Assistant "Login attempt or request with invalid authentication" alerts for the `/api/akuvox_ac/ui/state` endpoint.

### Description
- Add token normalization via `normalizeTokenCandidate` and an `INVALID_TOKEN_LITERALS` set in `custom_components/akuvox_ac/www/head.html` and `custom_components/akuvox_ac/www/head-mob.html` to reject obvious non-token values and malformed/too-short strings before remembering or using them.
- Update `getToken`, `rememberToken`, and `scanTokenStorage` logic in both shell pages so fallback parsing only persists validated bearer candidates (instead of blindly trimming arbitrary storage strings).
- Change surface: `custom_components/akuvox_ac/www/head.html` and `custom_components/akuvox_ac/www/head-mob.html`.
- Release impact: patch

### Testing
- Attempted to run `pytest -q custom_components/akuvox_ac/tests/test_coordinator_timestamp.py`, but the test run failed in this environment with an `ImportError: cannot import name 'UTC' from 'datetime'`, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee88b8d734832c8c7c965a6daca5f9)