### PR TITLE
fix: resolve Home Assistant async warnings in dashboard and sensors

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -6,6 +6,7 @@ import logging
 import json
 import re
 import time
+from functools import partial
 from datetime import timedelta
 from pathlib import Path
 from collections import OrderedDict
@@ -2638,9 +2639,11 @@ class AkuvoxDashboardView(HomeAssistantView):
             hass: HomeAssistant = request.app["hass"]
             signed = _signed_paths_for_request(hass, request)
             try:
-                html = asset.read_text(encoding="utf-8")
+                html = await hass.async_add_executor_job(
+                    partial(asset.read_text, encoding="utf-8")
+                )
             except Exception:
-                html = asset.read_text()
+                html = await hass.async_add_executor_job(asset.read_text)
             html = _inject_signed_paths(html, signed, clear_cache=not bool(signed))
             response = web.Response(text=html, content_type="text/html")
             response.headers["X-AK-AC-Variant"] = variant

--- a/custom_components/akuvox_ac/sensor.py
+++ b/custom_components/akuvox_ac/sensor.py
@@ -49,7 +49,7 @@ class _Base(AkuvoxOnlineSensor := object):
         pass
 
     def _coord_updated(self) -> None:
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:


### PR DESCRIPTION
### Motivation
- The dashboard handler performed blocking file I/O (`Path.read_text`) on the Home Assistant event loop, causing asyncio blocking warnings.  
- Sensor coordinator callbacks invoked `async_write_ha_state()` from non-event-loop threads, triggering thread-safety warnings and risking state corruption.  
- Release impact: patch.

### Description
- Move dashboard HTML file reads off the event loop by running `asset.read_text(encoding="utf-8")` via `hass.async_add_executor_job(partial(...))` and use an executor fallback for the non-utf8 case.  
- Add `functools.partial` import and preserve existing signed-path injection and response headers.  
- Replace `self.async_write_ha_state()` in `_coord_updated` with `self.schedule_update_ha_state()` to ensure thread-safe sensor updates.  
- Modified files: `custom_components/akuvox_ac/http.py` and `custom_components/akuvox_ac/sensor.py`.

### Testing
- Ran `python -m compileall custom_components/akuvox_ac/http.py custom_components/akuvox_ac/sensor.py`, which succeeded.  
- Verified the changes were staged and committed successfully in the local repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0537d1d60832ca3322b7b2f04d158)