### PR TITLE
[codex] Fix notify on access targets

### DIFF
--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.event import async_call_later
 
 from .const import DOMAIN, EVENT_NON_KEY_ACCESS_GRANTED, DEFAULT_ACCESS_HISTORY_LIMIT
-from .ha_id import normalize_ha_id
+from .ha_id import normalize_ha_id, normalize_user_id
 from .api import AkuvoxAPI
 from .http import (
     _build_phone_index,
@@ -54,12 +54,34 @@ def _now_iso(hass: HomeAssistant) -> str:
     return dt_util.utcnow().isoformat() + "Z"
 
 
+def _canonical_notify_user_id(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    text = _safe_str(value).strip()
+    if not text:
+        return None
+    return normalize_user_id(text) or text
+
+
+def _notify_user_matches(candidate: Any, user_id: Any) -> bool:
+    candidate_text = _canonical_notify_user_id(candidate)
+    user_text = _canonical_notify_user_id(user_id)
+    if not candidate_text or not user_text:
+        return False
+
+    candidate_norm = normalize_user_id(candidate_text)
+    user_norm = normalize_user_id(user_text)
+    if candidate_norm and user_norm:
+        return candidate_norm == user_norm
+    return candidate_text.casefold() == user_text.casefold()
+
+
 def _derive_targets_from_raw(raw: Any, event_type: str, *, user_id: Optional[str] = None) -> List[str]:
     out: List[str] = []
     if not isinstance(raw, dict):
         return out
 
-    norm_user = str(user_id).strip() if user_id not in (None, "") else None
+    norm_user = _canonical_notify_user_id(user_id)
     for target, cfg in raw.items():
         if not isinstance(target, str) or not target:
             continue
@@ -71,19 +93,25 @@ def _derive_targets_from_raw(raw: Any, event_type: str, *, user_id: Optional[str
         elif event_type == "any_denied" and config.get("any_denied"):
             out.append(target)
         elif event_type == "user_granted":
-            granted_cfg = config.get("granted") if isinstance(config.get("granted"), dict) else {}
-            any_flag = bool(granted_cfg.get("any")) if isinstance(granted_cfg, dict) else bool(config.get("granted_any"))
-            users_raw = granted_cfg.get("users") if isinstance(granted_cfg, dict) else config.get("granted_users")
+            granted_cfg = config.get("granted")
+            if isinstance(granted_cfg, dict):
+                any_flag = bool(granted_cfg.get("any"))
+                users_raw = granted_cfg.get("users")
+                specific_flag = bool(granted_cfg.get("specific")) if "specific" in granted_cfg else bool(users_raw)
+            else:
+                any_flag = bool(config.get("granted_any"))
+                users_raw = config.get("granted_users")
+                specific_flag = bool(users_raw)
             if any_flag:
                 out.append(target)
-            elif norm_user and users_raw:
+            elif norm_user and specific_flag and users_raw:
                 if isinstance(users_raw, (list, tuple, set)):
-                    normalized = {str(u).strip() for u in users_raw if str(u).strip()}
+                    normalized = [str(u).strip() for u in users_raw if str(u).strip()]
                 elif isinstance(users_raw, str):
-                    normalized = {users_raw.strip()}
+                    normalized = [users_raw.strip()]
                 else:
-                    normalized = set()
-                if norm_user in normalized:
+                    normalized = []
+                if any(_notify_user_matches(item, norm_user) for item in normalized):
                     out.append(target)
     return out
 
@@ -597,7 +625,7 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         if not raw_text:
             return None
 
-        normalized_raw = normalize_ha_id(raw_text)
+        normalized_raw = normalize_user_id(raw_text)
         resolved = normalized_raw or raw_text
 
         users = self.users if isinstance(self.users, list) else []
@@ -605,14 +633,20 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             return resolved
 
         def _user_id_from_record(record: Dict[str, Any]) -> Optional[str]:
-            for key in ("ID", "UserID", "UserId", "id", "user_id"):
+            for key in ("UserID", "UserId", "user_id", "id"):
                 value = record.get(key)
                 if value in (None, ""):
                     continue
                 text = _safe_str(value).strip()
                 if not text:
                     continue
-                return normalize_ha_id(text) or text
+                return normalize_user_id(text) or text
+
+            device_id = record.get("ID")
+            if device_id not in (None, ""):
+                text = _safe_str(device_id).strip()
+                if text:
+                    return normalize_user_id(text) or text
             return None
 
         for user in users:
@@ -621,23 +655,31 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             user_id = _user_id_from_record(user)
             if not user_id:
                 continue
-            if user_id == resolved:
-                return user_id
-            if normalize_ha_id(user_id) and normalize_ha_id(user_id) == normalized_raw:
-                return user_id
-
-        raw_lower = raw_text.casefold()
-        for user in users:
-            if not isinstance(user, dict):
-                continue
-            user_id = _user_id_from_record(user)
-            if not user_id:
-                continue
-            for key in ("Name", "name", "UserName", "username", "User", "user"):
+            for key in (
+                "ID",
+                "UserID",
+                "UserId",
+                "id",
+                "user_id",
+                "Name",
+                "name",
+                "UserName",
+                "username",
+                "User",
+                "user",
+                "CardNo",
+                "CardNumber",
+            ):
                 value = user.get(key)
                 if value in (None, ""):
                     continue
-                if _safe_str(value).strip().casefold() == raw_lower:
+                text = _safe_str(value).strip()
+                if not text:
+                    continue
+                if text.casefold() == raw_text.casefold():
+                    return user_id
+                candidate_norm = normalize_user_id(text)
+                if candidate_norm and normalized_raw and candidate_norm == normalized_raw:
                     return user_id
 
         return resolved

--- a/custom_components/akuvox_ac/ha_id.py
+++ b/custom_components/akuvox_ac/ha_id.py
@@ -29,7 +29,7 @@ def normalize_ha_id(value: Any) -> Optional[str]:
     if not suffix or not suffix.isdigit():
         return None
 
-    return f"HA{suffix}"
+    return f"HA{int(suffix):03d}"
 
 
 def normalize_temp_id(value: Any) -> Optional[str]:
@@ -57,7 +57,7 @@ def normalize_temp_id(value: Any) -> Optional[str]:
     if not suffix or not suffix.isdigit():
         return None
 
-    return f"TMP{suffix}"
+    return f"TMP{int(suffix):03d}"
 
 
 def normalize_user_id(value: Any) -> Optional[str]:

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -165,6 +165,148 @@ def _coerce_bool(value: Any) -> Optional[bool]:
     return None
 
 
+def _canonical_notify_user_id(value: Any) -> str:
+    try:
+        text = str(value or "").strip()
+    except Exception:
+        return ""
+    if not text:
+        return ""
+    return normalize_user_id(text) or text
+
+
+def _notify_user_matches(candidate: Any, user_id: Any) -> bool:
+    candidate_text = _canonical_notify_user_id(candidate)
+    user_text = _canonical_notify_user_id(user_id)
+    if not candidate_text or not user_text:
+        return False
+
+    candidate_norm = normalize_user_id(candidate_text)
+    user_norm = normalize_user_id(user_text)
+    if candidate_norm and user_norm:
+        return candidate_norm == user_norm
+    return candidate_text.casefold() == user_text.casefold()
+
+
+def _normalize_notify_target_services(raw: Any) -> List[str]:
+    if isinstance(raw, (list, tuple, set)):
+        values = raw
+    elif raw in (None, ""):
+        values = []
+    else:
+        values = [raw]
+
+    out: List[str] = []
+    seen: set[str] = set()
+    for value in values:
+        try:
+            text = str(value or "").strip()
+        except Exception:
+            continue
+        if text.lower().startswith("notify."):
+            text = text.split(".", 1)[1].strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def _sync_notify_on_access_targets(
+    raw_targets: Any,
+    user_id: Any,
+    *,
+    enabled: bool,
+    selected_targets: Any,
+) -> Tuple[Dict[str, Dict[str, Any]], bool]:
+    user_key = _canonical_notify_user_id(user_id)
+    if not user_key:
+        return raw_targets if isinstance(raw_targets, dict) else {}, False
+
+    targets: Dict[str, Dict[str, Any]] = {}
+    if isinstance(raw_targets, dict):
+        for target, cfg in raw_targets.items():
+            if not isinstance(target, str) or not target.strip():
+                continue
+            targets[target] = dict(cfg) if isinstance(cfg, dict) else {}
+
+    selected = set(_normalize_notify_target_services(selected_targets)) if enabled else set()
+    changed = False
+
+    for target in selected:
+        if target not in targets:
+            targets[target] = {}
+            changed = True
+
+    for target, cfg in list(targets.items()):
+        granted = cfg.get("granted") if isinstance(cfg.get("granted"), dict) else {}
+        original_users_raw = granted.get("users") or []
+        if isinstance(original_users_raw, (list, tuple, set)):
+            original_users = [str(item).strip() for item in original_users_raw if str(item or "").strip()]
+        elif isinstance(original_users_raw, str) and original_users_raw.strip():
+            original_users = [original_users_raw.strip()]
+        else:
+            original_users = []
+
+        next_users: List[str] = []
+        removed_user = False
+        for existing in original_users:
+            if _notify_user_matches(existing, user_key):
+                removed_user = True
+                continue
+            if not any(_notify_user_matches(existing, kept) for kept in next_users):
+                next_users.append(existing)
+
+        should_have_user = enabled and target in selected
+        added_user = False
+        if should_have_user and not any(_notify_user_matches(existing, user_key) for existing in next_users):
+            next_users.append(user_key)
+            added_user = True
+
+        if removed_user or added_user:
+            granted["users"] = next_users
+            granted["specific"] = bool(next_users)
+            cfg["granted"] = granted
+            targets[target] = cfg
+            changed = True
+        elif should_have_user and not bool(granted.get("specific")):
+            granted["specific"] = True
+            cfg["granted"] = granted
+            targets[target] = cfg
+            changed = True
+
+    return targets, changed
+
+
+async def _set_notify_on_access_for_user(
+    settings_store: Any,
+    user_id: Any,
+    *,
+    enabled: bool,
+    selected_targets: Any,
+) -> None:
+    if not settings_store or not hasattr(settings_store, "get_alert_targets"):
+        return
+    if not hasattr(settings_store, "set_alert_targets"):
+        return
+    try:
+        targets = settings_store.get_alert_targets()
+        updated, changed = _sync_notify_on_access_targets(
+            targets,
+            user_id,
+            enabled=enabled,
+            selected_targets=selected_targets,
+        )
+        if changed:
+            await settings_store.set_alert_targets(updated)
+    except Exception as err:
+        _LOGGER.debug(
+            "Failed to update notify-on-access targets for %s: %s",
+            _canonical_notify_user_id(user_id) or user_id,
+            err,
+        )
+
+
 def _context_user_name(hass: HomeAssistant, context) -> str:
     """Best-effort friendly name for the actor behind a service/http call."""
 
@@ -2437,10 +2579,13 @@ class AkuvoxSettingsStore(Store):
 
                 users_raw = []
                 specific_flag = False
+                specific_supplied = False
                 if isinstance(granted_cfg, dict):
                     users_raw = granted_cfg.get("users") or []
                     any_flag = bool(granted_cfg.get("any"))
-                    specific_flag = bool(granted_cfg.get("specific"))
+                    if "specific" in granted_cfg:
+                        specific_flag = bool(granted_cfg.get("specific"))
+                        specific_supplied = True
                 else:
                     any_flag = False
 
@@ -2453,7 +2598,7 @@ class AkuvoxSettingsStore(Store):
                 elif isinstance(users_raw, str) and users_raw.strip():
                     users_list = [users_raw.strip()]
 
-                if not specific_flag and users_list:
+                if not specific_supplied and users_list:
                     specific_flag = True
 
                 data["granted"] = {
@@ -2476,7 +2621,7 @@ class AkuvoxSettingsStore(Store):
     def targets_for_event(self, event_type: str, *, user_id: Optional[str] = None) -> List[str]:
         mapping = self.get_alert_targets()
         out: List[str] = []
-        norm_user = str(user_id).strip() if user_id not in (None, "") else None
+        norm_user = _canonical_notify_user_id(user_id)
         for target, cfg in mapping.items():
             if event_type == "device_offline" and cfg.get("device_offline"):
                 out.append(target)
@@ -2488,7 +2633,11 @@ class AkuvoxSettingsStore(Store):
                 granted = cfg.get("granted") or {}
                 if granted.get("any"):
                     out.append(target)
-                elif norm_user and norm_user in (granted.get("users") or []):
+                elif (
+                    norm_user
+                    and granted.get("specific")
+                    and any(_notify_user_matches(user, norm_user) for user in (granted.get("users") or []))
+                ):
                     out.append(target)
         return out
 
@@ -4690,6 +4839,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             exit_permission=d.get("exit_permission"),
         )
 
+        if "notify_on_access" in d or "notify_targets" in d:
+            settings_store: Optional[AkuvoxSettingsStore] = hass.data[DOMAIN].get("settings_store")
+            await _set_notify_on_access_for_user(
+                settings_store,
+                temp_id,
+                enabled=_coerce_bool(d.get("notify_on_access")) is True,
+                selected_targets=d.get("notify_targets"),
+            )
+
         phone_for_contact = str(d.get("phone") or "").strip()
         if phone_for_contact:
             manager: Optional[SyncManager] = hass.data.get(DOMAIN, {}).get("sync_manager")
@@ -4719,16 +4877,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await users_store.async_save()
 
         one_time = bool(d.get("one_time") or d.get("one_time_use") or d.get("one_time_code"))
-        notify_on_access = bool(d.get("notify_on_access"))
-        notify_targets_raw = d.get("notify_targets")
-        notify_targets = []
-        if isinstance(notify_targets_raw, (list, tuple, set)):
-            notify_targets = [
-                str(target).strip()
-                for target in notify_targets_raw
-                if str(target).strip()
-            ]
-        notify_targets = list(dict.fromkeys(notify_targets))
+        notify_on_access = _coerce_bool(d.get("notify_on_access")) is True
         access_start = d.get("access_start")
         access_end = d.get("access_end")
         expires_at = d.get("expires_at") or d.get("temporary_expires_at")
@@ -4754,31 +4903,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             temporary_created_at=dt_util.now(),
         )
 
-        if notify_on_access:
+        if "notify_on_access" in d or "notify_targets" in d:
             settings_store: Optional[AkuvoxSettingsStore] = hass.data[DOMAIN].get("settings_store")
-            if settings_store:
-                targets = settings_store.get_alert_targets()
-                updated = False
-                if notify_targets:
-                    for target in notify_targets:
-                        if target not in targets:
-                            targets[target] = {}
-                            updated = True
-                for target, cfg in targets.items():
-                    if notify_targets and target not in notify_targets:
-                        continue
-                    if not isinstance(cfg, dict):
-                        cfg = {}
-                    granted = cfg.get("granted") if isinstance(cfg.get("granted"), dict) else {}
-                    users = list(granted.get("users") or [])
-                    if temp_id not in users:
-                        users.append(temp_id)
-                        granted["users"] = users
-                        cfg["granted"] = granted
-                        targets[target] = cfg
-                        updated = True
-                if updated:
-                    await settings_store.set_alert_targets(targets)
+            await _set_notify_on_access_for_user(
+                settings_store,
+                temp_id,
+                enabled=notify_on_access,
+                selected_targets=d.get("notify_targets"),
+            )
 
         hass.data[DOMAIN]["sync_queue"].mark_change(
             None,
@@ -4893,6 +5025,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             paused_schedule_id=paused_schedule_id,
             paused_schedule_name=paused_schedule_name,
         )
+
+        if "notify_on_access" in d or "notify_targets" in d:
+            settings_store: Optional[AkuvoxSettingsStore] = hass.data[DOMAIN].get("settings_store")
+            await _set_notify_on_access_for_user(
+                settings_store,
+                effective_id,
+                enabled=_coerce_bool(d.get("notify_on_access")) is True,
+                selected_targets=d.get("notify_targets"),
+            )
 
         if paused_flag is not True:
             old_name = str(existing_profile.get("name") or "").strip()

--- a/custom_components/akuvox_ac/services.yaml
+++ b/custom_components/akuvox_ac/services.yaml
@@ -27,6 +27,15 @@ add_user:
             - match
             - working_days
             - always
+    notify_on_access:
+      required: false
+      selector:
+        boolean:
+    notify_targets:
+      required: false
+      example: ["notify.mobile_app_phone"]
+      selector:
+        object:
     relays:
       required: false
       example: "3"
@@ -133,6 +142,15 @@ edit_user:
             - match
             - working_days
             - always
+    notify_on_access:
+      required: false
+      selector:
+        boolean:
+    notify_targets:
+      required: false
+      example: ["notify.mobile_app_phone"]
+      selector:
+        object:
     face_image_path:
       required: false
       selector:

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -9,7 +9,7 @@ ensure_homeassistant_stubs()
 
 from custom_components.akuvox_ac.access_history import AccessHistory
 from custom_components.akuvox_ac.const import DOMAIN
-from custom_components.akuvox_ac.coordinator import AkuvoxCoordinator
+from custom_components.akuvox_ac.coordinator import AkuvoxCoordinator, _derive_targets_from_raw
 
 
 class _StorageStub:
@@ -148,6 +148,48 @@ def test_resolve_event_user_id_keeps_canonical_id_when_present():
     resolved = coord._resolve_event_user_id({"UserID": "ha005"})
 
     assert resolved == "HA005"
+
+
+def test_resolve_event_user_id_maps_device_row_id_to_canonical_user_id():
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.users = [{"ID": "8011", "UserID": "HA012", "Name": "Walt"}]
+
+    resolved = coord._resolve_event_user_id({"UserID": "8011"})
+
+    assert resolved == "HA012"
+
+
+def test_resolve_event_user_id_prefers_canonical_user_id_for_name_match():
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.users = [{"ID": "8011", "UserID": "HA012", "Name": "Walt"}]
+
+    resolved = coord._resolve_event_user_id({"UserName": "walt"})
+
+    assert resolved == "HA012"
+
+
+def test_derive_targets_from_raw_matches_normalized_specific_user_ids():
+    targets = {
+        "mobile_app_lees_iphone": {
+            "granted": {"specific": True, "users": ["ha-012"]}
+        }
+    }
+
+    assert _derive_targets_from_raw(targets, "user_granted", user_id="HA012") == [
+        "mobile_app_lees_iphone"
+    ]
+
+
+def test_derive_targets_from_raw_ignores_specific_users_when_disabled():
+    targets = {
+        "mobile_app_lees_iphone": {
+            "granted": {"specific": False, "users": ["HA012"]}
+        }
+    }
+
+    assert _derive_targets_from_raw(targets, "user_granted", user_id="HA012") == []
 
 
 def test_dispatch_notification_appends_system_event_on_success():

--- a/custom_components/akuvox_ac/tests/test_ha_id.py
+++ b/custom_components/akuvox_ac/tests/test_ha_id.py
@@ -1,0 +1,21 @@
+from custom_components.akuvox_ac.ha_id import (
+    normalize_ha_id,
+    normalize_temp_id,
+    normalize_user_id,
+)
+
+
+def test_normalize_ha_id_returns_padded_canonical_id():
+    assert normalize_ha_id("HA1") == "HA001"
+    assert normalize_ha_id("ha-12") == "HA012"
+    assert normalize_ha_id("HA123") == "HA123"
+
+
+def test_normalize_temp_id_returns_padded_canonical_id():
+    assert normalize_temp_id("TMP1") == "TMP001"
+    assert normalize_temp_id("tmp-12") == "TMP012"
+
+
+def test_normalize_user_id_prefers_supported_namespaces():
+    assert normalize_user_id("HA7") == "HA007"
+    assert normalize_user_id("TMP7") == "TMP007"

--- a/custom_components/akuvox_ac/tests/test_notify_on_access.py
+++ b/custom_components/akuvox_ac/tests/test_notify_on_access.py
@@ -1,0 +1,87 @@
+from typing import Any, Dict
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac.integration import (  # noqa: E402
+    AkuvoxSettingsStore,
+    _sync_notify_on_access_targets,
+)
+
+
+def _settings_store(targets: Dict[str, Any]) -> AkuvoxSettingsStore:
+    store = object.__new__(AkuvoxSettingsStore)
+    store.data = {"alerts": {"targets": targets}}
+    return store
+
+
+def test_settings_store_matches_normalized_specific_notify_user():
+    store = _settings_store(
+        {
+            "mobile_app_lees_iphone": {
+                "granted": {"specific": True, "users": ["ha-012"]}
+            }
+        }
+    )
+
+    assert store.targets_for_event("user_granted", user_id="HA012") == [
+        "mobile_app_lees_iphone"
+    ]
+
+
+def test_settings_store_preserves_disabled_specific_user_list():
+    store = _settings_store(
+        {
+            "mobile_app_lees_iphone": {
+                "granted": {"specific": False, "users": ["HA012"]}
+            }
+        }
+    )
+
+    cleaned = store.get_alert_targets()
+
+    assert cleaned["mobile_app_lees_iphone"]["granted"]["specific"] is False
+    assert store.targets_for_event("user_granted", user_id="HA012") == []
+
+
+def test_settings_store_treats_legacy_user_list_as_specific():
+    store = _settings_store(
+        {
+            "mobile_app_lees_iphone": {
+                "granted": {"users": ["HA012"]}
+            }
+        }
+    )
+
+    cleaned = store.get_alert_targets()
+
+    assert cleaned["mobile_app_lees_iphone"]["granted"]["specific"] is True
+    assert store.targets_for_event("user_granted", user_id="ha-012") == [
+        "mobile_app_lees_iphone"
+    ]
+
+
+def test_sync_notify_on_access_targets_replaces_per_user_targets():
+    targets = {
+        "mobile_app_lees_iphone": {
+            "granted": {"any": False, "specific": True, "users": ["HA012", "HA099"]}
+        },
+        "mobile_app_verns_iphone": {
+            "granted": {"any": True, "specific": False, "users": []}
+        },
+    }
+
+    updated, changed = _sync_notify_on_access_targets(
+        targets,
+        "ha-012",
+        enabled=True,
+        selected_targets=["notify.mobile_app_verns_iphone"],
+    )
+
+    assert changed is True
+    assert updated["mobile_app_lees_iphone"]["granted"]["users"] == ["HA099"]
+    assert updated["mobile_app_lees_iphone"]["granted"]["specific"] is True
+    assert updated["mobile_app_verns_iphone"]["granted"]["users"] == ["HA012"]
+    assert updated["mobile_app_verns_iphone"]["granted"]["specific"] is True
+    assert updated["mobile_app_verns_iphone"]["granted"]["any"] is True

--- a/custom_components/akuvox_ac/www/face_rec-mob.html
+++ b/custom_components/akuvox_ac/www/face_rec-mob.html
@@ -224,9 +224,9 @@ const API_UPLOAD_FACE = signedPath('upload_face', '/api/akuvox_ac/ui/upload_face
 function qsGet(k){ return new URLSearchParams(location.search).get(k) || ''; }
 function normalizeHaId(value){
   if (!value) return '';
-  const match = String(value).trim().match(/^HA-?(\d{3,})$/i);
+  const match = String(value).trim().match(/^HA-?(\d+)$/i);
   if (!match) return '';
-  return `HA${match[1]}`;
+  return `HA${match[1].padStart(3, '0')}`;
 }
 const RAW_USER_ID = qsGet('user');      // e.g. HA001 or HA-001
 const USER_ID = normalizeHaId(RAW_USER_ID);

--- a/custom_components/akuvox_ac/www/face_rec.html
+++ b/custom_components/akuvox_ac/www/face_rec.html
@@ -224,9 +224,9 @@ const API_UPLOAD_FACE = signedPath('upload_face', '/api/akuvox_ac/ui/upload_face
 function qsGet(k){ return new URLSearchParams(location.search).get(k) || ''; }
 function normalizeHaId(value){
   if (!value) return '';
-  const match = String(value).trim().match(/^HA-?(\d{3,})$/i);
+  const match = String(value).trim().match(/^HA-?(\d+)$/i);
   if (!match) return '';
-  return `HA${match[1]}`;
+  return `HA${match[1].padStart(3, '0')}`;
 }
 const RAW_USER_ID = qsGet('user');      // e.g. HA001 or HA-001
 const USER_ID = normalizeHaId(RAW_USER_ID);

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -884,7 +884,7 @@ function normalizeHaUserId(value){
   let suffix = text.slice(2);
   if (suffix.startsWith('-')) suffix = suffix.slice(1);
   if (!suffix || !/^\d+$/.test(suffix)) return '';
-  return `HA${suffix}`;
+  return `HA${suffix.padStart(3, '0')}`;
 }
 
 function parseHaUserIdNumber(value){
@@ -1523,10 +1523,10 @@ function scheduleDisplayId(rawId){
   if (!Number.isFinite(numeric) || numeric <= 0) return '';
   if (numeric >= 1000){
     const adjusted = numeric - 901;
-    return adjusted > 0 ? `HA${adjusted}` : '';
+    return adjusted > 0 ? `HA${String(adjusted).padStart(3, '0')}` : '';
   }
   if (numeric >= 100){
-    return `HA${numeric}`;
+    return `HA${String(numeric).padStart(3, '0')}`;
   }
   return '';
 }

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -943,7 +943,7 @@ function normalizeHaUserId(value){
   let suffix = text.slice(2);
   if (suffix.startsWith('-')) suffix = suffix.slice(1);
   if (!suffix || !/^\d+$/.test(suffix)) return '';
-  return `HA${suffix}`;
+  return `HA${suffix.padStart(3, '0')}`;
 }
 
 function parseHaUserIdNumber(value){
@@ -1607,10 +1607,10 @@ function scheduleDisplayId(rawId){
   if (!Number.isFinite(numeric) || numeric <= 0) return '';
   if (numeric >= 1000){
     const adjusted = numeric - 901;
-    return adjusted > 0 ? `HA${adjusted}` : '';
+    return adjusted > 0 ? `HA${String(adjusted).padStart(3, '0')}` : '';
   }
   if (numeric >= 100){
-    return `HA${numeric}`;
+    return `HA${String(numeric).padStart(3, '0')}`;
   }
   return '';
 }

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -916,6 +916,19 @@ function friendlyName(service){
   return service;
 }
 
+function normalizedUserKey(value){
+  const text = String(value ?? '').trim();
+  const match = text.match(/^(HA|TMP)-?(\d+)$/i);
+  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  return text.toLowerCase();
+}
+
+function grantedUsersInclude(users, userId){
+  const key = normalizedUserKey(userId);
+  if (!key || !Array.isArray(users)) return false;
+  return users.some(item => normalizedUserKey(item) === key);
+}
+
 function ensureTargetDefaults(target){
   if (!ALERT_TARGETS[target] || typeof ALERT_TARGETS[target] !== 'object'){
     ALERT_TARGETS[target] = {
@@ -1132,7 +1145,7 @@ function renderAlerts(){
         const row = document.createElement('div');
         row.className = 'form-check';
         row.innerHTML = `
-          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="granted_users" data-user-id="${userId}" ${cfg.granted.users.includes(userId) ? 'checked' : ''}>
+          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="granted_users" data-user-id="${userId}" ${grantedUsersInclude(cfg.granted.users, userId) ? 'checked' : ''}>
           <label class="form-check-label">${user.name} (${userId})</label>
         `;
         list.appendChild(row);

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -919,7 +919,7 @@ function friendlyName(service){
 function normalizedUserKey(value){
   const text = String(value ?? '').trim();
   const match = text.match(/^(HA|TMP)-?(\d+)$/i);
-  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  if (match) return `${match[1].toUpperCase()}${match[2].padStart(3, '0')}`.toLowerCase();
   return text.toLowerCase();
 }
 

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -918,6 +918,19 @@ function friendlyName(service){
   return service;
 }
 
+function normalizedUserKey(value){
+  const text = String(value ?? '').trim();
+  const match = text.match(/^(HA|TMP)-?(\d+)$/i);
+  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  return text.toLowerCase();
+}
+
+function grantedUsersInclude(users, userId){
+  const key = normalizedUserKey(userId);
+  if (!key || !Array.isArray(users)) return false;
+  return users.some(item => normalizedUserKey(item) === key);
+}
+
 function ensureTargetDefaults(target){
   if (!ALERT_TARGETS[target] || typeof ALERT_TARGETS[target] !== 'object'){
     ALERT_TARGETS[target] = {
@@ -1134,7 +1147,7 @@ function renderAlerts(){
         const row = document.createElement('div');
         row.className = 'form-check';
         row.innerHTML = `
-          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="granted_users" data-user-id="${userId}" ${cfg.granted.users.includes(userId) ? 'checked' : ''}>
+          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="granted_users" data-user-id="${userId}" ${grantedUsersInclude(cfg.granted.users, userId) ? 'checked' : ''}>
           <label class="form-check-label">${user.name} (${userId})</label>
         `;
         list.appendChild(row);

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -921,7 +921,7 @@ function friendlyName(service){
 function normalizedUserKey(value){
   const text = String(value ?? '').trim();
   const match = text.match(/^(HA|TMP)-?(\d+)$/i);
-  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  if (match) return `${match[1].toUpperCase()}${match[2].padStart(3, '0')}`.toLowerCase();
   return text.toLowerCase();
 }
 

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -806,7 +806,7 @@ function normalizeHaUserId(value){
   let suffix = text.slice(2);
   if (suffix.startsWith('-')) suffix = suffix.slice(1);
   if (!suffix || !/^\d+$/.test(suffix)) return '';
-  return `HA${suffix}`;
+  return `HA${suffix.padStart(3, '0')}`;
 }
 
 function parseHaUserIdNumber(value){
@@ -1090,7 +1090,7 @@ function scheduleDisplayId(rawId){
   if (!Number.isFinite(numeric) || numeric <= 0) return '';
   const suffix = numeric >= 1000 ? numeric - 1000 : numeric;
   if (suffix <= 0) return '';
-  return `HA${suffix}`;
+  return `HA${String(suffix).padStart(3, '0')}`;
 }
 
 function formatScheduleDisplay(rawId, label){

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -951,7 +951,7 @@ function escapeHtml(value){
 function normalizedUserKey(value){
   const text = String(value ?? '').trim();
   const match = text.match(/^(HA|TMP)-?(\d+)$/i);
-  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  if (match) return `${match[1].toUpperCase()}${match[2].padStart(3, '0')}`.toLowerCase();
   return text.toLowerCase();
 }
 
@@ -1366,7 +1366,7 @@ function selectExistingUser(id, options = {}){
 }
 
 // ---------- schedule id mapping helpers ----------
-let SCHED_MAP = []; // [{id:"1001", name:"24/7 Access", label:"24/7 Access", display:"HA1 - 24/7 Access"}, ...]
+let SCHED_MAP = []; // [{id:"1001", name:"24/7 Access", label:"24/7 Access", display:"HA001 - 24/7 Access"}, ...]
 
 function scheduleDisplayId(rawId){
   const text = String(rawId ?? '').trim();
@@ -1375,10 +1375,10 @@ function scheduleDisplayId(rawId){
   if (!Number.isFinite(numeric) || numeric <= 0) return '';
   if (numeric >= 1000){
     const adjusted = numeric - 901;
-    return adjusted > 0 ? `HA${adjusted}` : '';
+    return adjusted > 0 ? `HA${String(adjusted).padStart(3, '0')}` : '';
   }
   if (numeric >= 100){
-    return `HA${numeric}`;
+    return `HA${String(numeric).padStart(3, '0')}`;
   }
   return '';
 }

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -949,7 +949,10 @@ function escapeHtml(value){
 }
 
 function normalizedUserKey(value){
-  return String(value ?? '').trim().toLowerCase();
+  const text = String(value ?? '').trim();
+  const match = text.match(/^(HA|TMP)-?(\d+)$/i);
+  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  return text.toLowerCase();
 }
 
 function isRegistryUser(userId){
@@ -1489,11 +1492,14 @@ function allNotifyTargets(){
 
 function getNotifyTargetsForUser(userId){
   if (!userId) return [];
+  const userKey = normalizedUserKey(userId);
   const out = [];
   Object.keys(ALERT_TARGETS || {}).forEach(service => {
     ensureAlertTargetDefaults(service);
-    const users = ALERT_TARGETS[service].granted.users || [];
-    if (users.includes(userId)) out.push(service);
+    const granted = ALERT_TARGETS[service].granted || {};
+    if (granted.specific === false) return;
+    const users = granted.users || [];
+    if (users.some(item => normalizedUserKey(item) === userKey)) out.push(service);
   });
   return out;
 }
@@ -2173,6 +2179,8 @@ function fillPhones(){
 
 function applyNotifyTargetsForUser(userId, selectedServices, enabled){
   if (!userId) return;
+  const userKey = normalizedUserKey(userId);
+  const storedUserId = String(userId || '').trim();
   const selected = new Set(enabled ? (selectedServices || []) : []);
   const allTargets = new Set([
     ...Object.keys(ALERT_TARGETS || {}),
@@ -2183,24 +2191,32 @@ function applyNotifyTargetsForUser(userId, selectedServices, enabled){
     const users = Array.isArray(ALERT_TARGETS[service].granted.users)
       ? [...ALERT_TARGETS[service].granted.users]
       : [];
-    const hasUser = users.includes(userId);
+    const filtered = users.filter(item => normalizedUserKey(item) !== userKey);
+    const hasUser = filtered.length !== users.length;
     const shouldHave = selected.has(service);
-    if (shouldHave && !hasUser) users.push(userId);
-    if (!shouldHave && hasUser) {
-      ALERT_TARGETS[service].granted.users = users.filter(u => u !== userId);
-    } else {
-      ALERT_TARGETS[service].granted.users = users;
+    if (shouldHave) filtered.push(storedUserId);
+    ALERT_TARGETS[service].granted.users = filtered;
+    if (shouldHave || hasUser) {
+      ALERT_TARGETS[service].granted.specific = filtered.length > 0;
     }
   });
 }
 
-async function saveNotifyTargets(){
-  if (!CURRENT || !CURRENT.id) return;
+function collectNotifySelection(){
+  if (!CURRENT || !CURRENT.id) return { enabled: false, targets: [] };
   const toggle = document.getElementById('notify_on_access');
   const enabled = !!(toggle && toggle.checked);
   const selected = enabled
     ? Array.from(document.querySelectorAll('input[data-notify-target]:checked')).map(el => el.dataset.notifyTarget)
     : [];
+  return { enabled, targets: selected.filter(Boolean) };
+}
+
+async function saveNotifyTargets(){
+  if (!CURRENT || !CURRENT.id) return;
+  const selection = collectNotifySelection();
+  const enabled = selection.enabled;
+  const selected = selection.targets;
   applyNotifyTargetsForUser(CURRENT.id, selected, enabled);
   CURRENT.notify_targets = selected;
   await apiPost(API_SETTINGS, { alerts: { targets: ALERT_TARGETS } });
@@ -2290,6 +2306,10 @@ async function save(){
     CURRENT.access_start = payload.access_start;
     CURRENT.access_end = payload.access_end;
 
+    const notifySelection = collectNotifySelection();
+    payload.notify_on_access = notifySelection.enabled;
+    payload.notify_targets = notifySelection.targets;
+
     // Save/update the profile against the reserved ID
     const saveRes = await fetchWithAuth(API_EDIT_USER, {
       method:'POST',
@@ -2304,12 +2324,8 @@ async function save(){
     }
     try { await saveRes.json(); } catch {}
 
-    try {
-      await saveNotifyTargets();
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      alert('Failed to update access notifications: ' + (err && err.message ? err.message : err));
-    }
+    applyNotifyTargetsForUser(CURRENT.id, notifySelection.targets, notifySelection.enabled);
+    CURRENT.notify_targets = notifySelection.targets;
 
     // If a photo is selected, upload it now
     const fileInput = document.getElementById('facefile');

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -951,7 +951,10 @@ function escapeHtml(value){
 }
 
 function normalizedUserKey(value){
-  return String(value ?? '').trim().toLowerCase();
+  const text = String(value ?? '').trim();
+  const match = text.match(/^(HA|TMP)-?(\d+)$/i);
+  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  return text.toLowerCase();
 }
 
 function isRegistryUser(userId){
@@ -1491,11 +1494,14 @@ function allNotifyTargets(){
 
 function getNotifyTargetsForUser(userId){
   if (!userId) return [];
+  const userKey = normalizedUserKey(userId);
   const out = [];
   Object.keys(ALERT_TARGETS || {}).forEach(service => {
     ensureAlertTargetDefaults(service);
-    const users = ALERT_TARGETS[service].granted.users || [];
-    if (users.includes(userId)) out.push(service);
+    const granted = ALERT_TARGETS[service].granted || {};
+    if (granted.specific === false) return;
+    const users = granted.users || [];
+    if (users.some(item => normalizedUserKey(item) === userKey)) out.push(service);
   });
   return out;
 }
@@ -2175,6 +2181,8 @@ function fillPhones(){
 
 function applyNotifyTargetsForUser(userId, selectedServices, enabled){
   if (!userId) return;
+  const userKey = normalizedUserKey(userId);
+  const storedUserId = String(userId || '').trim();
   const selected = new Set(enabled ? (selectedServices || []) : []);
   const allTargets = new Set([
     ...Object.keys(ALERT_TARGETS || {}),
@@ -2185,24 +2193,32 @@ function applyNotifyTargetsForUser(userId, selectedServices, enabled){
     const users = Array.isArray(ALERT_TARGETS[service].granted.users)
       ? [...ALERT_TARGETS[service].granted.users]
       : [];
-    const hasUser = users.includes(userId);
+    const filtered = users.filter(item => normalizedUserKey(item) !== userKey);
+    const hasUser = filtered.length !== users.length;
     const shouldHave = selected.has(service);
-    if (shouldHave && !hasUser) users.push(userId);
-    if (!shouldHave && hasUser) {
-      ALERT_TARGETS[service].granted.users = users.filter(u => u !== userId);
-    } else {
-      ALERT_TARGETS[service].granted.users = users;
+    if (shouldHave) filtered.push(storedUserId);
+    ALERT_TARGETS[service].granted.users = filtered;
+    if (shouldHave || hasUser) {
+      ALERT_TARGETS[service].granted.specific = filtered.length > 0;
     }
   });
 }
 
-async function saveNotifyTargets(){
-  if (!CURRENT || !CURRENT.id) return;
+function collectNotifySelection(){
+  if (!CURRENT || !CURRENT.id) return { enabled: false, targets: [] };
   const toggle = document.getElementById('notify_on_access');
   const enabled = !!(toggle && toggle.checked);
   const selected = enabled
     ? Array.from(document.querySelectorAll('input[data-notify-target]:checked')).map(el => el.dataset.notifyTarget)
     : [];
+  return { enabled, targets: selected.filter(Boolean) };
+}
+
+async function saveNotifyTargets(){
+  if (!CURRENT || !CURRENT.id) return;
+  const selection = collectNotifySelection();
+  const enabled = selection.enabled;
+  const selected = selection.targets;
   applyNotifyTargetsForUser(CURRENT.id, selected, enabled);
   CURRENT.notify_targets = selected;
   await apiPost(API_SETTINGS, { alerts: { targets: ALERT_TARGETS } });
@@ -2292,6 +2308,10 @@ async function save(){
     CURRENT.access_start = payload.access_start;
     CURRENT.access_end = payload.access_end;
 
+    const notifySelection = collectNotifySelection();
+    payload.notify_on_access = notifySelection.enabled;
+    payload.notify_targets = notifySelection.targets;
+
     // Save/update the profile against the reserved ID
     const saveRes = await fetchWithAuth(API_EDIT_USER, {
       method:'POST',
@@ -2306,12 +2326,8 @@ async function save(){
     }
     try { await saveRes.json(); } catch {}
 
-    try {
-      await saveNotifyTargets();
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      alert('Failed to update access notifications: ' + (err && err.message ? err.message : err));
-    }
+    applyNotifyTargetsForUser(CURRENT.id, notifySelection.targets, notifySelection.enabled);
+    CURRENT.notify_targets = notifySelection.targets;
 
     // If a photo is selected, upload it now
     const fileInput = document.getElementById('facefile');

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -953,7 +953,7 @@ function escapeHtml(value){
 function normalizedUserKey(value){
   const text = String(value ?? '').trim();
   const match = text.match(/^(HA|TMP)-?(\d+)$/i);
-  if (match) return `${match[1].toUpperCase()}${match[2]}`.toLowerCase();
+  if (match) return `${match[1].toUpperCase()}${match[2].padStart(3, '0')}`.toLowerCase();
   return text.toLowerCase();
 }
 
@@ -1368,7 +1368,7 @@ function selectExistingUser(id, options = {}){
 }
 
 // ---------- schedule id mapping helpers ----------
-let SCHED_MAP = []; // [{id:"1001", name:"24/7 Access", label:"24/7 Access", display:"HA1 - 24/7 Access"}, ...]
+let SCHED_MAP = []; // [{id:"1001", name:"24/7 Access", label:"24/7 Access", display:"HA001 - 24/7 Access"}, ...]
 
 function scheduleDisplayId(rawId){
   const text = String(rawId ?? '').trim();
@@ -1377,10 +1377,10 @@ function scheduleDisplayId(rawId){
   if (!Number.isFinite(numeric) || numeric <= 0) return '';
   if (numeric >= 1000){
     const adjusted = numeric - 901;
-    return adjusted > 0 ? `HA${adjusted}` : '';
+    return adjusted > 0 ? `HA${String(adjusted).padStart(3, '0')}` : '';
   }
   if (numeric >= 100){
-    return `HA${numeric}`;
+    return `HA${String(numeric).padStart(3, '0')}`;
   }
   return '';
 }


### PR DESCRIPTION
## Summary
- Saves notify-on-access selections through the backend user services so the web form and backend alert target map stay in sync.
- Resolves access events from Akuvox device row IDs, stored device-ID mappings, local registry names, or live device users back to the canonical Home Assistant user ID before matching notification targets.
- Honors the global settings "Specific User Granted Access" toggle when resolving alerts, and normalizes HA/TMP IDs in the relevant UI comparisons.
- Canonicalizes Home Assistant user IDs to padded `HA001` format and updates UI display/entry helpers to match.

## Root Cause
The user edit page updated alert target settings separately from the user edit service, while backend access-event matching only compared exact IDs. Events that arrived with a device-local row ID such as `8124`, or only a friendly name such as `Daniel Gallagher (Geeves)`, could miss a configured `HA004` rule when the live device user list was unavailable during a suppressed access-history refresh. Diagnostics would then show "No matched notification targets" even though the current rules listed the right HA user.

## Validation
- Passed: `git diff --check`
- Passed: JavaScript syntax parse for updated UI pages with Node
- Not run: Python/pytest suite because `python`, `py`, and `pytest` are not installed on this machine.