### PR TITLE
fix: recreate users instead of in-place updates

### DIFF
--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -3993,17 +3993,22 @@ class SyncManager:
             except Exception:
                 pass
 
-        # 3) Update changed users (update in place)
+        # 3) Update changed users (delete + recreate to preserve face profile integrity)
         if not add_missing_only:
             for ha_key, desired, existing in update_batch:
                 try:
-                    await self._set_user_on_device(
+                    await self._replace_user_on_device(
                         api,
-                        desired,
                         ha_key,
-                        existing,
-                        storage=getattr(coord, "storage", None),
+                        desired,
+                        existing=existing,
                     )
+                    try:
+                        coord._append_event(  # type: ignore[attr-defined]
+                            f"User {ha_key} recreated from update payload"
+                        )
+                    except Exception:
+                        pass
                 except Exception:
                     latest: Optional[Dict[str, Any]] = None
                     try:


### PR DESCRIPTION
### Motivation
- Device-side in-place `user.set` updates can break face profile linkage, so updates should be performed via delete-and-recreate to preserve face profiles and avoid regressions; Release impact: patch.

### Description
- Replace the reconciliation path that called `_set_user_on_device` (in-place `user.set`) with `_replace_user_on_device` (delete then `user.add`) for update batches. 
- Add an event log entry when a user is recreated from an update payload for visibility into sync activity. 
- Preserve the existing fallback recreate logic for additional resilience when initial attempts fail.

### Testing
- Ran `pytest -q custom_components/akuvox_ac/tests/test_paused_user_sync.py custom_components/akuvox_ac/tests/test_api_face_payload.py` in this environment, which failed due to an environment import error: `ImportError: cannot import name 'UTC' from 'datetime'` (Python 3.10 test-stub issue), so automated tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f058a7255c832c87f4869197d6346a)