### PR TITLE
fix: extend signed dashboard API URL lifetime

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1609,7 +1609,7 @@ def _signed_paths_for_request(
             signed[key] = async_sign_path(
                 hass,
                 path,
-                dt.timedelta(minutes=10),
+                dt.timedelta(hours=12),
                 refresh_token_id=refresh_id,
             )
         except Exception as err:  # pragma: no cover - best effort


### PR DESCRIPTION
### Motivation
- Increase the signed dashboard API path lifetime to reduce expired `authSig` during long-open dashboard sessions and avoid Home Assistant HTTP ban warnings; release impact: patch.

### Description
- In `custom_components/akuvox_ac/http.py` update `_signed_paths_for_request` to use `dt.timedelta(hours=12)` instead of `dt.timedelta(minutes=10)` so signed UI API URLs remain valid for 12 hours.

### Testing
- Ran `pytest -q custom_components/akuvox_ac/tests/test_face_status.py`, which failed during test bootstrap with `ImportError: cannot import name 'UTC' from 'datetime'`, so automated tests did not execute to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee939c1408832c83f9b6bfab398305)