### PR TITLE
Respect FaceRegisterStatus in sync comparison and add user summary for update events in UI

### DIFF
--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -1299,6 +1299,38 @@ def _integrity_field_differences(
     return diffs
 
 
+def _record_matches_desired_fields(local: Dict[str, Any], desired: Dict[str, Any]) -> bool:
+    """Return True when ``local`` already satisfies the desired payload values."""
+
+    if not isinstance(local, dict) or not isinstance(desired, dict):
+        return False
+
+    def _text(value: Any) -> str:
+        return str(value or "").strip()
+
+    def _face_flag(record: Dict[str, Any]) -> Optional[bool]:
+        raw = record.get("FaceRegister")
+        if raw in (None, ""):
+            raw = record.get("FaceRegisterStatus")
+        return _normalize_boolish(raw)
+
+    for key, desired_value in desired.items():
+        if key == "FaceRegister":
+            expected_face = _normalize_boolish(desired_value)
+            actual_face = _face_flag(local)
+            if expected_face is True and actual_face is not True:
+                return False
+            if expected_face is False and actual_face is True:
+                return False
+            continue
+
+        local_value = local.get(key)
+        if _text(local_value) != _text(desired_value):
+            return False
+
+    return True
+
+
 def _schedule_times_out_of_order(spec: Mapping[str, Any]) -> bool:
     start = AkuvoxSchedulesStore._time_to_minutes(spec.get("start"))
     end = AkuvoxSchedulesStore._time_to_minutes(spec.get("end"))
@@ -3914,8 +3946,10 @@ class SyncManager:
                 elif not local:
                     add_batch.append(desired_base)
                 else:
-                    replace = full or str(prof.get("status") or "").lower() == "pending" or any(
-                        str(local.get(k)) != str(v) for k, v in desired_base.items()
+                    replace = (
+                        full
+                        or str(prof.get("status") or "").lower() == "pending"
+                        or not _record_matches_desired_fields(local, desired_base)
                     )
                     if replace or needs_group_move:
                         update_batch.append((ha_key, desired_base, local))

--- a/custom_components/akuvox_ac/tests/test_paused_user_sync.py
+++ b/custom_components/akuvox_ac/tests/test_paused_user_sync.py
@@ -79,3 +79,37 @@ def test_prepare_user_set_payload_keeps_existing_face_url_and_status():
     assert payload.get("FaceUrl") == ""
     assert payload.get("FaceRegisterStatus") == "1"
     assert payload.get("ContactID") == "16"
+
+
+def test_record_matches_desired_fields_treats_face_register_status_as_registered():
+    local = {
+        "UserID": "HA001",
+        "Name": "User One",
+        "FaceUrl": "https://example.invalid/device/Face/HA001.jpg",
+        "FaceRegisterStatus": "1",
+    }
+    desired = {
+        "UserID": "HA001",
+        "Name": "User One",
+        "FaceUrl": "https://example.invalid/device/Face/HA001.jpg",
+        "FaceRegister": 1,
+    }
+
+    assert integration._record_matches_desired_fields(local, desired) is True
+
+
+def test_record_matches_desired_fields_detects_missing_face_registration():
+    local = {
+        "UserID": "HA001",
+        "Name": "User One",
+        "FaceUrl": "https://example.invalid/device/Face/HA001.jpg",
+        "FaceRegisterStatus": "0",
+    }
+    desired = {
+        "UserID": "HA001",
+        "Name": "User One",
+        "FaceUrl": "https://example.invalid/device/Face/HA001.jpg",
+        "FaceRegister": 1,
+    }
+
+    assert integration._record_matches_desired_fields(local, desired) is False

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1149,6 +1149,12 @@ const EVENT_CALL_USER_KEYS = [
 const EVENT_PIN_KEYS = [
   'Pin','PIN','Passcode','Password','Credential','CardNumber','CardNo','digits',
 ];
+const EVENT_USER_ID_KEYS = [
+  'UserID','user_id','UserId','userid','ID','id',
+];
+const EVENT_USER_NAME_KEYS = [
+  'UserName','user_name','userName','Name','name','User','user',
+];
 const EVENT_DETAIL_KEYS = {
   call: [
     'status_label','status','call_type','CallType','CallStatus','CallMode','CallNumber','CallNo','CallNum','number','digits',
@@ -1208,6 +1214,22 @@ function pickFirstEventText(event, keys){
   return '';
 }
 
+function userSummaryForEvent(event){
+  const userId = pickFirstEventText(event, EVENT_USER_ID_KEYS);
+  const userNameRaw = pickFirstEventText(event, EVENT_USER_NAME_KEYS);
+  const userName = userNameRaw && userId && String(userNameRaw).trim() === String(userId).trim() ? '' : userNameRaw;
+  if (userName && userId) return `${userName} (${userId})`;
+  if (userName) return userName;
+  if (userId) return userId;
+  return '';
+}
+
+function isUserUpdateEvent(typeLabel, fallbackMessage){
+  const detail = `${typeLabel || ''} ${fallbackMessage || ''}`.toLowerCase();
+  if (!detail.includes('user')) return false;
+  return /\b(update|updated|edit|edited|modify|modified)\b/.test(detail);
+}
+
 function describeEventForDisplay(event){
   const category = normalizeEventCategory(event && event._category) || categorizeEvent(event);
   const normalizedCategory = category || 'system';
@@ -1251,6 +1273,10 @@ function describeEventForDisplay(event){
   const parts = [label];
   if (device) parts.push(device);
   if (detail) parts.push(detail);
+  if (isUserUpdateEvent(typeLabel, fallbackMessage)) {
+    const userSummary = userSummaryForEvent(event);
+    if (userSummary) parts.push(userSummary);
+  }
   return {
     category: normalizedCategory,
     title: parts.join(' - '),

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1212,6 +1212,12 @@ const EVENT_CALL_USER_KEYS = [
 const EVENT_PIN_KEYS = [
   'Pin','PIN','Passcode','Password','Credential','CardNumber','CardNo','digits',
 ];
+const EVENT_USER_ID_KEYS = [
+  'UserID','user_id','UserId','userid','ID','id',
+];
+const EVENT_USER_NAME_KEYS = [
+  'UserName','user_name','userName','Name','name','User','user',
+];
 const EVENT_DETAIL_KEYS = {
   call: [
     'status_label','status','call_type','CallType','CallStatus','CallMode','CallNumber','CallNo','CallNum','number','digits',
@@ -1284,6 +1290,22 @@ function pickFirstEventText(event, keys){
   return '';
 }
 
+function userSummaryForEvent(event){
+  const userId = pickFirstEventText(event, EVENT_USER_ID_KEYS);
+  const userNameRaw = pickFirstEventText(event, EVENT_USER_NAME_KEYS);
+  const userName = userNameRaw && userId && String(userNameRaw).trim() === String(userId).trim() ? '' : userNameRaw;
+  if (userName && userId) return `${userName} (${userId})`;
+  if (userName) return userName;
+  if (userId) return userId;
+  return '';
+}
+
+function isUserUpdateEvent(typeLabel, fallbackMessage){
+  const detail = `${typeLabel || ''} ${fallbackMessage || ''}`.toLowerCase();
+  if (!detail.includes('user')) return false;
+  return /\b(update|updated|edit|edited|modify|modified)\b/.test(detail);
+}
+
 function describeEventForDisplay(event){
   const category = normalizeEventCategory(event && event._category) || categorizeEvent(event);
   const normalizedCategory = category || 'system';
@@ -1327,6 +1349,10 @@ function describeEventForDisplay(event){
   const parts = [label];
   if (device) parts.push(device);
   if (detail) parts.push(detail);
+  if (isUserUpdateEvent(typeLabel, fallbackMessage)) {
+    const userSummary = userSummaryForEvent(event);
+    if (userSummary) parts.push(userSummary);
+  }
   return {
     category: normalizedCategory,
     title: parts.join(' - '),


### PR DESCRIPTION
### Motivation

- Ensure sync logic treats device-side `FaceRegisterStatus` as equivalent to a desired `FaceRegister` flag so unnecessary updates are avoided.
- Replace a naive per-field string comparison with a dedicated matcher that understands boolean-ish and alternate field names.
- Improve event list readability by including a compact user summary for events that represent user updates.

### Description

- Add `_record_matches_desired_fields` to `integration.py` to compare a local record against a desired payload, treating `FaceRegister` and `FaceRegisterStatus` as equivalent and normalizing text values.  The sync decision now uses this function instead of a blind `str(local.get(k)) != str(v)` check.
- Update sync logic in `SyncManager` to call `_record_matches_desired_fields` when deciding whether to replace/update user records.
- Add two unit tests in `tests/test_paused_user_sync.py` verifying that `FaceRegisterStatus: '1'` is treated as registered and that a `'0'` status is detected as missing.
- Extend the web UI (`www/index.html` and `www/index-mob.html`) with `EVENT_USER_ID_KEYS` and `EVENT_USER_NAME_KEYS`, plus `userSummaryForEvent` and `isUserUpdateEvent` helper functions, and append a user summary to event titles when the event appears to be a user update.

### Testing

- Ran the unit tests in `custom_components/akuvox_ac/tests/test_paused_user_sync.py` including the two new tests and they passed.
- Existing tests in the same module were exercised and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05554bef4832c84fdbe81d4fb6773)