### PR TITLE
[codex] Avoid stale dashboard auth requests

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -2644,7 +2644,7 @@ class AkuvoxDashboardView(HomeAssistantView):
                 )
             except Exception:
                 html = await hass.async_add_executor_job(asset.read_text)
-            html = _inject_signed_paths(html, signed, clear_cache=not bool(signed))
+            html = _inject_signed_paths(html, signed)
             response = web.Response(text=html, content_type="text/html")
             response.headers["X-AK-AC-Variant"] = variant
             return response

--- a/custom_components/akuvox_ac/www/device_edit-mob.html
+++ b/custom_components/akuvox_ac/www/device_edit-mob.html
@@ -388,8 +388,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/device_edit.html
+++ b/custom_components/akuvox_ac/www/device_edit.html
@@ -391,8 +391,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/device_management-mob.html
+++ b/custom_components/akuvox_ac/www/device_management-mob.html
@@ -334,8 +334,12 @@ const REJECTED_TOKENS = new Set();
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? findHaToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -393,7 +393,11 @@ function currentAuthSig(){
 }
 
 async function fetchWithAuth(url, options = {}) {
-  const token = findHaToken();
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  const token = null;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = new Headers(options.headers || {});
   if (token && !REJECTED_TOKENS.has(token)) {
     headers.set('Authorization', 'Bearer ' + token);

--- a/custom_components/akuvox_ac/www/diagnostics.html
+++ b/custom_components/akuvox_ac/www/diagnostics.html
@@ -393,7 +393,11 @@ function currentAuthSig(){
 }
 
 async function fetchWithAuth(url, options = {}) {
-  const token = findHaToken();
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  const token = null;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = new Headers(options.headers || {});
   if (token && !REJECTED_TOKENS.has(token)) {
     headers.set('Authorization', 'Bearer ' + token);

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -317,8 +317,12 @@ const REJECTED_TOKENS = new Set();
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? findHaToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });

--- a/custom_components/akuvox_ac/www/event_history.html
+++ b/custom_components/akuvox_ac/www/event_history.html
@@ -317,8 +317,12 @@ const REJECTED_TOKENS = new Set();
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? findHaToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });

--- a/custom_components/akuvox_ac/www/face_rec-mob.html
+++ b/custom_components/akuvox_ac/www/face_rec-mob.html
@@ -106,8 +106,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/face_rec.html
+++ b/custom_components/akuvox_ac/www/face_rec.html
@@ -106,8 +106,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -959,6 +959,10 @@ function signedPath(key, fallback){
   return fallback;
 }
 
+function isSignedPath(url){
+  return typeof url === 'string' && /[?&]authSig=/.test(url);
+}
+
 const API_STATE = signedPath('state', '/api/akuvox_ac/ui/state');
 const API_ACTION = signedPath('action', '/api/akuvox_ac/ui/action');
 
@@ -967,8 +971,6 @@ function buildUrl(view, params = {}){
   Object.entries(params || {}).forEach(([k,v]) => {
     if (v !== undefined && v !== null && v !== '') search.set(k, v);
   });
-  const token = getToken();
-  if (token) search.set('token', token);
   const authSig = currentAuthSig();
   if (authSig) search.set('authSig', authSig);
   const query = search.toString();
@@ -1176,7 +1178,13 @@ function paramsFromButton(btn){
 }
 
 async function postJson(url, body = {}){
-  const token = getToken();
+  const signedRequest = isSignedPath(url);
+  const token = null;
+  if (!signedRequest) {
+    const error = new Error('authentication required');
+    error.status = 401;
+    throw error;
+  }
   const headers = new Headers({ 'Content-Type': 'application/json' });
   if (token) headers.set('Authorization', 'Bearer ' + token);
   let response;
@@ -1295,7 +1303,13 @@ async function runDashboardAction(action){
 async function fetchVersion(){
   const badge = document.getElementById('appVersion');
   const footer = document.getElementById('appFooter');
-  const token = getToken();
+  const signedRequest = isSignedPath(API_STATE);
+  const token = null;
+  if (!signedRequest) {
+    if (badge) badge.textContent = 'Version unavailable';
+    if (footer) footer.textContent = '';
+    return;
+  }
   const headers = token ? { 'Authorization': 'Bearer ' + token } : {};
   try {
     const res = await fetch(API_STATE, {

--- a/custom_components/akuvox_ac/www/head.html
+++ b/custom_components/akuvox_ac/www/head.html
@@ -935,6 +935,10 @@ function signedPath(key, fallback){
   return fallback;
 }
 
+function isSignedPath(url){
+  return typeof url === 'string' && /[?&]authSig=/.test(url);
+}
+
 const API_STATE = signedPath('state', '/api/akuvox_ac/ui/state');
 
 function buildUrl(view, params = {}){
@@ -942,8 +946,6 @@ function buildUrl(view, params = {}){
   Object.entries(params || {}).forEach(([k,v]) => {
     if (v !== undefined && v !== null && v !== '') search.set(k, v);
   });
-  const token = getToken();
-  if (token) search.set('token', token);
   const authSig = currentAuthSig();
   if (authSig) search.set('authSig', authSig);
   const query = search.toString();
@@ -1180,7 +1182,13 @@ function runDashboardAction(action){
 async function fetchVersion(){
   const badge = document.getElementById('appVersion');
   const footer = document.getElementById('appFooter');
-  const token = getToken();
+  const signedRequest = isSignedPath(API_STATE);
+  const token = null;
+  if (!signedRequest) {
+    if (badge) badge.textContent = 'Version unavailable';
+    if (footer) footer.textContent = '';
+    return;
+  }
   const headers = token ? { 'Authorization': 'Bearer ' + token } : {};
   try {
     const res = await fetch(API_STATE, {

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -354,8 +354,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -375,8 +375,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/schedules-mob.html
+++ b/custom_components/akuvox_ac/www/schedules-mob.html
@@ -293,8 +293,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/schedules.html
+++ b/custom_components/akuvox_ac/www/schedules.html
@@ -293,8 +293,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -335,8 +335,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -336,8 +336,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/temp_user-mob.html
+++ b/custom_components/akuvox_ac/www/temp_user-mob.html
@@ -143,9 +143,17 @@ function signedPath(key, fallback) {
   return signed[key] || fallback;
 }
 
+function isSignedPath(url) {
+  return typeof url === 'string' && /[?&]authSig=/.test(url);
+}
+
 async function callService(service, data) {
-  const token = getAuthToken();
   const url = signedPath(`service_${service}`, `/api/services/akuvox_ac/${service}`);
+  const signedRequest = isSignedPath(url);
+  const token = null;
+  if (!signedRequest) {
+    throw new Error('authentication required');
+  }
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -167,7 +175,11 @@ function escapeHtml(value){
 }
 
 async function fetchWithAuth(url, options = {}) {
-  const token = getAuthToken();
+  const signedRequest = isSignedPath(url);
+  const token = null;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...(options.headers || {}) };
   if (token) headers.Authorization = `Bearer ${token}`;
   return fetch(url, { ...options, headers });

--- a/custom_components/akuvox_ac/www/temp_user.html
+++ b/custom_components/akuvox_ac/www/temp_user.html
@@ -126,9 +126,17 @@ function signedPath(key, fallback) {
   return signed[key] || fallback;
 }
 
+function isSignedPath(url) {
+  return typeof url === 'string' && /[?&]authSig=/.test(url);
+}
+
 async function callService(service, data) {
-  const token = getAuthToken();
   const url = signedPath(`service_${service}`, `/api/services/akuvox_ac/${service}`);
+  const signedRequest = isSignedPath(url);
+  const token = null;
+  if (!signedRequest) {
+    throw new Error('authentication required');
+  }
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -150,7 +158,11 @@ function escapeHtml(value){
 }
 
 async function fetchWithAuth(url, options = {}) {
-  const token = getAuthToken();
+  const signedRequest = isSignedPath(url);
+  const token = null;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...(options.headers || {}) };
   if (token) headers.Authorization = `Bearer ${token}`;
   return fetch(url, { ...options, headers });

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -384,8 +384,12 @@ const REJECTED_TOKENS = new Set();
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? findHaToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -500,8 +500,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -500,8 +500,12 @@ function nextBearerToken(){
 
 async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const originalHeaders = { ...(options.headers || {}) };
-  let bearer = allowRetry ? nextBearerToken() : null;
-  let usedBearer = !!bearer;
+  const signedRequest = typeof url === 'string' && /[?&]authSig=/.test(url);
+  let bearer = null;
+  let usedBearer = false;
+  if (!signedRequest) {
+    return new Response('authentication required', { status: 401 });
+  }
   const headers = { ...originalHeaders };
   if (bearer) headers['Authorization'] = 'Bearer ' + bearer;
 


### PR DESCRIPTION
## Summary

- Prevent Akuvox dashboard pages from sending cached Home Assistant bearer tokens to signed Akuvox UI API paths.
- Block protected dashboard API calls locally when a signed `authSig` URL is unavailable, instead of making plain `/api/akuvox_ac/*` requests that can trigger Home Assistant login-failed/ban logging.
- Stop dashboard page loads without a current signing context from clearing previously injected signed API paths.

## Root Cause

The dashboard had two auth paths: signed URLs injected by Home Assistant and a fallback that reused cached browser bearer tokens. If the signed paths were missing or cleared, the UI could call `/api/akuvox_ac/ui/state` directly with a stale cached bearer token, which Home Assistant logged as an invalid authentication attempt.

## Validation

- `git diff --check`