### PR TITLE
Show user identity in diagnostics and flag face registration mismatches in user UI

### DIFF
--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -1313,6 +1313,18 @@ function requestActionValue(req){
   return '';
 }
 
+function requestOverviewIdentity(req){
+  if (!req || typeof req !== 'object') return { userId: '', name: '' };
+  const payload = req.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return { userId: '', name: '' };
+  const userIdRaw = payload.USERID ?? payload.UserID ?? payload.userId ?? payload.userid ?? '';
+  const nameRaw = payload.NAME ?? payload.Name ?? payload.name ?? '';
+  return {
+    userId: String(userIdRaw || '').trim(),
+    name: String(nameRaw || '').trim(),
+  };
+}
+
 function isDeviceFunctionCommand(req){
   const action = requestActionValue(req).toLowerCase();
   return action !== 'get';
@@ -1366,6 +1378,7 @@ function renderSyncErrors(devices = DIAG_DATA){
     const action = requestActionValue(req);
     const status = req.status != null ? String(req.status) : '—';
     const path = req.path || req.url || '—';
+    const overviewIdentity = requestOverviewIdentity(req);
     const hasError = requestHasError(req);
     const message = req.error || 'No explicit error message was returned.';
     const statusBadgeClass = hasError ? 'diag-status-error' : 'diag-status-ok';
@@ -1375,6 +1388,8 @@ function renderSyncErrors(devices = DIAG_DATA){
         <summary>
           <span class="badge method ${escapeHtml(method.toLowerCase())}">${escapeHtml(method)}</span>
           ${action ? `<span class="badge diag-action-badge">${escapeHtml(action)}</span>` : ''}
+          ${overviewIdentity.userId ? `<span class="badge diag-type-badge">USERID: ${escapeHtml(overviewIdentity.userId)}</span>` : ''}
+          ${overviewIdentity.name ? `<span class="badge diag-type-badge">NAME: ${escapeHtml(overviewIdentity.name)}</span>` : ''}
           <code>${escapeHtml(path)}</code>
           <span class="diag-summary-meta">
             <span>${escapeHtml(row.deviceName)}</span>
@@ -1834,9 +1849,12 @@ function renderRequestList(container, device){
     details.className = 'diag-request';
     if (idx === 0) details.open = true;
     const method = String(req.method || 'GET').toUpperCase();
+    const overviewIdentity = requestOverviewIdentity(req);
     const methodBadge = `<span class="badge method ${method.toLowerCase()}">${escapeHtml(method)}</span>`;
     const typeLabel = requestTypeLabelFromValue(requestTypeValue(req));
     const typeBadge = typeLabel ? `<span class="badge diag-type-badge">${escapeHtml(typeLabel)}</span>` : '';
+    const userIdBadge = overviewIdentity.userId ? `<span class="badge diag-type-badge">USERID: ${escapeHtml(overviewIdentity.userId)}</span>` : '';
+    const nameBadge = overviewIdentity.name ? `<span class="badge diag-type-badge">NAME: ${escapeHtml(overviewIdentity.name)}</span>` : '';
     const path = req.path || '';
     const status = req.status != null ? String(req.status) : '—';
     const ok = req.ok === true;
@@ -1844,6 +1862,8 @@ function renderRequestList(container, device){
     summary.innerHTML = `
       ${methodBadge}
       ${typeBadge}
+      ${userIdBadge}
+      ${nameBadge}
       <code>${escapeHtml(path || (req.url || ''))}</code>
       <span class="diag-summary-meta">
         <span>Status: ${escapeHtml(status)}</span>

--- a/custom_components/akuvox_ac/www/diagnostics.html
+++ b/custom_components/akuvox_ac/www/diagnostics.html
@@ -1313,6 +1313,18 @@ function requestActionValue(req){
   return '';
 }
 
+function requestOverviewIdentity(req){
+  if (!req || typeof req !== 'object') return { userId: '', name: '' };
+  const payload = req.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return { userId: '', name: '' };
+  const userIdRaw = payload.USERID ?? payload.UserID ?? payload.userId ?? payload.userid ?? '';
+  const nameRaw = payload.NAME ?? payload.Name ?? payload.name ?? '';
+  return {
+    userId: String(userIdRaw || '').trim(),
+    name: String(nameRaw || '').trim(),
+  };
+}
+
 function isDeviceFunctionCommand(req){
   const action = requestActionValue(req).toLowerCase();
   return action !== 'get';
@@ -1366,6 +1378,7 @@ function renderSyncErrors(devices = DIAG_DATA){
     const action = requestActionValue(req);
     const status = req.status != null ? String(req.status) : '—';
     const path = req.path || req.url || '—';
+    const overviewIdentity = requestOverviewIdentity(req);
     const hasError = requestHasError(req);
     const message = req.error || 'No explicit error message was returned.';
     const statusBadgeClass = hasError ? 'diag-status-error' : 'diag-status-ok';
@@ -1375,6 +1388,8 @@ function renderSyncErrors(devices = DIAG_DATA){
         <summary>
           <span class="badge method ${escapeHtml(method.toLowerCase())}">${escapeHtml(method)}</span>
           ${action ? `<span class="badge diag-action-badge">${escapeHtml(action)}</span>` : ''}
+          ${overviewIdentity.userId ? `<span class="badge diag-type-badge">USERID: ${escapeHtml(overviewIdentity.userId)}</span>` : ''}
+          ${overviewIdentity.name ? `<span class="badge diag-type-badge">NAME: ${escapeHtml(overviewIdentity.name)}</span>` : ''}
           <code>${escapeHtml(path)}</code>
           <span class="diag-summary-meta">
             <span>${escapeHtml(row.deviceName)}</span>
@@ -1834,9 +1849,12 @@ function renderRequestList(container, device){
     details.className = 'diag-request';
     if (idx === 0) details.open = true;
     const method = String(req.method || 'GET').toUpperCase();
+    const overviewIdentity = requestOverviewIdentity(req);
     const methodBadge = `<span class="badge method ${method.toLowerCase()}">${escapeHtml(method)}</span>`;
     const typeLabel = requestTypeLabelFromValue(requestTypeValue(req));
     const typeBadge = typeLabel ? `<span class="badge diag-type-badge">${escapeHtml(typeLabel)}</span>` : '';
+    const userIdBadge = overviewIdentity.userId ? `<span class="badge diag-type-badge">USERID: ${escapeHtml(overviewIdentity.userId)}</span>` : '';
+    const nameBadge = overviewIdentity.name ? `<span class="badge diag-type-badge">NAME: ${escapeHtml(overviewIdentity.name)}</span>` : '';
     const path = req.path || '';
     const status = req.status != null ? String(req.status) : '—';
     const ok = req.ok === true;
@@ -1844,6 +1862,8 @@ function renderRequestList(container, device){
     summary.innerHTML = `
       ${methodBadge}
       ${typeBadge}
+      ${userIdBadge}
+      ${nameBadge}
       <code>${escapeHtml(path || (req.url || ''))}</code>
       <span class="diag-summary-meta">
         <span>Status: ${escapeHtml(status)}</span>

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1401,6 +1401,7 @@ const FACE_STATUS_FIELDS = [
   'has_face','hasFace','HasFace'
 ];
 const FACE_STATE_FIELDS = ['face_status','faceStatus','FaceStatus'];
+const FACE_REGISTER_FIELDS = ['FaceRegister','face_register','faceRegister','FaceRegisterStatus','faceRegisterStatus'];
 
 function normalizeFaceFlag(value){
   if (typeof value === 'boolean') return value;
@@ -1467,6 +1468,26 @@ function computeFaceActive(record){
   const url = extractFaceUrl(record);
   if (url) return true;
   return false;
+}
+
+function extractFaceRegisterFlag(record){
+  if (!record || typeof record !== 'object') return null;
+  for (const key of FACE_REGISTER_FIELDS){
+    if (!(key in record)) continue;
+    const normalized = normalizeFaceFlag(record[key]);
+    if (normalized !== null){
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function hasFaceRegistrationMismatch(record){
+  if (!record || typeof record !== 'object') return false;
+  const url = extractFaceUrl(record);
+  if (!url) return false;
+  const registerFlag = extractFaceRegisterFlag(record);
+  return registerFlag === false;
 }
 
 function scheduleDisplayId(rawId){
@@ -1545,6 +1566,7 @@ function renderUsers(devs, registryUsers, kpis){
         ? r.face_active
         : (statusHint === 'active' ? true : computeFaceActive(r)),
       face_error_count: Number(r.face_error_count || 0),
+      face_register_mismatch: hasFaceRegistrationMismatch(r),
       _seenOn: new Set(),
       _denied: false,
       _pinOnDevice: false
@@ -1567,6 +1589,7 @@ function renderUsers(devs, registryUsers, kpis){
       const last = u.LastAccess || u.last_access || '';
       const deviceFaceUrl = extractFaceUrl(u);
       const deviceFaceActive = computeFaceActive(u);
+      const deviceFaceMismatch = hasFaceRegistrationMismatch(u);
       const devicePin = extractPin(u);
 
       if (!by.has(key)) {
@@ -1587,6 +1610,7 @@ function renderUsers(devs, registryUsers, kpis){
           face_status: deviceFaceActive ? 'active' : '',
           face_active: deviceFaceActive,
           face_error_count: 0,
+          face_register_mismatch: deviceFaceMismatch,
           _pinOnDevice: !!devicePin
         });
         return;
@@ -1620,6 +1644,7 @@ function renderUsers(devs, registryUsers, kpis){
       if (!cur.face_url && deviceFaceUrl) {
         cur.face_url = deviceFaceUrl;
       }
+      cur.face_register_mismatch = !!cur.face_register_mismatch || deviceFaceMismatch;
       const deviceScheduleName = u.ScheduleName || u.schedule_name || '';
       const deviceScheduleId = u.ScheduleId || u.schedule_id || '';
       const deviceAccessLevel = u.AccessLevel || u.access_level || '';
@@ -1701,8 +1726,12 @@ function renderUsers(devs, registryUsers, kpis){
     const statusLower = String(rest.face_status || '').trim().toLowerCase();
     let faceStatusFinal = statusLower;
     let faceActiveFinal;
+    const faceMismatch = !!rest.face_register_mismatch || hasFaceRegistrationMismatch(rest);
 
-    if (faceStatusFinal === 'active') {
+    if (faceMismatch) {
+      faceStatusFinal = 'error';
+      faceActiveFinal = false;
+    } else if (faceStatusFinal === 'active') {
       faceActiveFinal = true;
     } else if (faceStatusFinal === 'pending') {
       faceActiveFinal = false;
@@ -1765,6 +1794,7 @@ function renderUsers(devs, registryUsers, kpis){
       pendingDevices: pendingDevices.length,
       face_active: !!faceActiveFinal,
       face_status: faceStatusFinal,
+      face_register_mismatch: faceMismatch,
       access_schedule: scheduleDisplay
     };
   }).filter(u => {
@@ -1805,6 +1835,8 @@ function renderUsers(devs, registryUsers, kpis){
     const hasFaceProfile = !!u.face_url || u.face_active;
     if (accessLower === 'deleted') {
       faceBadge = badge('Deleted', 'inactive');
+    } else if (faceStatusLower === 'error' || u.face_register_mismatch) {
+      faceBadge = badge('Error', 'offline');
     } else if (faceStatusLower === 'pending' && u.remote_enrol_pending) {
       faceBadge = badge('Pending remote enrolment', 'pending');
     } else if (faceStatusLower === 'active' || (faceStatusLower === '' && u.face_active)) {

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1485,6 +1485,7 @@ const FACE_STATUS_FIELDS = [
   'has_face','hasFace','HasFace'
 ];
 const FACE_STATE_FIELDS = ['face_status','faceStatus','FaceStatus'];
+const FACE_REGISTER_FIELDS = ['FaceRegister','face_register','faceRegister','FaceRegisterStatus','faceRegisterStatus'];
 
 function normalizeFaceFlag(value){
   if (typeof value === 'boolean') return value;
@@ -1551,6 +1552,26 @@ function computeFaceActive(record){
   const url = extractFaceUrl(record);
   if (url) return true;
   return false;
+}
+
+function extractFaceRegisterFlag(record){
+  if (!record || typeof record !== 'object') return null;
+  for (const key of FACE_REGISTER_FIELDS){
+    if (!(key in record)) continue;
+    const normalized = normalizeFaceFlag(record[key]);
+    if (normalized !== null){
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function hasFaceRegistrationMismatch(record){
+  if (!record || typeof record !== 'object') return false;
+  const url = extractFaceUrl(record);
+  if (!url) return false;
+  const registerFlag = extractFaceRegisterFlag(record);
+  return registerFlag === false;
 }
 
 function scheduleDisplayId(rawId){
@@ -1687,6 +1708,7 @@ function renderUsers(devs, registryUsers, kpis){
         ? r.face_active
         : (statusHint === 'active' ? true : computeFaceActive(r)),
       face_error_count: Number(r.face_error_count || 0),
+      face_register_mismatch: hasFaceRegistrationMismatch(r),
       _seenOn: new Set(),
       _denied: false,
       _pinOnDevice: false
@@ -1709,6 +1731,7 @@ function renderUsers(devs, registryUsers, kpis){
       const last = u.LastAccess || u.last_access || '';
       const deviceFaceUrl = extractFaceUrl(u);
       const deviceFaceActive = computeFaceActive(u);
+      const deviceFaceMismatch = hasFaceRegistrationMismatch(u);
       const devicePin = extractPin(u);
 
       if (!by.has(key)) {
@@ -1726,6 +1749,7 @@ function renderUsers(devs, registryUsers, kpis){
           face_status: deviceFaceActive ? 'active' : '',
           face_active: deviceFaceActive,
           face_error_count: 0,
+          face_register_mismatch: deviceFaceMismatch,
           schedule_name: u.ScheduleName || u.schedule_name || '',
           schedule_id: u.ScheduleId || u.schedule_id || '',
           access_level: u.AccessLevel || u.access_level || '',
@@ -1774,6 +1798,7 @@ function renderUsers(devs, registryUsers, kpis){
       if (!cur.face_url && deviceFaceUrl) {
         cur.face_url = deviceFaceUrl;
       }
+      cur.face_register_mismatch = !!cur.face_register_mismatch || deviceFaceMismatch;
       if (cur.fromRegistry) {
         if (deviceFaceActive) {
           cur._deviceFaceActive = true;
@@ -1843,8 +1868,12 @@ function renderUsers(devs, registryUsers, kpis){
     const statusLower = String(rest.face_status || '').trim().toLowerCase();
     let faceStatusFinal = statusLower;
     let faceActiveFinal;
+    const faceMismatch = !!rest.face_register_mismatch || hasFaceRegistrationMismatch(rest);
 
-    if (faceStatusFinal === 'active') {
+    if (faceMismatch) {
+      faceStatusFinal = 'error';
+      faceActiveFinal = false;
+    } else if (faceStatusFinal === 'active') {
       faceActiveFinal = true;
     } else if (faceStatusFinal === 'pending') {
       faceActiveFinal = false;
@@ -1908,6 +1937,7 @@ function renderUsers(devs, registryUsers, kpis){
       pendingDevices: pendingDevices.length,
       face_active: !!faceActiveFinal,
       face_status: faceStatusFinal,
+      face_register_mismatch: faceMismatch,
       access_schedule: scheduleDisplay
     };
   }).filter(u => {
@@ -1981,6 +2011,8 @@ function renderUsers(devs, registryUsers, kpis){
     const hasFaceProfile = !!u.face_url || u.face_active;
     if (accessLower === 'deleted') {
       faceBadge = badge('Deleted', 'inactive');
+    } else if (faceStatusLower === 'error' || u.face_register_mismatch) {
+      faceBadge = badge('Error', 'offline');
     } else if (faceStatusLower === 'pending' && u.remote_enrol_pending) {
       faceBadge = badge('Pending remote enrolment', 'pending');
     } else if (faceStatusLower === 'active' || (faceStatusLower === '' && u.face_active)) {


### PR DESCRIPTION
### Motivation
- Improve diagnostics and user list UX by exposing user identity extracted from request payloads and surface face registration mismatches detected between a face URL and an explicit registration flag.
- Make it easier to triage device commands by showing `USERID`/`NAME` in request overviews.
- Detect and mark cases where a face image exists but the device reports registration as disabled, so these can be surfaced as an error state.

### Description
- Added `requestOverviewIdentity` to extract `USERID`/`Name`/`userId` variants from request payloads and display `USERID` and `NAME` badges in `renderSyncErrors` and request lists in both `diagnostics.html` and `diagnostics-mob.html`.
- Introduced `FACE_REGISTER_FIELDS`, `extractFaceRegisterFlag`, and `hasFaceRegistrationMismatch` helpers to detect registration flags and mismatches from various payload key names in `index.html` and `index-mob.html`.
- Propagated `face_register_mismatch` into the user aggregation/merge logic and used it to mark `face_status` as `error` (and `face_active` as false) when a mismatch is detected.
- Updated face badge rendering to show an `Error` badge when a user has a registration mismatch, in both desktop and mobile index pages.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee90f9d5c0832c9eff95edf2c69466)