### PR TITLE
fix: recreate users when face recognition enters error state

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1836,6 +1836,19 @@ def _device_face_is_active(record: Mapping[str, Any]) -> bool:
     return True
 
 
+def _device_face_registration_mismatch(record: Mapping[str, Any]) -> bool:
+    url = str(
+        record.get("FaceUrl")
+        or record.get("FaceURL")
+        or record.get("face_url")
+        or ""
+    ).strip()
+    if not url:
+        return False
+    flag = _face_flag_from_record(record)
+    return flag is False
+
+
 def _evaluate_face_status(
     hass: HomeAssistant,
     user: Mapping[str, Any],
@@ -1847,7 +1860,7 @@ def _evaluate_face_status(
         return "none"
 
     has_face_asset = _face_image_exists(hass, user_id)
-    wants_face = stored_status in {"pending", "active"} or has_face_asset
+    wants_face = stored_status in {"pending", "active", "error"} or has_face_asset
     if not wants_face:
         return "none"
 
@@ -1877,6 +1890,8 @@ def _evaluate_face_status(
                 break
         if record is None:
             return "pending"
+        if _device_face_registration_mismatch(record):
+            return "error"
         face_active = _device_face_is_active(record)
         if not face_active:
             return "pending"
@@ -1927,7 +1942,7 @@ async def _refresh_face_statuses(
         if not users_store:
             continue
 
-        status_for_store = desired_status if desired_status in {"pending", "active"} else ""
+        status_for_store = desired_status if desired_status in {"pending", "active", "error"} else ""
         stored_status_norm = stored_status if stored_status else ""
         stored_errors = stored.get("face_error_count")
         clear_errors = bool(stored_errors) and desired_status == "active"

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -4131,13 +4131,16 @@ class SyncManager:
                             and any(diff in ("face status", "face url") for diff in diffs)
                         )
                         if face_mismatch and device_type_raw.lower() == "intercom":
+                            profile_face_status = str(
+                                (registry.get(ha_key) or {}).get("face_status") or ""
+                            ).strip().lower()
+                            force_recreate_on_error = profile_face_status == "error"
                             expected_face = _face_flag_from_record(desired)
                             expected_url = str(
                                 desired.get("FaceUrl") or desired.get("FaceURL") or ""
                             ).strip()
                             if expected_url or expected_face:
-                                error_count = await self._bump_face_error_count(ha_key)
-                                if error_count >= FACE_SYNC_ERROR_THRESHOLD:
+                                if force_recreate_on_error:
                                     try:
                                         await self._recreate_user_for_face_mismatch(
                                             api,
@@ -4145,19 +4148,51 @@ class SyncManager:
                                             desired,
                                             local,
                                         )
-                                        await self._reset_face_error_count(ha_key)
+                                        try:
+                                            if users_store:
+                                                await users_store.upsert_profile(
+                                                    ha_key,
+                                                    face_status="pending",
+                                                    face_error_count=0,
+                                                )
+                                        except Exception:
+                                            pass
                                         try:
                                             coord._append_event(
-                                                f"Recreated {ha_key} after {error_count} face sync errors"
+                                                f"Recreated {ha_key} due to face sync error state"
                                             )  # type: ignore[attr-defined]
                                         except Exception:
                                             pass
+                                        continue
                                     except Exception as err:
                                         _LOGGER.warning(
-                                            "Failed to recreate user %s after face sync errors: %s",
+                                            "Failed to recreate user %s after face error state: %s",
                                             ha_key,
                                             err,
                                         )
+                                else:
+                                    error_count = await self._bump_face_error_count(ha_key)
+                                    if error_count >= FACE_SYNC_ERROR_THRESHOLD:
+                                        try:
+                                            await self._recreate_user_for_face_mismatch(
+                                                api,
+                                                ha_key,
+                                                desired,
+                                                local,
+                                            )
+                                            await self._reset_face_error_count(ha_key)
+                                            try:
+                                                coord._append_event(
+                                                    f"Recreated {ha_key} after {error_count} face sync errors"
+                                                )  # type: ignore[attr-defined]
+                                            except Exception:
+                                                pass
+                                        except Exception as err:
+                                            _LOGGER.warning(
+                                                "Failed to recreate user %s after face sync errors: %s",
+                                                ha_key,
+                                                err,
+                                            )
                         mismatch_reason = f"{ha_key} mismatch: {', '.join(diffs)}"
                         break
 


### PR DESCRIPTION
### Motivation
- Keep dashboard-visible face errors and backend sync behavior aligned by treating face-registration mismatches as an explicit `error` face status and persisting it so sync logic can respond immediately.  
- When a user is marked `face_status: error` the intent is to delete and recreate that user on the next integrity pass to recover from broken face registrations.  
- Release impact: patch

### Description
- Added `_device_face_registration_mismatch` in `custom_components/akuvox_ac/http.py` to detect cases where a face URL exists but the register flag is explicitly false.  
- Extended `_evaluate_face_status` to treat stored `face_status == "error"` as a valid state and to return `"error"` when a device record shows a registration mismatch, and to persist `error` via the users store.  
- Updated integrity sync in `custom_components/akuvox_ac/integration.py` to check the registry-stored `face_status` and, if it is `error`, immediately recreate the user, set the stored profile back to `pending` and clear the face error count so the user is re-synced on the next pass.  
- Preserved existing threshold-based recreate behavior for repeated non-`error` face mismatches so prior retry semantics remain intact.  

### Testing
- Ran `python -m compileall custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee95b9e7e0832c98f63c63ecc8f9c0)