### PR TITLE
[codex] Prune stale notification users

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -3495,6 +3495,8 @@ class AkuvoxUISettings(HomeAssistantView):
             except Exception:
                 access_bounds = (MIN_ACCESS_HISTORY_LIMIT, MAX_ACCESS_HISTORY_LIMIT)
             try:
+                if users_store and hasattr(settings, "prune_stale_alert_users"):
+                    await settings.prune_stale_alert_users(users_store)
                 alerts = {"targets": settings.get_alert_targets()}
             except Exception:
                 data = getattr(settings, "data", {})
@@ -3511,6 +3513,9 @@ class AkuvoxUISettings(HomeAssistantView):
                     if not canonical:
                         continue
                     if _profile_is_empty_reserved(prof):
+                        continue
+                    status = str((prof or {}).get("status") or "").strip().lower()
+                    if status == "deleted":
                         continue
                     name = prof.get("name") or canonical
                     registry_users.append({"id": canonical, "name": name})
@@ -3581,6 +3586,7 @@ class AkuvoxUISettings(HomeAssistantView):
             payload = {}
 
         settings = root.get("settings_store")
+        users_store = root.get("users_store")
         manager = root.get("sync_manager")
         queue = root.get("sync_queue")
 
@@ -3686,6 +3692,8 @@ class AkuvoxUISettings(HomeAssistantView):
             targets = alerts_payload.get("targets") if isinstance(alerts_payload, dict) else {}
             try:
                 await settings.set_alert_targets(targets)
+                if users_store and hasattr(settings, "prune_stale_alert_users"):
+                    await settings.prune_stale_alert_users(users_store)
                 response["alerts"] = {"targets": settings.get_alert_targets()}
             except Exception as err:
                 return web.json_response({"ok": False, "error": str(err)}, status=400)
@@ -4228,6 +4236,13 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
                 _LOGGER.debug("Failed to assemble diagnostics payload: %s", err)
 
         settings_store = root.get("settings_store")
+        users_store = root.get("users_store")
+        if settings_store and users_store and hasattr(settings_store, "prune_stale_alert_users"):
+            try:
+                await settings_store.prune_stale_alert_users(users_store)
+            except Exception:
+                pass
+
         access_limit = DEFAULT_ACCESS_HISTORY_LIMIT
         access_bounds = (MIN_ACCESS_HISTORY_LIMIT, MAX_ACCESS_HISTORY_LIMIT)
         if settings_store and hasattr(settings_store, "get_access_history_limit"):

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -278,6 +278,81 @@ def _sync_notify_on_access_targets(
     return targets, changed
 
 
+def _active_notification_user_ids(users_store: Any) -> Set[str]:
+    """Return user IDs still present in the local user table."""
+
+    if not users_store or not hasattr(users_store, "all"):
+        return set()
+    try:
+        users = users_store.all() or {}
+    except Exception:
+        return set()
+    if not isinstance(users, Mapping):
+        return set()
+
+    active: Set[str] = set()
+    for key, profile in users.items():
+        canonical = normalize_user_id(key)
+        if not canonical:
+            continue
+        if not isinstance(profile, Mapping):
+            continue
+        if _profile_is_empty_reserved(profile):
+            continue
+        status = str(profile.get("status") or "").strip().lower()
+        if status == "deleted":
+            continue
+        active.add(canonical)
+    return active
+
+
+def _prune_notify_targets_to_users(
+    raw_targets: Any,
+    active_user_ids: Set[str],
+) -> Tuple[Dict[str, Dict[str, Any]], bool]:
+    targets: Dict[str, Dict[str, Any]] = {}
+    if isinstance(raw_targets, dict):
+        for target, cfg in raw_targets.items():
+            if not isinstance(target, str) or not target.strip():
+                continue
+            targets[target] = dict(cfg) if isinstance(cfg, dict) else {}
+
+    changed = False
+    for target, cfg in list(targets.items()):
+        granted = cfg.get("granted") if isinstance(cfg.get("granted"), dict) else {}
+        original_users_raw = granted.get("users") or []
+        if isinstance(original_users_raw, (list, tuple, set)):
+            original_users = [
+                str(item).strip() for item in original_users_raw if str(item or "").strip()
+            ]
+        elif isinstance(original_users_raw, str) and original_users_raw.strip():
+            original_users = [original_users_raw.strip()]
+        else:
+            original_users = []
+
+        next_users: List[str] = []
+        seen: Set[str] = set()
+        for user in original_users:
+            canonical = normalize_user_id(user)
+            if not canonical or canonical not in active_user_ids or canonical in seen:
+                changed = True
+                continue
+            if canonical != user:
+                changed = True
+            seen.add(canonical)
+            next_users.append(canonical)
+
+        if next_users != original_users:
+            changed = True
+            granted["users"] = next_users
+            if not next_users:
+                granted["specific"] = False
+            cfg["granted"] = granted
+            targets[target] = cfg
+
+    return targets, changed
+
+
 async def _set_notify_on_access_for_user(
     settings_store: Any,
     user_id: Any,
@@ -2618,6 +2693,14 @@ class AkuvoxSettingsStore(Store):
         self.data.setdefault("alerts", {})["targets"] = self._sanitize_alert_targets(targets)
         await self.async_save()
 
+    async def prune_stale_alert_users(self, users_store: Any) -> bool:
+        active_user_ids = _active_notification_user_ids(users_store)
+        targets = self.get_alert_targets()
+        updated, changed = _prune_notify_targets_to_users(targets, active_user_ids)
+        if changed:
+            await self.set_alert_targets(updated)
+        return changed
+
     def targets_for_event(self, event_type: str, *, user_id: Optional[str] = None) -> List[str]:
         mapping = self.get_alert_targets()
         out: List[str] = []
@@ -3230,6 +3313,18 @@ class SyncManager:
     def _settings_store(self) -> AkuvoxSettingsStore:
         return self._root().get("settings_store")
 
+    async def _prune_stale_alert_users(self) -> None:
+        settings = self._settings_store()
+        users_store = self._users_store()
+        if not settings or not users_store:
+            return
+        if not hasattr(settings, "prune_stale_alert_users"):
+            return
+        try:
+            await settings.prune_stale_alert_users(users_store)
+        except Exception:
+            pass
+
     def _devices(self) -> List[Tuple[str, AkuvoxCoordinator, AkuvoxAPI, Dict[str, Any]]]:
         out: List[Tuple[str, AkuvoxCoordinator, AkuvoxAPI, Dict[str, Any]]] = []
         for k, v in self._root().items():
@@ -3828,6 +3923,7 @@ class SyncManager:
         except Exception:
             registry_all = {}
 
+        removed_profile = False
         for key, profile in (registry_all or {}).items():
             status_raw = str((profile or {}).get("status") or "").strip().lower()
             if status_raw != "deleted":
@@ -3837,8 +3933,12 @@ class SyncManager:
             if canonical and canonical not in active_device_keys:
                 try:
                     await users_store.delete(canonical)
+                    removed_profile = True
                 except Exception:
                     continue
+
+        if removed_profile:
+            await self._prune_stale_alert_users()
 
     async def _push_schedules(self, api: AkuvoxAPI, schedules: Dict[str, Any]):
         if not schedules:
@@ -4026,6 +4126,7 @@ class SyncManager:
                         )
                     except Exception:
                         pass
+                await self._prune_stale_alert_users()
 
             await self._remove_missing_users(api, local_users, reg_key_set)
 
@@ -4524,6 +4625,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         settings = AkuvoxSettingsStore(hass)
         await settings.async_load()
         root["settings_store"] = settings
+
+    settings_store = root.get("settings_store")
+    users_store = root.get("users_store")
+    if settings_store and users_store and hasattr(settings_store, "prune_stale_alert_users"):
+        try:
+            await settings_store.prune_stale_alert_users(users_store)
+        except Exception:
+            pass
 
     if "sync_manager" not in root:
         root["sync_manager"] = SyncManager(hass)
@@ -5175,6 +5284,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         updated = True
                 if updated:
                     await settings_store.set_alert_targets(targets)
+                if users_store and hasattr(settings_store, "prune_stale_alert_users"):
+                    await settings_store.prune_stale_alert_users(users_store)
             except Exception:
                 pass
 

--- a/custom_components/akuvox_ac/tests/test_notify_on_access.py
+++ b/custom_components/akuvox_ac/tests/test_notify_on_access.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict
 
 from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
@@ -13,7 +14,21 @@ from custom_components.akuvox_ac.integration import (  # noqa: E402
 def _settings_store(targets: Dict[str, Any]) -> AkuvoxSettingsStore:
     store = object.__new__(AkuvoxSettingsStore)
     store.data = {"alerts": {"targets": targets}}
+    store.saved = 0
+
+    async def _async_save():
+        store.saved += 1
+
+    store.async_save = _async_save
     return store
+
+
+class _UsersStoreStub:
+    def __init__(self, users: Dict[str, Dict[str, Any]]) -> None:
+        self._users = users
+
+    def all(self) -> Dict[str, Dict[str, Any]]:
+        return dict(self._users)
 
 
 def test_settings_store_matches_normalized_specific_notify_user():
@@ -85,3 +100,49 @@ def test_sync_notify_on_access_targets_replaces_per_user_targets():
     assert updated["mobile_app_verns_iphone"]["granted"]["users"] == ["HA012"]
     assert updated["mobile_app_verns_iphone"]["granted"]["specific"] is True
     assert updated["mobile_app_verns_iphone"]["granted"]["any"] is True
+
+
+def test_prune_stale_alert_users_removes_deleted_and_missing_users():
+    store = _settings_store(
+        {
+            "mobile_app_elles_iphone": {
+                "granted": {
+                    "any": False,
+                    "specific": True,
+                    "users": ["HA004", "TMP002", "tmp-003", "HA099", "bad-id"],
+                }
+            }
+        }
+    )
+    users = _UsersStoreStub(
+        {
+            "HA004": {"name": "Daniel", "status": "active"},
+            "TMP003": {"name": "Visitor", "status": "active", "temporary": True},
+            "HA099": {"name": "Deleted", "status": "deleted"},
+        }
+    )
+
+    changed = asyncio.run(store.prune_stale_alert_users(users))
+
+    assert changed is True
+    granted = store.get_alert_targets()["mobile_app_elles_iphone"]["granted"]
+    assert granted["specific"] is True
+    assert granted["users"] == ["HA004", "TMP003"]
+    assert store.saved == 1
+
+
+def test_prune_stale_alert_users_disables_empty_specific_list():
+    store = _settings_store(
+        {
+            "mobile_app_elles_iphone": {
+                "granted": {"any": False, "specific": True, "users": ["TMP002"]}
+            }
+        }
+    )
+
+    changed = asyncio.run(store.prune_stale_alert_users(_UsersStoreStub({})))
+
+    assert changed is True
+    granted = store.get_alert_targets()["mobile_app_elles_iphone"]["granted"]
+    assert granted["specific"] is False
+    assert granted["users"] == []


### PR DESCRIPTION
## Summary
- prune notify-on-access user lists against the local users table so deleted or missing IDs like `TMP002` disappear automatically
- run the prune during startup, settings/diagnostics reads, explicit deletes, and sync cleanup of deleted profiles
- keep deleted profiles out of the global settings notification user list

## Validation
- `git diff --check`
- Python/pytest not run because `python`, `py`, and a bundled Python runtime are not available on this machine.