### PR TITLE
[codex] Add notification diagnostics view

### DIFF
--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -33,6 +33,7 @@ CALLER_LOOKBACK_SECONDS = 120
 CALLER_CLEAR_DELAY_SECONDS = 10
 CALLER_EVENT_WINDOW_SECONDS = 30
 ACCESS_PERMITTED_NOTIFICATION_WINDOW_SECONDS = 10
+NOTIFICATION_DIAGNOSTICS_LIMIT = 200
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -125,6 +126,9 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         notifications = self.storage.data.get("notifications")
         if not isinstance(notifications, dict):
             self.storage.data["notifications"] = {}
+        notification_diagnostics = self.storage.data.get("notification_diagnostics")
+        if not isinstance(notification_diagnostics, list):
+            self.storage.data["notification_diagnostics"] = []
         alerts_state = self.storage.data.get("alerts_state")
         if not isinstance(alerts_state, dict):
             self.storage.data["alerts_state"] = {}
@@ -343,7 +347,8 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         """Fetch recent door events and handle non-key access notifications."""
 
         notifications = self.storage.data.get("notifications") or {}
-        notify_targets: List[str] = [] if suppress_notifications else list(notifications.get("targets") or [])
+        configured_notify_targets: List[str] = list(notifications.get("targets") or [])
+        notify_targets: List[str] = [] if suppress_notifications else configured_notify_targets
 
         events: List[Dict[str, Any]] = []
 
@@ -411,6 +416,7 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
                     if suppress_notifications:
                         latest_event = dict(latest_event)
                         latest_event["_skip_notifications"] = True
+                        latest_event["_suppressed_notification_targets"] = configured_notify_targets
                     storage_dirty = await self._handle_door_event(latest_event, notify_targets)
                     if storage_dirty:
                         try:
@@ -434,6 +440,7 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             if suppress_notifications:
                 event = dict(event)
                 event["_skip_notifications"] = True
+                event["_suppressed_notification_targets"] = configured_notify_targets
             if await self._handle_door_event(event, notify_targets):
                 storage_dirty = True
             last_processed_key = key
@@ -754,13 +761,50 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
 
         notifications = self.storage.data.get("notifications") or {}
         notify_targets: List[str] = list(notifications.get("targets") or [])
+        notification_diag_dirty = False
         if self._is_access_permitted_button_event(event):
-            if not self._has_recent_door_event(ACCESS_PERMITTED_NOTIFICATION_WINDOW_SECONDS):
+            try:
+                user_id = self._resolve_event_user_id(event)
+            except Exception:
+                user_id = self._extract_event_user_id(event)
+            user_name = self._extract_event_user_name(event)
+            alert_targets = _alert_targets_for_event(
+                self.hass,
+                "user_granted",
+                user_id=user_id,
+            )
+            planned_targets = self._dedupe_notification_target_items(
+                self._notification_target_items(
+                    notify_targets,
+                    channel="access_notification",
+                )
+                + self._notification_target_items(
+                    alert_targets,
+                    channel="alert_notification",
+                )
+            )
+            has_recent_door_event = self._has_recent_door_event(
+                ACCESS_PERMITTED_NOTIFICATION_WINDOW_SECONDS
+            )
+            if not has_recent_door_event:
                 event["_skip_notifications"] = True
                 notify_targets = []
+            notification_diag_dirty = self._record_notification_diagnostic(
+                source="access_permitted_button",
+                channel="decision",
+                event_type="user_granted",
+                status="ready" if has_recent_door_event else "skipped",
+                targets=planned_targets,
+                user_id=user_id,
+                user_name=user_name,
+                event_summary=self._notification_event_summary(event),
+                reason=None
+                if has_recent_door_event
+                else "No recent door event was available for the Access Permitted button.",
+            )
 
         storage_dirty = await self._handle_door_event(event, notify_targets)
-        if storage_dirty:
+        if storage_dirty or notification_diag_dirty:
             try:
                 await self.storage.async_save()
             except Exception as err:
@@ -952,6 +996,14 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             event_kind = "granted"
 
         if event_kind:
+            if skip_notifications and self._record_suppressed_notification_diagnostic(
+                event,
+                event_kind=event_kind,
+                user_id=user_id,
+                summary=summary_text or None,
+                notify_targets=notify_targets,
+            ):
+                storage_changed = True
             self._update_access_state(event_kind, event, user_id=user_id, summary=summary_text or None)
             if event_kind == "granted":
                 manager = self.hass.data.get(DOMAIN, {}).get("sync_manager")
@@ -1532,6 +1584,181 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             summary=summary,
         )
 
+    def _notification_event_summary(self, event: Optional[Dict[str, Any]]) -> str:
+        if not isinstance(event, dict):
+            return ""
+        for key in ("Event", "EventType", "Description", "Message", "Result", "Type"):
+            value = event.get(key)
+            if value in (None, ""):
+                continue
+            text = _safe_str(value).strip()
+            if text:
+                return text
+        return ""
+
+    def _notification_target_items(
+        self,
+        targets: List[Any],
+        *,
+        channel: Optional[str] = None,
+    ) -> List[Dict[str, str]]:
+        items: List[Dict[str, str]] = []
+        for target in targets or []:
+            text = _safe_str(target).strip()
+            if not text:
+                continue
+            item = {
+                "target": text,
+                "target_label": self._format_notification_target(text),
+            }
+            if channel:
+                item["channel"] = channel
+            items.append(item)
+        return items
+
+    @staticmethod
+    def _dedupe_notification_target_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        seen: set[Tuple[str, str]] = set()
+        out: List[Dict[str, Any]] = []
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            target = _safe_str(item.get("target")).strip()
+            if not target:
+                continue
+            channel = _safe_str(item.get("channel")).strip()
+            key = (channel, target)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(dict(item))
+        return out
+
+    def _record_notification_diagnostic(
+        self,
+        *,
+        source: str,
+        channel: str,
+        event_type: str,
+        status: str,
+        target: Optional[Any] = None,
+        targets: Optional[List[Dict[str, Any]]] = None,
+        title: Optional[str] = None,
+        message: Optional[str] = None,
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        event_summary: Optional[str] = None,
+        reason: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> bool:
+        data = getattr(self.storage, "data", None)
+        if not isinstance(data, dict):
+            return False
+
+        diagnostics = data.get("notification_diagnostics")
+        if not isinstance(diagnostics, list):
+            diagnostics = []
+            data["notification_diagnostics"] = diagnostics
+
+        record: Dict[str, Any] = {
+            "timestamp": _now_iso(self.hass),
+            "entry_id": self.entry_id,
+            "device_name": self.device_name,
+            "source": source,
+            "channel": channel,
+            "event_type": event_type,
+            "status": status,
+        }
+
+        target_text = _safe_str(target).strip() if target not in (None, "") else ""
+        if target_text:
+            record["target"] = target_text
+            record["target_label"] = self._format_notification_target(target_text)
+
+        if targets is not None:
+            record["targets"] = self._dedupe_notification_target_items(targets)
+
+        for key, value in (
+            ("title", title),
+            ("message", message),
+            ("user_id", user_id),
+            ("user_name", user_name),
+            ("event_summary", event_summary),
+            ("reason", reason),
+            ("error", error),
+        ):
+            if value in (None, ""):
+                continue
+            record[key] = _safe_str(value)
+
+        diagnostics.insert(0, record)
+        del diagnostics[NOTIFICATION_DIAGNOSTICS_LIMIT:]
+        return True
+
+    def _record_suppressed_notification_diagnostic(
+        self,
+        event: Dict[str, Any],
+        *,
+        event_kind: str,
+        user_id: Optional[str],
+        summary: Optional[str],
+        notify_targets: List[str],
+    ) -> bool:
+        if self._is_access_permitted_button_event(event):
+            return False
+
+        alert_event_type = "user_granted" if event_kind == "granted" else "any_denied"
+        alert_targets = _alert_targets_for_event(
+            self.hass,
+            alert_event_type,
+            user_id=user_id,
+        )
+
+        suppressed_targets_raw = event.get("_suppressed_notification_targets")
+        access_targets: List[str] = []
+        if isinstance(suppressed_targets_raw, (list, tuple, set)):
+            access_targets = [
+                str(target).strip()
+                for target in suppressed_targets_raw
+                if target not in (None, "") and str(target).strip()
+            ]
+        elif isinstance(suppressed_targets_raw, str) and suppressed_targets_raw.strip():
+            access_targets = [suppressed_targets_raw.strip()]
+        elif notify_targets:
+            access_targets = list(notify_targets)
+
+        planned_targets = self._dedupe_notification_target_items(
+            self._notification_target_items(
+                access_targets,
+                channel="access_notification",
+            )
+            + self._notification_target_items(
+                alert_targets,
+                channel="alert_notification",
+            )
+        )
+
+        return self._record_notification_diagnostic(
+            source="suppressed_door_event",
+            channel="decision",
+            event_type=alert_event_type,
+            status="skipped",
+            targets=planned_targets,
+            user_id=user_id,
+            user_name=self._extract_event_user_name(event),
+            event_summary=self._notification_event_summary(event) or summary,
+            reason="Notifications were suppressed for this access history refresh.",
+        )
+
+    async def _async_save_notification_diagnostics(self) -> None:
+        saver = getattr(self.storage, "async_save", None)
+        if not callable(saver):
+            return
+        try:
+            await saver()
+        except Exception as err:
+            _LOGGER.debug("Failed to persist notification diagnostics: %s", _safe_str(err))
+
     async def _dispatch_notification(self, event: Dict[str, Any], notify_targets: List[str]) -> None:
         """Send notifications for a door event (best effort)."""
 
@@ -1540,6 +1767,21 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
 
         service = getattr(self.hass, "services", None)
         if service is None or not hasattr(service, "async_call"):
+            for target in notify_targets:
+                self._record_notification_diagnostic(
+                    source="access_event",
+                    channel="access_notification",
+                    event_type="non_key_access",
+                    status="skipped",
+                    target=target,
+                    title=self.device_name,
+                    message=self._notification_event_summary(event),
+                    user_id=self._extract_event_user_id(event),
+                    user_name=self._extract_event_user_name(event),
+                    event_summary=self._notification_event_summary(event),
+                    reason="Home Assistant notify service was unavailable.",
+                )
+            await self._async_save_notification_diagnostics()
             return
 
         message = _safe_str(event.get("Event") or event.get("EventType") or "Akuvox access granted")
@@ -1549,19 +1791,47 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             "data": {"event": event, "device_name": self.device_name},
         }
 
+        notification_diag_dirty = False
         for target in notify_targets:
             target_label = self._format_notification_target(target)
+            user_label = self._extract_event_user_name(event) or self._extract_event_user_id(event) or "Unknown user"
             try:
                 await service.async_call("notify", target, data, blocking=False)
-                user_label = self._extract_event_user_name(event) or self._extract_event_user_id(event) or "Unknown user"
                 self._append_event(
                     f"System notification sent to {target_label} — {user_label} accessed the gate"
                 )
+                notification_diag_dirty = self._record_notification_diagnostic(
+                    source="access_event",
+                    channel="access_notification",
+                    event_type="non_key_access",
+                    status="sent",
+                    target=target,
+                    title=self.device_name,
+                    message=message,
+                    user_id=self._extract_event_user_id(event),
+                    user_name=user_label,
+                    event_summary=self._notification_event_summary(event),
+                ) or notification_diag_dirty
             except Exception as err:
                 self._append_event(
                     f"System notification failed for {target_label} — {_safe_str(err)}"
                 )
+                notification_diag_dirty = self._record_notification_diagnostic(
+                    source="access_event",
+                    channel="access_notification",
+                    event_type="non_key_access",
+                    status="failed",
+                    target=target,
+                    title=self.device_name,
+                    message=message,
+                    user_id=self._extract_event_user_id(event),
+                    user_name=user_label,
+                    event_summary=self._notification_event_summary(event),
+                    error=_safe_str(err),
+                ) or notification_diag_dirty
                 _LOGGER.debug("Failed to dispatch notification to %s: %s", target, _safe_str(err))
+        if notification_diag_dirty:
+            await self._async_save_notification_diagnostics()
 
     @staticmethod
     def _format_notification_target(target: Any) -> str:
@@ -1622,8 +1892,24 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         title = f"Akuvox • {self.device_name}"
         service = getattr(self.hass, "services", None)
         if not service or not hasattr(service, "async_call"):
+            for target in targets:
+                self._record_notification_diagnostic(
+                    source="system_alert",
+                    channel="alert_notification",
+                    event_type=event_type,
+                    status="skipped",
+                    target=target,
+                    title=title,
+                    message=message,
+                    user_id=user_id,
+                    user_name=who if event_type == "user_granted" else None,
+                    event_summary=summary,
+                    reason="Home Assistant notify service was unavailable.",
+                )
+            await self._async_save_notification_diagnostics()
             return
 
+        notification_diag_dirty = False
         for target in targets:
             try:
                 await service.async_call(
@@ -1632,5 +1918,32 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
                     {"title": title, "message": message, "data": data},
                     blocking=False,
                 )
+                notification_diag_dirty = self._record_notification_diagnostic(
+                    source="system_alert",
+                    channel="alert_notification",
+                    event_type=event_type,
+                    status="sent",
+                    target=target,
+                    title=title,
+                    message=message,
+                    user_id=user_id,
+                    user_name=who if event_type == "user_granted" else None,
+                    event_summary=summary,
+                ) or notification_diag_dirty
             except Exception as err:
+                notification_diag_dirty = self._record_notification_diagnostic(
+                    source="system_alert",
+                    channel="alert_notification",
+                    event_type=event_type,
+                    status="failed",
+                    target=target,
+                    title=title,
+                    message=message,
+                    user_id=user_id,
+                    user_name=who if event_type == "user_granted" else None,
+                    event_summary=summary,
+                    error=_safe_str(err),
+                ) or notification_diag_dirty
                 _LOGGER.debug("Failed to notify %s: %s", target, _safe_str(err))
+        if notification_diag_dirty:
+            await self._async_save_notification_diagnostics()

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -4013,6 +4013,176 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
 
         return results
 
+    @staticmethod
+    def _format_notification_target(target: Any) -> str:
+        raw = str(target or "").strip()
+        if not raw:
+            return "unknown target"
+        normalized = raw
+        if normalized.lower().startswith("mobile_app_"):
+            normalized = normalized[len("mobile_app_") :]
+        normalized = normalized.replace("_", " ").replace(".", " ")
+        normalized = " ".join(part for part in normalized.split() if part)
+        return normalized or raw
+
+    @classmethod
+    def _notification_target_item(
+        cls,
+        target: Any,
+        *,
+        channel: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        text = str(target or "").strip()
+        if not text:
+            return None
+        item: Dict[str, Any] = {
+            "target": text,
+            "target_label": cls._format_notification_target(text),
+        }
+        if channel:
+            item["channel"] = channel
+        return item
+
+    def _notification_rules_snapshot(
+        self,
+        root: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        alert_targets: List[Dict[str, Any]] = []
+        settings = root.get("settings_store")
+        targets: Dict[str, Any] = {}
+        if settings and hasattr(settings, "get_alert_targets"):
+            try:
+                targets = settings.get_alert_targets()
+            except Exception:
+                targets = {}
+        elif settings:
+            data = getattr(settings, "data", {})
+            alerts = data.get("alerts") if isinstance(data, dict) else {}
+            raw_targets = alerts.get("targets") if isinstance(alerts, dict) else {}
+            if isinstance(raw_targets, dict):
+                targets = raw_targets
+
+        if isinstance(targets, dict):
+            for target, cfg in sorted(targets.items(), key=lambda pair: str(pair[0])):
+                item = self._notification_target_item(
+                    target,
+                    channel="alert_notification",
+                )
+                if not item:
+                    continue
+                config = cfg if isinstance(cfg, dict) else {}
+                granted = config.get("granted") if isinstance(config.get("granted"), dict) else {}
+                users_raw = granted.get("users") if isinstance(granted, dict) else []
+                if isinstance(users_raw, (list, tuple, set)):
+                    granted_users = [
+                        str(user).strip()
+                        for user in users_raw
+                        if user not in (None, "") and str(user).strip()
+                    ]
+                elif isinstance(users_raw, str) and users_raw.strip():
+                    granted_users = [users_raw.strip()]
+                else:
+                    granted_users = []
+                item.update(
+                    {
+                        "device_offline": bool(config.get("device_offline")),
+                        "integrity_failed": bool(config.get("integrity_failed")),
+                        "any_denied": bool(config.get("any_denied")),
+                        "granted_any": bool(granted.get("any")),
+                        "granted_users": granted_users,
+                    }
+                )
+                alert_targets.append(item)
+
+        access_targets_by_device: List[Dict[str, Any]] = []
+        manager = root.get("sync_manager")
+        if manager:
+            try:
+                for entry_id, coord, _api, _opts in manager._devices():  # type: ignore[attr-defined]
+                    storage = getattr(coord, "storage", None)
+                    data = getattr(storage, "data", {}) if storage else {}
+                    notifications = data.get("notifications") if isinstance(data, dict) else {}
+                    raw_targets = (
+                        notifications.get("targets")
+                        if isinstance(notifications, dict)
+                        else []
+                    )
+                    target_items: List[Dict[str, Any]] = []
+                    if isinstance(raw_targets, (list, tuple, set)):
+                        for target in raw_targets:
+                            item = self._notification_target_item(
+                                target,
+                                channel="access_notification",
+                            )
+                            if item:
+                                target_items.append(item)
+                    elif isinstance(raw_targets, str) and raw_targets.strip():
+                        item = self._notification_target_item(
+                            raw_targets,
+                            channel="access_notification",
+                        )
+                        if item:
+                            target_items.append(item)
+
+                    name = (
+                        getattr(coord, "display_name", None)
+                        or getattr(coord, "device_name", None)
+                        or entry_id
+                    )
+                    access_targets_by_device.append(
+                        {
+                            "entry_id": entry_id,
+                            "device_name": name,
+                            "targets": target_items,
+                        }
+                    )
+            except Exception as err:  # pragma: no cover - best effort
+                _LOGGER.debug("Failed to assemble notification rules: %s", err)
+
+        return {
+            "alert_targets": alert_targets,
+            "access_targets_by_device": access_targets_by_device,
+        }
+
+    def _notification_diagnostics_snapshot(
+        self,
+        root: Dict[str, Any],
+        limit: int = 200,
+    ) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        manager = root.get("sync_manager")
+        if manager:
+            try:
+                for entry_id, coord, _api, _opts in manager._devices():  # type: ignore[attr-defined]
+                    device_name = (
+                        getattr(coord, "display_name", None)
+                        or getattr(coord, "device_name", None)
+                        or entry_id
+                    )
+                    storage = getattr(coord, "storage", None)
+                    data = getattr(storage, "data", {}) if storage else {}
+                    raw_records = (
+                        data.get("notification_diagnostics")
+                        if isinstance(data, dict)
+                        else []
+                    )
+                    if not isinstance(raw_records, list):
+                        continue
+                    for raw in raw_records:
+                        if not isinstance(raw, dict):
+                            continue
+                        record = self._copy_json(raw)
+                        if not isinstance(record, dict):
+                            continue
+                        record.setdefault("entry_id", entry_id)
+                        record.setdefault("device_name", device_name)
+                        records.append(record)
+            except Exception as err:  # pragma: no cover - best effort
+                _LOGGER.debug("Failed to assemble notification diagnostics: %s", err)
+
+        records.sort(key=lambda item: str(item.get("timestamp") or ""), reverse=True)
+        return records[: max(1, int(limit or 1))]
+
     async def _build_payload(
         self, root: Dict[str, Any], limit_override: Optional[int] = None
     ) -> Dict[str, Any]:
@@ -4119,6 +4289,8 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
             "max_history_limit": max_limit,
             "face_attempts": self._summarize_face_attempts(devices),
             "access_events": aggregated_events,
+            "notification_events": self._notification_diagnostics_snapshot(root),
+            "notification_rules": self._notification_rules_snapshot(root),
             "access_event_limit": access_limit,
             "min_access_event_limit": min_access,
             "max_access_event_limit": max_access,

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -8,6 +8,7 @@ from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
 ensure_homeassistant_stubs()
 
 from custom_components.akuvox_ac.access_history import AccessHistory
+from custom_components.akuvox_ac.const import DOMAIN
 from custom_components.akuvox_ac.coordinator import AkuvoxCoordinator
 
 
@@ -46,6 +47,14 @@ class _ServiceStub:
             raise RuntimeError("push unavailable")
 
 
+class _SettingsStub:
+    def __init__(self, targets: List[str]) -> None:
+        self.targets = list(targets)
+
+    def targets_for_event(self, event_type: str, *, user_id: str | None = None) -> List[str]:
+        return list(self.targets)
+
+
 def _build_coordinator(api, storage) -> AkuvoxCoordinator:
     coord = object.__new__(AkuvoxCoordinator)
     coord.api = api
@@ -54,6 +63,7 @@ def _build_coordinator(api, storage) -> AkuvoxCoordinator:
     coord.device_name = "Akuvox"
     coord.hass = type("H", (), {"data": {}, "loop": None})()
     coord._publish_access_history = lambda events: None  # type: ignore[attr-defined]
+    coord.users = []
     return coord
 
 
@@ -100,6 +110,10 @@ def test_dispatch_notification_appends_system_event_on_success():
         coord.events[0]["Event"]
         == "System notification sent to elles iphone — Neil smalley accessed the gate"
     )
+    diag = storage.data["notification_diagnostics"]
+    assert diag[0]["status"] == "sent"
+    assert diag[0]["channel"] == "access_notification"
+    assert diag[0]["target"] == "mobile_app_elles_iphone"
 
 
 def test_dispatch_notification_appends_system_event_on_failure():
@@ -119,6 +133,86 @@ def test_dispatch_notification_appends_system_event_on_failure():
 
     assert len(coord.events) == 1
     assert coord.events[0]["Event"].startswith("System notification failed for elles iphone —")
+    diag = storage.data["notification_diagnostics"]
+    assert diag[0]["status"] == "failed"
+    assert diag[0]["error"] == "push unavailable"
+
+
+def test_send_alert_notification_records_system_notification():
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.hass.services = _ServiceStub()
+    coord.hass.data = {DOMAIN: {"settings_store": _SettingsStub(["mobile_app_admin_phone"])}}
+
+    asyncio.run(
+        coord._send_alert_notification(
+            "user_granted",
+            user_id="HA007",
+            summary="access granted",
+            extra={"event": {"UserName": "Alice"}},
+        )
+    )
+
+    diag = storage.data["notification_diagnostics"]
+    assert diag[0]["status"] == "sent"
+    assert diag[0]["channel"] == "alert_notification"
+    assert diag[0]["event_type"] == "user_granted"
+    assert diag[0]["message"] == "Alice opened the gate."
+
+
+def test_access_permitted_button_records_would_notify_targets_when_skipped():
+    storage = _StorageStub()
+    storage.data["notifications"] = {"targets": ["mobile_app_gate_phone"]}
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.hass.data = {DOMAIN: {"settings_store": _SettingsStub(["mobile_app_admin_phone"])}}
+    coord._has_recent_door_event = lambda _window: False  # type: ignore[method-assign]
+
+    handled: List[Dict[str, Any]] = []
+
+    async def _handle(event, _targets):
+        handled.append(dict(event))
+        return False
+
+    coord._handle_door_event = _handle  # type: ignore[attr-defined]
+
+    asyncio.run(coord.async_handle_manual_event({"Event": "Access permitted button pressed"}))
+
+    assert handled[0]["_skip_notifications"] is True
+    diag = storage.data["notification_diagnostics"]
+    assert diag[0]["source"] == "access_permitted_button"
+    assert diag[0]["status"] == "skipped"
+    assert [item["target"] for item in diag[0]["targets"]] == [
+        "mobile_app_gate_phone",
+        "mobile_app_admin_phone",
+    ]
+
+
+def test_suppressed_door_event_records_user_specific_notification_targets():
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.hass.data = {DOMAIN: {"settings_store": _SettingsStub(["mobile_app_admin_phone"])}}
+
+    recorded = coord._record_suppressed_notification_diagnostic(
+        {
+            "Event": "Door unlocked",
+            "UserID": "HA007",
+            "UserName": "Alice",
+            "_suppressed_notification_targets": ["mobile_app_gate_phone"],
+        },
+        event_kind="granted",
+        user_id="HA007",
+        summary="door unlocked",
+        notify_targets=[],
+    )
+
+    assert recorded is True
+    diag = storage.data["notification_diagnostics"]
+    assert diag[0]["source"] == "suppressed_door_event"
+    assert diag[0]["user_id"] == "HA007"
+    assert [item["target"] for item in diag[0]["targets"]] == [
+        "mobile_app_gate_phone",
+        "mobile_app_admin_phone",
+    ]
 
 
 def test_process_door_events_skips_events_not_newer_than_last_timestamp():

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -165,6 +165,22 @@
     .diag-event-meta span{ display:inline-flex; align-items:center; gap:0.35rem; }
     .diag-event-empty{ color:var(--muted); font-style:italic; }
     .diag-event-filters .btn{ min-width:72px; }
+    .diag-notification-list{ display:flex; flex-direction:column; gap:0.75rem; }
+    .diag-notification{ border:1px solid #1c2e4f; border-radius:0.75rem; padding:0.85rem 1rem; background:#0b172d; }
+    .diag-notification-title{ display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; font-weight:600; }
+    .diag-notification-meta{ margin-top:0.35rem; color:var(--muted); font-size:0.85rem; display:flex; flex-wrap:wrap; gap:0.65rem; }
+    .diag-notification-meta span{ display:inline-flex; align-items:center; gap:0.35rem; }
+    .diag-target-list{ margin-top:0.65rem; display:flex; gap:0.45rem; flex-wrap:wrap; }
+    .diag-target-chip{ display:inline-flex; align-items:center; gap:0.3rem; border:1px solid #264064; border-radius:999px; padding:0.18rem 0.6rem; color:var(--text); background:rgba(13,110,253,0.14); font-size:0.78rem; }
+    .diag-notification-rules{ display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:0.75rem; }
+    .diag-notification-rule{ border:1px solid #1c2e4f; border-radius:0.75rem; padding:0.85rem 1rem; background:#0b172d; }
+    .diag-notification-rule-title{ font-weight:600; margin-bottom:0.35rem; }
+    .diag-notification-rule-meta{ color:var(--muted); font-size:0.85rem; }
+    .badge.notification-status{ font-size:0.7rem; text-transform:uppercase; letter-spacing:0.05em; }
+    .badge.notification-status.sent{ background:rgba(25,135,84,0.22); color:#2ff0c4; }
+    .badge.notification-status.failed{ background:rgba(220,53,69,0.25); color:#ff7d8a; }
+    .badge.notification-status.skipped{ background:rgba(255,193,7,0.16); color:#ffd86b; }
+    .badge.notification-status.ready{ background:rgba(13,202,240,0.18); color:#9ee7ff; }
     @media (max-width: 768px){
       .diag-container{ max-width:100%; padding:0 1rem; }
       .diag-toggle{ padding:0.85rem 1rem; }
@@ -552,6 +568,7 @@ function openInApp(view, params = {}, options = {}) {
   <div class="nav nav-tabs diag-tabs" id="diagTabNav" role="tablist">
     <button class="nav-link active" type="button" data-tab-target="requests">Request history</button>
     <button class="nav-link" type="button" data-tab-target="events">Event storage</button>
+    <button class="nav-link" type="button" data-tab-target="notifications">Notifications</button>
     <button class="nav-link" type="button" data-tab-target="sync-errors">Device commands</button>
     <button class="nav-link" type="button" data-tab-target="face">Manual diagnostics</button>
   </div>
@@ -611,6 +628,32 @@ function openInApp(view, params = {}, options = {}) {
             <button class="btn btn-sm btn-outline-info" type="button" data-event-filter="call">Call</button>
           </div>
           <div id="eventsList" class="diag-events-list mt-3"></div>
+        </div>
+      </div>
+    </div>
+    <div class="diag-tab-pane" id="tabNotifications" data-tab="notifications" hidden>
+      <div class="diag-settings-card card">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div>
+              <div class="form-label text-uppercase small muted mb-1">Notification diagnostics</div>
+              <div class="h3 mb-0" id="notificationsCount">—</div>
+              <div class="form-text" id="notificationsMeta">—</div>
+            </div>
+            <button class="btn btn-info" type="button" id="btnRefreshNotifications"><i class="bi bi-arrow-clockwise me-1"></i>Refresh</button>
+          </div>
+        </div>
+      </div>
+      <div class="diag-settings-card card">
+        <div class="card-body">
+          <h5 class="mb-2">Current notification rules</h5>
+          <div id="notificationRules" class="diag-notification-rules"></div>
+        </div>
+      </div>
+      <div class="diag-settings-card card">
+        <div class="card-body">
+          <h5 class="mb-2">Notification log</h5>
+          <div id="notificationsList" class="diag-notification-list"></div>
         </div>
       </div>
     </div>
@@ -703,12 +746,19 @@ const eventsLimitHelperEl = document.getElementById('eventsLimitHelper');
 const eventsStatusEl = document.getElementById('eventsStatus');
 const btnRefreshEvents = document.getElementById('btnRefreshEvents');
 const btnOpenEventHistory = document.getElementById('btnOpenEventHistory');
+const notificationsListEl = document.getElementById('notificationsList');
+const notificationsCountEl = document.getElementById('notificationsCount');
+const notificationsMetaEl = document.getElementById('notificationsMeta');
+const notificationRulesEl = document.getElementById('notificationRules');
+const btnRefreshNotifications = document.getElementById('btnRefreshNotifications');
 const syncErrorsListEl = document.getElementById('syncErrorsList');
 const syncTypeFilterHelperEl = document.getElementById('syncTypeFilterHelper');
 let DIAG_DATA = [];
 let FACE_ATTEMPTS = [];
+let NOTIFICATION_EVENTS = [];
+let NOTIFICATION_RULES = { alert_targets: [], access_targets_by_device: [] };
 let ACTIVE_TAB = 'requests';
-const VALID_TABS = Object.freeze(['requests', 'events', 'sync-errors', 'face']);
+const VALID_TABS = Object.freeze(['requests', 'events', 'notifications', 'sync-errors', 'face']);
 let HISTORY_LIMIT = 50;
 let MIN_HISTORY_LIMIT = 10;
 let MAX_HISTORY_LIMIT = 200;
@@ -1693,6 +1743,179 @@ function applyEventsResponse(data){
   updateEventsSummary();
 }
 
+function notificationStatusLabel(status){
+  const value = String(status || '').toLowerCase();
+  if (value === 'sent') return 'Sent';
+  if (value === 'failed') return 'Failed';
+  if (value === 'skipped') return 'Skipped';
+  if (value === 'ready') return 'Would notify';
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : 'Recorded';
+}
+
+function notificationSourceLabel(record){
+  const source = String(record?.source || '').toLowerCase();
+  const channel = String(record?.channel || '').toLowerCase();
+  if (source === 'access_permitted_button') return 'Access permitted button';
+  if (channel === 'access_notification') return 'Access notification';
+  if (channel === 'alert_notification') return 'System alert';
+  return source ? source.replace(/_/g, ' ') : 'Notification';
+}
+
+function notificationEventLabel(record){
+  const raw = record?.event_type || record?.eventType || '';
+  const text = String(raw || '').trim();
+  if (!text) return '';
+  return text.replace(/_/g, ' ');
+}
+
+function notificationTargets(record){
+  const out = [];
+  const targets = Array.isArray(record?.targets) ? record.targets : [];
+  targets.forEach((target) => {
+    if (!target || typeof target !== 'object') return;
+    const label = String(target.target_label || target.label || target.target || '').trim();
+    if (!label) return;
+    const channel = String(target.channel || '').replace(/_/g, ' ');
+    out.push({ label, channel });
+  });
+  const single = String(record?.target_label || record?.target || '').trim();
+  if (single){
+    out.push({ label: single, channel: String(record?.channel || '').replace(/_/g, ' ') });
+  }
+  const seen = new Set();
+  return out.filter((item) => {
+    const key = `${item.channel}:${item.label}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function notificationTargetChips(record){
+  const targets = notificationTargets(record);
+  if (!targets.length){
+    return '<div class="diag-notification-meta"><span><i class="bi bi-bell-slash"></i>No matched notification targets</span></div>';
+  }
+  const chips = targets.map((target) => {
+    const channel = target.channel ? ` <small>${escapeHtml(target.channel)}</small>` : '';
+    return `<span class="diag-target-chip"><i class="bi bi-phone"></i>${escapeHtml(target.label)}${channel}</span>`;
+  }).join('');
+  return `<div class="diag-target-list">${chips}</div>`;
+}
+
+function renderNotificationRules(rules = NOTIFICATION_RULES){
+  if (!notificationRulesEl) return;
+  const alertTargets = Array.isArray(rules?.alert_targets) ? rules.alert_targets : [];
+  const accessDevices = Array.isArray(rules?.access_targets_by_device) ? rules.access_targets_by_device : [];
+  const cards = [];
+
+  alertTargets.forEach((target) => {
+    const bits = [];
+    if (target.device_offline) bits.push('device offline');
+    if (target.integrity_failed) bits.push('integrity failed');
+    if (target.any_denied) bits.push('any denied access');
+    if (target.granted_any) bits.push('any gate open');
+    const users = Array.isArray(target.granted_users) ? target.granted_users.filter(Boolean) : [];
+    if (users.length) bits.push(`specific gate opens: ${users.join(', ')}`);
+    cards.push(`
+      <div class="diag-notification-rule">
+        <div class="diag-notification-rule-title">${escapeHtml(target.target_label || target.target || 'Target')}</div>
+        <div class="diag-notification-rule-meta">${escapeHtml(bits.join(' • ') || 'No enabled alert rules')}</div>
+      </div>
+    `);
+  });
+
+  accessDevices.forEach((device) => {
+    const targets = Array.isArray(device.targets) ? device.targets : [];
+    const chips = targets.length
+      ? targets.map((target) => `<span class="diag-target-chip"><i class="bi bi-phone"></i>${escapeHtml(target.target_label || target.target || 'Target')}</span>`).join('')
+      : '<span class="diag-notification-rule-meta">No access notification targets</span>';
+    cards.push(`
+      <div class="diag-notification-rule">
+        <div class="diag-notification-rule-title">${escapeHtml(device.device_name || device.entry_id || 'Device')}</div>
+        <div class="diag-notification-rule-meta mb-2">Access permitted and non-key access notifications</div>
+        <div class="diag-target-list">${chips}</div>
+      </div>
+    `);
+  });
+
+  notificationRulesEl.innerHTML = cards.length
+    ? cards.join('')
+    : '<div class="diag-event-empty">No notification rules are configured yet.</div>';
+}
+
+function renderNotifications(events = NOTIFICATION_EVENTS){
+  if (!notificationsListEl) return;
+  const list = (Array.isArray(events) ? events : [])
+    .slice()
+    .sort((a, b) => String(b?.timestamp || '').localeCompare(String(a?.timestamp || '')));
+
+  if (!list.length){
+    notificationsListEl.innerHTML = '<div class="diag-event-empty">No notification diagnostics have been recorded yet.</div>';
+    return;
+  }
+
+  notificationsListEl.innerHTML = list.map((record) => {
+    const status = String(record?.status || 'recorded').toLowerCase();
+    const title = record?.event_summary || record?.message || notificationSourceLabel(record);
+    const source = notificationSourceLabel(record);
+    const eventLabel = notificationEventLabel(record);
+    const device = record?.device_name || record?.entry_id || '';
+    const user = record?.user_name || record?.user_id || '';
+    const when = formatDateTime(record?.timestamp);
+    const detail = record?.error || record?.reason || '';
+    const detailHtml = detail ? `<div class="diag-notification-meta"><span><i class="bi bi-info-circle"></i>${escapeHtml(detail)}</span></div>` : '';
+    const eventMeta = eventLabel ? `<span><i class="bi bi-tag"></i>${escapeHtml(eventLabel)}</span>` : '';
+    const userMeta = user ? `<span><i class="bi bi-person-badge"></i>${escapeHtml(user)}</span>` : '';
+    const deviceMeta = device ? `<span><i class="bi bi-hdd-network"></i>${escapeHtml(device)}</span>` : '';
+    return `
+      <div class="diag-notification">
+        <div class="diag-notification-title">
+          <span class="badge notification-status ${escapeHtml(status)}">${escapeHtml(notificationStatusLabel(status))}</span>
+          <span>${escapeHtml(title)}</span>
+        </div>
+        <div class="diag-notification-meta">
+          <span><i class="bi bi-clock-history"></i>${escapeHtml(when)}</span>
+          <span><i class="bi bi-bell"></i>${escapeHtml(source)}</span>
+          ${eventMeta}
+          ${deviceMeta}
+          ${userMeta}
+        </div>
+        ${notificationTargetChips(record)}
+        ${detailHtml}
+      </div>
+    `;
+  }).join('');
+}
+
+function updateNotificationsSummary(){
+  const total = Array.isArray(NOTIFICATION_EVENTS) ? NOTIFICATION_EVENTS.length : 0;
+  if (notificationsCountEl) notificationsCountEl.textContent = String(total);
+  if (notificationsMetaEl){
+    const latest = NOTIFICATION_EVENTS
+      .map((item) => item?.timestamp)
+      .filter(Boolean)
+      .sort()
+      .pop();
+    notificationsMetaEl.textContent = latest ? `Last notification ${formatDateTime(latest)}` : 'No notifications recorded';
+  }
+}
+
+function applyNotificationsResponse(data){
+  if (data && typeof data === 'object'){
+    NOTIFICATION_EVENTS = Array.isArray(data.notification_events) ? data.notification_events : [];
+    NOTIFICATION_RULES = data.notification_rules && typeof data.notification_rules === 'object'
+      ? data.notification_rules
+      : { alert_targets: [], access_targets_by_device: [] };
+  } else {
+    NOTIFICATION_EVENTS = [];
+    NOTIFICATION_RULES = { alert_targets: [], access_targets_by_device: [] };
+  }
+  renderNotificationRules(NOTIFICATION_RULES);
+  renderNotifications(NOTIFICATION_EVENTS);
+  updateNotificationsSummary();
+}
+
 async function requestEventsRefresh(){
   const response = await fetchWithAuth(API_ACTION, {
     method: 'POST',
@@ -1936,6 +2159,7 @@ async function loadDiagnostics(){
     const data = await response.json();
     applyHistoryLimitResponse(data);
     applyEventsResponse(data);
+    applyNotificationsResponse(data);
     setHistoryLimitStatus('');
     DIAG_DATA = Array.isArray(data.devices) ? data.devices : [];
     FACE_ATTEMPTS = Array.isArray(data.face_attempts) ? data.face_attempts : [];
@@ -1999,6 +2223,9 @@ document.addEventListener('DOMContentLoaded', () => {
   btnRefreshEvents?.addEventListener('click', () => {
     refreshAccessEvents();
   });
+  btnRefreshNotifications?.addEventListener('click', () => {
+    loadDiagnostics();
+  });
   btnOpenEventHistory?.addEventListener('click', (ev) => {
     ev.preventDefault();
     openInApp('event_history');
@@ -2008,6 +2235,7 @@ document.addEventListener('DOMContentLoaded', () => {
   updateCommandDeviceOptions(DIAG_DATA);
   renderFaceAttempts(FACE_ATTEMPTS);
   renderSyncErrors(DIAG_DATA);
+  applyNotificationsResponse({});
   syncCommandPayloadState();
   setEventFilter(EVENT_FILTER_MODE);
   setActiveTab(ACTIVE_TAB);

--- a/custom_components/akuvox_ac/www/diagnostics.html
+++ b/custom_components/akuvox_ac/www/diagnostics.html
@@ -165,6 +165,22 @@
     .diag-event-meta span{ display:inline-flex; align-items:center; gap:0.35rem; }
     .diag-event-empty{ color:var(--muted); font-style:italic; }
     .diag-event-filters .btn{ min-width:72px; }
+    .diag-notification-list{ display:flex; flex-direction:column; gap:0.75rem; }
+    .diag-notification{ border:1px solid #1c2e4f; border-radius:0.75rem; padding:0.85rem 1rem; background:#0b172d; }
+    .diag-notification-title{ display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; font-weight:600; }
+    .diag-notification-meta{ margin-top:0.35rem; color:var(--muted); font-size:0.85rem; display:flex; flex-wrap:wrap; gap:0.65rem; }
+    .diag-notification-meta span{ display:inline-flex; align-items:center; gap:0.35rem; }
+    .diag-target-list{ margin-top:0.65rem; display:flex; gap:0.45rem; flex-wrap:wrap; }
+    .diag-target-chip{ display:inline-flex; align-items:center; gap:0.3rem; border:1px solid #264064; border-radius:999px; padding:0.18rem 0.6rem; color:var(--text); background:rgba(13,110,253,0.14); font-size:0.78rem; }
+    .diag-notification-rules{ display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:0.75rem; }
+    .diag-notification-rule{ border:1px solid #1c2e4f; border-radius:0.75rem; padding:0.85rem 1rem; background:#0b172d; }
+    .diag-notification-rule-title{ font-weight:600; margin-bottom:0.35rem; }
+    .diag-notification-rule-meta{ color:var(--muted); font-size:0.85rem; }
+    .badge.notification-status{ font-size:0.7rem; text-transform:uppercase; letter-spacing:0.05em; }
+    .badge.notification-status.sent{ background:rgba(25,135,84,0.22); color:#2ff0c4; }
+    .badge.notification-status.failed{ background:rgba(220,53,69,0.25); color:#ff7d8a; }
+    .badge.notification-status.skipped{ background:rgba(255,193,7,0.16); color:#ffd86b; }
+    .badge.notification-status.ready{ background:rgba(13,202,240,0.18); color:#9ee7ff; }
     @media (max-width: 768px){
       .diag-container{ max-width:100%; padding:0 1rem; }
       .diag-toggle{ padding:0.85rem 1rem; }
@@ -552,6 +568,7 @@ function openInApp(view, params = {}, options = {}) {
   <div class="nav nav-tabs diag-tabs" id="diagTabNav" role="tablist">
     <button class="nav-link active" type="button" data-tab-target="requests">Request history</button>
     <button class="nav-link" type="button" data-tab-target="events">Event storage</button>
+    <button class="nav-link" type="button" data-tab-target="notifications">Notifications</button>
     <button class="nav-link" type="button" data-tab-target="sync-errors">Device commands</button>
     <button class="nav-link" type="button" data-tab-target="face">Manual diagnostics</button>
   </div>
@@ -611,6 +628,32 @@ function openInApp(view, params = {}, options = {}) {
             <button class="btn btn-sm btn-outline-info" type="button" data-event-filter="call">Call</button>
           </div>
           <div id="eventsList" class="diag-events-list mt-3"></div>
+        </div>
+      </div>
+    </div>
+    <div class="diag-tab-pane" id="tabNotifications" data-tab="notifications" hidden>
+      <div class="diag-settings-card card">
+        <div class="card-body">
+          <div class="d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div>
+              <div class="form-label text-uppercase small muted mb-1">Notification diagnostics</div>
+              <div class="h3 mb-0" id="notificationsCount">—</div>
+              <div class="form-text" id="notificationsMeta">—</div>
+            </div>
+            <button class="btn btn-info" type="button" id="btnRefreshNotifications"><i class="bi bi-arrow-clockwise me-1"></i>Refresh</button>
+          </div>
+        </div>
+      </div>
+      <div class="diag-settings-card card">
+        <div class="card-body">
+          <h5 class="mb-2">Current notification rules</h5>
+          <div id="notificationRules" class="diag-notification-rules"></div>
+        </div>
+      </div>
+      <div class="diag-settings-card card">
+        <div class="card-body">
+          <h5 class="mb-2">Notification log</h5>
+          <div id="notificationsList" class="diag-notification-list"></div>
         </div>
       </div>
     </div>
@@ -703,12 +746,19 @@ const eventsLimitHelperEl = document.getElementById('eventsLimitHelper');
 const eventsStatusEl = document.getElementById('eventsStatus');
 const btnRefreshEvents = document.getElementById('btnRefreshEvents');
 const btnOpenEventHistory = document.getElementById('btnOpenEventHistory');
+const notificationsListEl = document.getElementById('notificationsList');
+const notificationsCountEl = document.getElementById('notificationsCount');
+const notificationsMetaEl = document.getElementById('notificationsMeta');
+const notificationRulesEl = document.getElementById('notificationRules');
+const btnRefreshNotifications = document.getElementById('btnRefreshNotifications');
 const syncErrorsListEl = document.getElementById('syncErrorsList');
 const syncTypeFilterHelperEl = document.getElementById('syncTypeFilterHelper');
 let DIAG_DATA = [];
 let FACE_ATTEMPTS = [];
+let NOTIFICATION_EVENTS = [];
+let NOTIFICATION_RULES = { alert_targets: [], access_targets_by_device: [] };
 let ACTIVE_TAB = 'requests';
-const VALID_TABS = Object.freeze(['requests', 'events', 'sync-errors', 'face']);
+const VALID_TABS = Object.freeze(['requests', 'events', 'notifications', 'sync-errors', 'face']);
 let HISTORY_LIMIT = 50;
 let MIN_HISTORY_LIMIT = 10;
 let MAX_HISTORY_LIMIT = 200;
@@ -1693,6 +1743,179 @@ function applyEventsResponse(data){
   updateEventsSummary();
 }
 
+function notificationStatusLabel(status){
+  const value = String(status || '').toLowerCase();
+  if (value === 'sent') return 'Sent';
+  if (value === 'failed') return 'Failed';
+  if (value === 'skipped') return 'Skipped';
+  if (value === 'ready') return 'Would notify';
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : 'Recorded';
+}
+
+function notificationSourceLabel(record){
+  const source = String(record?.source || '').toLowerCase();
+  const channel = String(record?.channel || '').toLowerCase();
+  if (source === 'access_permitted_button') return 'Access permitted button';
+  if (channel === 'access_notification') return 'Access notification';
+  if (channel === 'alert_notification') return 'System alert';
+  return source ? source.replace(/_/g, ' ') : 'Notification';
+}
+
+function notificationEventLabel(record){
+  const raw = record?.event_type || record?.eventType || '';
+  const text = String(raw || '').trim();
+  if (!text) return '';
+  return text.replace(/_/g, ' ');
+}
+
+function notificationTargets(record){
+  const out = [];
+  const targets = Array.isArray(record?.targets) ? record.targets : [];
+  targets.forEach((target) => {
+    if (!target || typeof target !== 'object') return;
+    const label = String(target.target_label || target.label || target.target || '').trim();
+    if (!label) return;
+    const channel = String(target.channel || '').replace(/_/g, ' ');
+    out.push({ label, channel });
+  });
+  const single = String(record?.target_label || record?.target || '').trim();
+  if (single){
+    out.push({ label: single, channel: String(record?.channel || '').replace(/_/g, ' ') });
+  }
+  const seen = new Set();
+  return out.filter((item) => {
+    const key = `${item.channel}:${item.label}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function notificationTargetChips(record){
+  const targets = notificationTargets(record);
+  if (!targets.length){
+    return '<div class="diag-notification-meta"><span><i class="bi bi-bell-slash"></i>No matched notification targets</span></div>';
+  }
+  const chips = targets.map((target) => {
+    const channel = target.channel ? ` <small>${escapeHtml(target.channel)}</small>` : '';
+    return `<span class="diag-target-chip"><i class="bi bi-phone"></i>${escapeHtml(target.label)}${channel}</span>`;
+  }).join('');
+  return `<div class="diag-target-list">${chips}</div>`;
+}
+
+function renderNotificationRules(rules = NOTIFICATION_RULES){
+  if (!notificationRulesEl) return;
+  const alertTargets = Array.isArray(rules?.alert_targets) ? rules.alert_targets : [];
+  const accessDevices = Array.isArray(rules?.access_targets_by_device) ? rules.access_targets_by_device : [];
+  const cards = [];
+
+  alertTargets.forEach((target) => {
+    const bits = [];
+    if (target.device_offline) bits.push('device offline');
+    if (target.integrity_failed) bits.push('integrity failed');
+    if (target.any_denied) bits.push('any denied access');
+    if (target.granted_any) bits.push('any gate open');
+    const users = Array.isArray(target.granted_users) ? target.granted_users.filter(Boolean) : [];
+    if (users.length) bits.push(`specific gate opens: ${users.join(', ')}`);
+    cards.push(`
+      <div class="diag-notification-rule">
+        <div class="diag-notification-rule-title">${escapeHtml(target.target_label || target.target || 'Target')}</div>
+        <div class="diag-notification-rule-meta">${escapeHtml(bits.join(' • ') || 'No enabled alert rules')}</div>
+      </div>
+    `);
+  });
+
+  accessDevices.forEach((device) => {
+    const targets = Array.isArray(device.targets) ? device.targets : [];
+    const chips = targets.length
+      ? targets.map((target) => `<span class="diag-target-chip"><i class="bi bi-phone"></i>${escapeHtml(target.target_label || target.target || 'Target')}</span>`).join('')
+      : '<span class="diag-notification-rule-meta">No access notification targets</span>';
+    cards.push(`
+      <div class="diag-notification-rule">
+        <div class="diag-notification-rule-title">${escapeHtml(device.device_name || device.entry_id || 'Device')}</div>
+        <div class="diag-notification-rule-meta mb-2">Access permitted and non-key access notifications</div>
+        <div class="diag-target-list">${chips}</div>
+      </div>
+    `);
+  });
+
+  notificationRulesEl.innerHTML = cards.length
+    ? cards.join('')
+    : '<div class="diag-event-empty">No notification rules are configured yet.</div>';
+}
+
+function renderNotifications(events = NOTIFICATION_EVENTS){
+  if (!notificationsListEl) return;
+  const list = (Array.isArray(events) ? events : [])
+    .slice()
+    .sort((a, b) => String(b?.timestamp || '').localeCompare(String(a?.timestamp || '')));
+
+  if (!list.length){
+    notificationsListEl.innerHTML = '<div class="diag-event-empty">No notification diagnostics have been recorded yet.</div>';
+    return;
+  }
+
+  notificationsListEl.innerHTML = list.map((record) => {
+    const status = String(record?.status || 'recorded').toLowerCase();
+    const title = record?.event_summary || record?.message || notificationSourceLabel(record);
+    const source = notificationSourceLabel(record);
+    const eventLabel = notificationEventLabel(record);
+    const device = record?.device_name || record?.entry_id || '';
+    const user = record?.user_name || record?.user_id || '';
+    const when = formatDateTime(record?.timestamp);
+    const detail = record?.error || record?.reason || '';
+    const detailHtml = detail ? `<div class="diag-notification-meta"><span><i class="bi bi-info-circle"></i>${escapeHtml(detail)}</span></div>` : '';
+    const eventMeta = eventLabel ? `<span><i class="bi bi-tag"></i>${escapeHtml(eventLabel)}</span>` : '';
+    const userMeta = user ? `<span><i class="bi bi-person-badge"></i>${escapeHtml(user)}</span>` : '';
+    const deviceMeta = device ? `<span><i class="bi bi-hdd-network"></i>${escapeHtml(device)}</span>` : '';
+    return `
+      <div class="diag-notification">
+        <div class="diag-notification-title">
+          <span class="badge notification-status ${escapeHtml(status)}">${escapeHtml(notificationStatusLabel(status))}</span>
+          <span>${escapeHtml(title)}</span>
+        </div>
+        <div class="diag-notification-meta">
+          <span><i class="bi bi-clock-history"></i>${escapeHtml(when)}</span>
+          <span><i class="bi bi-bell"></i>${escapeHtml(source)}</span>
+          ${eventMeta}
+          ${deviceMeta}
+          ${userMeta}
+        </div>
+        ${notificationTargetChips(record)}
+        ${detailHtml}
+      </div>
+    `;
+  }).join('');
+}
+
+function updateNotificationsSummary(){
+  const total = Array.isArray(NOTIFICATION_EVENTS) ? NOTIFICATION_EVENTS.length : 0;
+  if (notificationsCountEl) notificationsCountEl.textContent = String(total);
+  if (notificationsMetaEl){
+    const latest = NOTIFICATION_EVENTS
+      .map((item) => item?.timestamp)
+      .filter(Boolean)
+      .sort()
+      .pop();
+    notificationsMetaEl.textContent = latest ? `Last notification ${formatDateTime(latest)}` : 'No notifications recorded';
+  }
+}
+
+function applyNotificationsResponse(data){
+  if (data && typeof data === 'object'){
+    NOTIFICATION_EVENTS = Array.isArray(data.notification_events) ? data.notification_events : [];
+    NOTIFICATION_RULES = data.notification_rules && typeof data.notification_rules === 'object'
+      ? data.notification_rules
+      : { alert_targets: [], access_targets_by_device: [] };
+  } else {
+    NOTIFICATION_EVENTS = [];
+    NOTIFICATION_RULES = { alert_targets: [], access_targets_by_device: [] };
+  }
+  renderNotificationRules(NOTIFICATION_RULES);
+  renderNotifications(NOTIFICATION_EVENTS);
+  updateNotificationsSummary();
+}
+
 async function requestEventsRefresh(){
   const response = await fetchWithAuth(API_ACTION, {
     method: 'POST',
@@ -1936,6 +2159,7 @@ async function loadDiagnostics(){
     const data = await response.json();
     applyHistoryLimitResponse(data);
     applyEventsResponse(data);
+    applyNotificationsResponse(data);
     setHistoryLimitStatus('');
     DIAG_DATA = Array.isArray(data.devices) ? data.devices : [];
     FACE_ATTEMPTS = Array.isArray(data.face_attempts) ? data.face_attempts : [];
@@ -1999,6 +2223,9 @@ document.addEventListener('DOMContentLoaded', () => {
   btnRefreshEvents?.addEventListener('click', () => {
     refreshAccessEvents();
   });
+  btnRefreshNotifications?.addEventListener('click', () => {
+    loadDiagnostics();
+  });
   btnOpenEventHistory?.addEventListener('click', (ev) => {
     ev.preventDefault();
     openInApp('event_history');
@@ -2008,6 +2235,7 @@ document.addEventListener('DOMContentLoaded', () => {
   updateCommandDeviceOptions(DIAG_DATA);
   renderFaceAttempts(FACE_ATTEMPTS);
   renderSyncErrors(DIAG_DATA);
+  applyNotificationsResponse({});
   syncCommandPayloadState();
   setEventFilter(EVENT_FILTER_MODE);
   setActiveTab(ACTIVE_TAB);


### PR DESCRIPTION
## Summary
- Record diagnostics for Access Permitted notification decisions, suppressed door events, access notifications, and system alert notifications.
- Add notification diagnostics data to the global diagnostics API.
- Add a Notifications tab to desktop and mobile diagnostics views showing configured rules and recent notification events.
- Cover the new diagnostics logging paths with coordinator tests.

## Validation
- Passed: `node -e "const fs=require('fs'); for (const f of ['custom_components/akuvox_ac/www/diagnostics.html','custom_components/akuvox_ac/www/diagnostics-mob.html']) { const html=fs.readFileSync(f,'utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); for (const [i,s] of scripts.entries()) { new Function(s); } console.log(f + ': ok'); }"`
- Not run: Python/pytest suite, because `python`, `py`, and `pytest` are not installed on this machine.