### PR TITLE
fix: clear stale signed UI paths when auth context is unavailable

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1618,14 +1618,18 @@ def _signed_paths_for_request(
     return signed
 
 
-def _inject_signed_paths(html: str, signed: Dict[str, str]) -> str:
-    if not signed:
+def _inject_signed_paths(
+    html: str, signed: Dict[str, str], *, clear_cache: bool = False
+) -> str:
+    if not signed and not clear_cache:
         return html
 
-    try:
-        payload = json.dumps(signed)
-    except Exception:  # pragma: no cover - shouldn't happen
-        return html
+    payload = "{}"
+    if signed:
+        try:
+            payload = json.dumps(signed)
+        except Exception:  # pragma: no cover - shouldn't happen
+            payload = "{}"
 
     script = (
         "<script>"
@@ -1637,9 +1641,19 @@ def _inject_signed_paths(html: str, signed: Dict[str, str]) -> str:
         "    try { sessionStorage.setItem('akuvox_signed_paths', JSON.stringify(target)); } catch (err) {}"
         "    try { localStorage.setItem('akuvox_signed_paths', JSON.stringify(target)); } catch (err) {}"
         "  } catch (err) {}"
+        "%s"
         "})();"
         "</script>"
-    ) % payload
+    ) % (
+        payload,
+        (
+            "try { window.AK_AC_SIGNED_PATHS = {}; } catch (err) {};"
+            "try { sessionStorage.removeItem('akuvox_signed_paths'); } catch (err) {};"
+            "try { localStorage.removeItem('akuvox_signed_paths'); } catch (err) {};"
+            if clear_cache and not signed
+            else ""
+        ),
+    )
 
     lowered = html.lower()
     head_index = lowered.find("</head>")
@@ -2596,7 +2610,7 @@ class AkuvoxDashboardView(HomeAssistantView):
                 html = asset.read_text(encoding="utf-8")
             except Exception:
                 html = asset.read_text()
-            html = _inject_signed_paths(html, signed)
+            html = _inject_signed_paths(html, signed, clear_cache=not bool(signed))
             response = web.Response(text=html, content_type="text/html")
             response.headers["X-AK-AC-Variant"] = variant
             return response


### PR DESCRIPTION
### Motivation
- Prevent browsers from reusing expired `authSig` query strings persisted in `akuvox_signed_paths` which cause repeated Home Assistant "invalid authentication/login failed" requests to `/api/akuvox_ac/ui/*`.
- Ensure the dashboard UI clears any stale signed-path cache when the incoming request lacks a Home Assistant refresh-token auth context.

### Description
- Add a `clear_cache` flag to `_inject_signed_paths` and make it accept `html` + `signed` paths and optional cache-clearing behavior via `clear_cache=True` when no signed paths are available.
- Default the injected payload to `{}` when no signed paths are present and inject a small script that, when `clear_cache` is true and `signed` is empty, clears `window.AK_AC_SIGNED_PATHS` and removes the `akuvox_signed_paths` entries from `sessionStorage` and `localStorage`.
- Update the dashboard route to call `_inject_signed_paths(html, signed, clear_cache=not bool(signed))` so the browser-stored signed paths are purged when the request has no refresh-token context.
- Release impact: patch.

### Testing
- Ran `pytest -q custom_components/akuvox_ac/tests/test_face_status.py`, which failed in this environment due to an unrelated `ImportError: cannot import name 'UTC' from 'datetime'` in the test stubs, so unit tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee96e2d91c832ca86b1831a27df548)