### PR TITLE
[codex] Add HACS auto update feature

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -2263,6 +2263,7 @@ _SPECIAL_DEVICE_KEYS = {
     "settings_store",
     "sync_manager",
     "sync_queue",
+    "hacs_auto_updater",
     "_ui_registered",
     "_panel_registered",
 }
@@ -2998,6 +2999,17 @@ class AkuvoxUIAction(AkuvoxUIView):
                 _LOGGER.debug("Refresh-events service call failed via UI: %s", service_err)
                 return err(service_err)
 
+        if action == "hacs_update_check":
+            updater = root.get("hacs_auto_updater")
+            if not updater or not hasattr(updater, "async_run_check"):
+                return err("HACS auto updater is unavailable", code=500)
+            try:
+                status = await updater.async_run_check(reason="manual", force=True)
+                return web.json_response({"ok": True, "hacs_auto_update": status})
+            except Exception as service_err:
+                _LOGGER.debug("HACS update check failed via UI: %s", service_err)
+                return err(service_err)
+
         if action in ("force_full_sync", "sync_all"):
             queue = root.get("sync_queue")
             manager = root.get("sync_manager")
@@ -3549,6 +3561,23 @@ class AkuvoxUISettings(HomeAssistantView):
                 "face": True,
             }
         )
+        hacs_auto_update = (
+            settings.get_hacs_auto_update()
+            if settings and hasattr(settings, "get_hacs_auto_update")
+            else {
+                "enabled": False,
+                "interval_hours": 24,
+                "update_entity": "",
+                "backup": False,
+                "last_result": "disabled",
+            }
+        )
+        updater = root.get("hacs_auto_updater")
+        if updater and hasattr(updater, "status"):
+            try:
+                hacs_auto_update = updater.status()
+            except Exception:
+                pass
 
         return web.json_response(
             {
@@ -3572,6 +3601,9 @@ class AkuvoxUISettings(HomeAssistantView):
                 "min_access_event_limit": access_bounds[0],
                 "max_access_event_limit": access_bounds[1],
                 "credential_prompts": credential_prompts,
+                "hacs_auto_update": hacs_auto_update,
+                "min_hacs_auto_update_interval_hours": 1,
+                "max_hacs_auto_update_interval_hours": 168,
                 "groups": groups,
             }
         )
@@ -3704,6 +3736,23 @@ class AkuvoxUISettings(HomeAssistantView):
             try:
                 updated = await settings.set_credential_prompts(payload.get("credential_prompts"))
                 response["credential_prompts"] = updated
+            except Exception as err:
+                return web.json_response({"ok": False, "error": str(err)}, status=400)
+
+        if "hacs_auto_update" in payload:
+            if not settings or not hasattr(settings, "set_hacs_auto_update"):
+                return web.json_response({"ok": False, "error": "settings unavailable"}, status=500)
+            try:
+                updated = await settings.set_hacs_auto_update(payload.get("hacs_auto_update"))
+                updater = root.get("hacs_auto_updater")
+                if updater and hasattr(updater, "apply_settings"):
+                    updater.apply_settings()
+                if updater and hasattr(updater, "status"):
+                    try:
+                        updated = updater.status()
+                    except Exception:
+                        pass
+                response["hacs_auto_update"] = updated
             except Exception as err:
                 return web.json_response({"ok": False, "error": str(err)}, status=400)
 

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2515,6 +2515,8 @@ class AkuvoxSettingsStore(Store):
     DEFAULT_HEALTH_SECONDS = DEFAULT_POLL_INTERVAL
     MIN_HEALTH_SECONDS = MIN_HEALTH_CHECK_INTERVAL
     MAX_HEALTH_SECONDS = MAX_HEALTH_CHECK_INTERVAL
+    MIN_HACS_AUTO_UPDATE_HOURS = 1
+    MAX_HACS_AUTO_UPDATE_HOURS = 168
 
     DEFAULT_INTEGRITY_MINUTES = 15
     DEFAULT_FACE_INTEGRITY_ENABLED = True
@@ -2524,6 +2526,19 @@ class AkuvoxSettingsStore(Store):
         "anpr": False,
         "face": True,
         "phone": True,
+    }
+    DEFAULT_HACS_AUTO_UPDATE = {
+        "enabled": False,
+        "interval_hours": 24,
+        "update_entity": "",
+        "backup": False,
+        "last_checked": None,
+        "last_installed": None,
+        "last_result": "disabled",
+        "last_error": None,
+        "last_entity_id": None,
+        "installed_version": None,
+        "latest_version": None,
     }
 
     def __init__(self, hass: HomeAssistant):
@@ -2539,6 +2554,7 @@ class AkuvoxSettingsStore(Store):
             "health_check_interval_seconds": self.DEFAULT_HEALTH_SECONDS,
             "credential_prompts": dict(self.DEFAULT_CREDENTIAL_PROMPTS),
             "access_history_limit": DEFAULT_ACCESS_HISTORY_LIMIT,
+            "hacs_auto_update": dict(self.DEFAULT_HACS_AUTO_UPDATE),
         }
 
     async def async_load(self):
@@ -2597,6 +2613,9 @@ class AkuvoxSettingsStore(Store):
         self.data["credential_prompts"] = self._sanitize_credential_prompts(
             self.data.get("credential_prompts")
         )
+        self.data["hacs_auto_update"] = self._sanitize_hacs_auto_update(
+            self.data.get("hacs_auto_update")
+        )
 
         try:
             access_limit = self._normalize_access_history_limit(
@@ -2636,6 +2655,70 @@ class AkuvoxSettingsStore(Store):
         self.data["credential_prompts"] = sanitized
         await self.async_save()
         return sanitized
+
+    def _normalize_hacs_auto_update_hours(self, hours: Any) -> int:
+        try:
+            value = int(hours)
+        except Exception:
+            value = self.DEFAULT_HACS_AUTO_UPDATE["interval_hours"]
+        if value < self.MIN_HACS_AUTO_UPDATE_HOURS:
+            return self.MIN_HACS_AUTO_UPDATE_HOURS
+        if value > self.MAX_HACS_AUTO_UPDATE_HOURS:
+            return self.MAX_HACS_AUTO_UPDATE_HOURS
+        return value
+
+    def _sanitize_hacs_auto_update(self, raw: Any) -> Dict[str, Any]:
+        cfg = dict(self.DEFAULT_HACS_AUTO_UPDATE)
+        if not isinstance(raw, dict):
+            return cfg
+
+        enabled = _coerce_bool(raw.get("enabled"))
+        backup = _coerce_bool(raw.get("backup"))
+        cfg["enabled"] = bool(enabled) if enabled is not None else False
+        cfg["backup"] = bool(backup) if backup is not None else False
+        cfg["interval_hours"] = self._normalize_hacs_auto_update_hours(
+            raw.get("interval_hours")
+        )
+        cfg["update_entity"] = str(raw.get("update_entity") or "").strip()
+
+        for key in (
+            "last_checked",
+            "last_installed",
+            "last_result",
+            "last_error",
+            "last_entity_id",
+            "installed_version",
+            "latest_version",
+        ):
+            value = raw.get(key)
+            cfg[key] = str(value).strip() if value not in (None, "") else None
+        if not cfg["last_result"]:
+            cfg["last_result"] = "enabled" if cfg["enabled"] else "disabled"
+        return cfg
+
+    def get_hacs_auto_update(self) -> Dict[str, Any]:
+        return self._sanitize_hacs_auto_update(self.data.get("hacs_auto_update"))
+
+    async def set_hacs_auto_update(self, config: Any) -> Dict[str, Any]:
+        current = self.get_hacs_auto_update()
+        if isinstance(config, dict):
+            current.update(config)
+        sanitized = self._sanitize_hacs_auto_update(current)
+        if sanitized["enabled"] and sanitized.get("last_result") == "disabled":
+            sanitized["last_result"] = "enabled"
+        if not sanitized["enabled"]:
+            sanitized["last_result"] = "disabled"
+        self.data["hacs_auto_update"] = sanitized
+        await self.async_save()
+        return dict(sanitized)
+
+    async def update_hacs_auto_update_status(self, **updates: Any) -> Dict[str, Any]:
+        current = self.get_hacs_auto_update()
+        current.update(updates)
+        sanitized = self._sanitize_hacs_auto_update(current)
+        self.data["hacs_auto_update"] = sanitized
+        await self.async_save()
+        return dict(sanitized)
 
     def get_auto_sync_time(self) -> Optional[str]:
         return self.data.get("auto_sync_time")
@@ -2867,6 +2950,309 @@ class AkuvoxSettingsStore(Store):
                 ):
                     out.append(target)
         return out
+
+
+class HacsAutoUpdater:
+    """Managed HACS update checker for this custom integration."""
+
+    REPOSITORY = "DJGLTD/AK_Access_ctrl"
+    MATCHERS = (
+        "djgltd/ak_access_ctrl",
+        "ak_access_ctrl",
+        "akuvox_ac",
+        "akuvox_access_control",
+        "akuvox access control",
+        "ak access control",
+    )
+
+    def __init__(self, hass: HomeAssistant):
+        self.hass = hass
+        self._interval_unsub: Optional[Callable[[], None]] = None
+        self._startup_unsub: Optional[Callable[[], None]] = None
+        self._lock = asyncio.Lock()
+
+    def _root(self) -> Dict[str, Any]:
+        return self.hass.data.get(DOMAIN, {}) or {}
+
+    def _settings_store(self) -> Any:
+        settings = self._root().get("settings_store")
+        return settings if hasattr(settings, "get_hacs_auto_update") else None
+
+    def _config(self) -> Dict[str, Any]:
+        settings = self._settings_store()
+        if settings and hasattr(settings, "get_hacs_auto_update"):
+            try:
+                return settings.get_hacs_auto_update()
+            except Exception:
+                pass
+        return dict(AkuvoxSettingsStore.DEFAULT_HACS_AUTO_UPDATE)
+
+    def status(self) -> Dict[str, Any]:
+        status = self._config()
+        status["active"] = self._interval_unsub is not None
+        return status
+
+    def start(self) -> None:
+        self.apply_settings()
+        if self._startup_unsub is not None:
+            return
+        try:
+            self._startup_unsub = self.hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED,
+                self._handle_hass_started,
+            )
+        except Exception:
+            self._startup_unsub = None
+
+    def shutdown(self) -> None:
+        self._cancel_interval()
+        if self._startup_unsub:
+            try:
+                self._startup_unsub()
+            except Exception:
+                pass
+            self._startup_unsub = None
+
+    def apply_settings(self) -> None:
+        self._cancel_interval()
+        config = self._config()
+        if not config.get("enabled"):
+            return
+
+        hours = config.get("interval_hours", 24)
+        try:
+            hours = int(hours)
+        except Exception:
+            hours = 24
+        hours = max(
+            AkuvoxSettingsStore.MIN_HACS_AUTO_UPDATE_HOURS,
+            min(AkuvoxSettingsStore.MAX_HACS_AUTO_UPDATE_HOURS, hours),
+        )
+
+        def _schedule(_now):
+            self.hass.async_create_task(self.async_run_check(reason="scheduled"))
+
+        try:
+            self._interval_unsub = async_track_time_interval(
+                self.hass,
+                _schedule,
+                timedelta(hours=hours),
+            )
+        except Exception:
+            self._interval_unsub = None
+
+    def _cancel_interval(self) -> None:
+        if self._interval_unsub:
+            try:
+                self._interval_unsub()
+            except Exception:
+                pass
+            self._interval_unsub = None
+
+    def _handle_hass_started(self, _event) -> None:
+        self._startup_unsub = None
+        config = self._config()
+        if not config.get("enabled"):
+            return
+        if self._last_check_is_fresh(config):
+            return
+        self.hass.async_create_task(self.async_run_check(reason="startup"))
+
+    def _last_check_is_fresh(self, config: Mapping[str, Any]) -> bool:
+        last_checked = str(config.get("last_checked") or "").strip()
+        if not last_checked:
+            return False
+        try:
+            parsed = dt_util.parse_datetime(last_checked)
+        except Exception:
+            parsed = None
+        if parsed is None or parsed.tzinfo is None:
+            return False
+        try:
+            hours = int(config.get("interval_hours", 24) or 24)
+        except Exception:
+            hours = 24
+        hours = max(
+            AkuvoxSettingsStore.MIN_HACS_AUTO_UPDATE_HOURS,
+            min(AkuvoxSettingsStore.MAX_HACS_AUTO_UPDATE_HOURS, hours),
+        )
+        return dt_util.now() - parsed < timedelta(hours=hours)
+
+    def _score_update_entity(self, state: Any) -> int:
+        attrs = getattr(state, "attributes", {}) or {}
+        fields = [
+            getattr(state, "entity_id", ""),
+            attrs.get("title"),
+            attrs.get("friendly_name"),
+            attrs.get("repository"),
+            attrs.get("repository_name"),
+            attrs.get("release_url"),
+            attrs.get("entity_picture"),
+        ]
+        text = " ".join(str(field or "").lower() for field in fields)
+        score = 0
+        if self.REPOSITORY.lower() in text:
+            score += 100
+        for matcher in self.MATCHERS:
+            if matcher in text:
+                score += 30
+        if "hacs" in text:
+            score += 5
+        return score
+
+    def _find_update_entity(self, configured: Any = None) -> Optional[str]:
+        entity_id = str(configured or "").strip()
+        if entity_id:
+            state = self.hass.states.get(entity_id)
+            return entity_id if state is not None else None
+
+        try:
+            states = self.hass.states.async_all("update")
+        except TypeError:
+            try:
+                states = [
+                    state
+                    for state in self.hass.states.async_all()
+                    if str(getattr(state, "entity_id", "")).startswith("update.")
+                ]
+            except Exception:
+                states = []
+        except Exception:
+            states = []
+
+        best_entity: Optional[str] = None
+        best_score = 0
+        for state in states:
+            score = self._score_update_entity(state)
+            if score > best_score:
+                best_score = score
+                best_entity = getattr(state, "entity_id", None)
+
+        return best_entity if best_score >= 30 else None
+
+    def _update_available(self, state: Any) -> bool:
+        state_value = str(getattr(state, "state", "") or "").strip().lower()
+        if state_value == "on":
+            return True
+        if state_value == "off":
+            return False
+
+        attrs = getattr(state, "attributes", {}) or {}
+        installed = str(attrs.get("installed_version") or "").strip()
+        latest = str(attrs.get("latest_version") or "").strip()
+        skipped = str(attrs.get("skipped_version") or "").strip()
+        return bool(latest and installed and latest != installed and latest != skipped)
+
+    async def _record_status(self, **updates: Any) -> Dict[str, Any]:
+        settings = self._settings_store()
+        if settings and hasattr(settings, "update_hacs_auto_update_status"):
+            return await settings.update_hacs_auto_update_status(**updates)
+        status = self.status()
+        status.update(updates)
+        return status
+
+    async def _create_restart_notification(self, entity_id: str) -> None:
+        try:
+            await self.hass.services.async_call(
+                "persistent_notification",
+                "create",
+                {
+                    "notification_id": "akuvox_ac_hacs_auto_update",
+                    "title": "Akuvox Access Control updated",
+                    "message": (
+                        f"HACS installed an update for `{entity_id}`. "
+                        "Restart Home Assistant to load the new integration code."
+                    ),
+                },
+                blocking=False,
+            )
+        except Exception:
+            pass
+
+    async def async_run_check(
+        self, *, reason: str = "manual", force: bool = False
+    ) -> Dict[str, Any]:
+        config = self._config()
+        if not config.get("enabled") and not force:
+            return await self._record_status(last_result="disabled", last_error=None)
+
+        async with self._lock:
+            checked_at = dt_util.now().isoformat()
+            entity_id = self._find_update_entity(config.get("update_entity"))
+            if not entity_id:
+                return await self._record_status(
+                    last_checked=checked_at,
+                    last_result="entity_not_found",
+                    last_error="Could not find the HACS update entity for Akuvox Access Control.",
+                    last_entity_id=None,
+                )
+
+            try:
+                await self.hass.services.async_call(
+                    "homeassistant",
+                    "update_entity",
+                    {"entity_id": entity_id},
+                    blocking=True,
+                )
+            except Exception as err:
+                return await self._record_status(
+                    last_checked=checked_at,
+                    last_result="check_failed",
+                    last_error=str(err),
+                    last_entity_id=entity_id,
+                )
+
+            state = self.hass.states.get(entity_id)
+            if state is None:
+                return await self._record_status(
+                    last_checked=checked_at,
+                    last_result="entity_not_found",
+                    last_error=f"{entity_id} is no longer available.",
+                    last_entity_id=entity_id,
+                )
+
+            attrs = getattr(state, "attributes", {}) or {}
+            installed = attrs.get("installed_version")
+            latest = attrs.get("latest_version")
+            base_status = {
+                "last_checked": checked_at,
+                "last_entity_id": entity_id,
+                "installed_version": installed,
+                "latest_version": latest,
+            }
+
+            if not self._update_available(state):
+                return await self._record_status(
+                    **base_status,
+                    last_result="up_to_date",
+                    last_error=None,
+                )
+
+            service_data: Dict[str, Any] = {"entity_id": entity_id}
+            if config.get("backup"):
+                service_data["backup"] = True
+
+            try:
+                await self.hass.services.async_call(
+                    "update",
+                    "install",
+                    service_data,
+                    blocking=True,
+                )
+            except Exception as err:
+                return await self._record_status(
+                    **base_status,
+                    last_result="install_failed",
+                    last_error=str(err),
+                )
+
+            await self._create_restart_notification(entity_id)
+            return await self._record_status(
+                **base_status,
+                last_installed=dt_util.now().isoformat(),
+                last_result="installed",
+                last_error=None,
+            )
 
 
 # ---------------------- Robust device user lookup + delete ---------------------- #
@@ -4787,6 +5173,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if "sync_queue" not in root:
         root["sync_queue"] = SyncQueue(hass)
 
+    if "hacs_auto_updater" not in root:
+        root["hacs_auto_updater"] = HacsAutoUpdater(hass)
+    try:
+        root["hacs_auto_updater"].start()
+    except Exception:
+        pass
+
     await _remove_legacy_integration_device(hass, entry)
 
     settings = root.get("settings_store")
@@ -5626,6 +6019,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry_id = data.get("entry_id")
         await hass.data[DOMAIN]["sync_queue"].sync_now(entry_id, trigger="sync_now service")
 
+    async def svc_hacs_update_check(call):
+        root = hass.data.get(DOMAIN, {})
+        updater = root.get("hacs_auto_updater") if isinstance(root, dict) else None
+        if updater and hasattr(updater, "async_run_check"):
+            await updater.async_run_check(reason="service", force=True)
+
     async def svc_add_missing_users(call):
         data = call.data if isinstance(call.data, Mapping) else {}
         entry_id = data.get("entry_id")
@@ -5702,6 +6101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.services.async_register(DOMAIN, "refresh_events", svc_refresh_events)
     hass.services.async_register(DOMAIN, "force_full_sync", svc_force_full_sync)
     hass.services.async_register(DOMAIN, "sync_now", svc_sync_now)
+    hass.services.async_register(DOMAIN, "hacs_update_check", svc_hacs_update_check)
     hass.services.async_register(DOMAIN, "add_missing_users", svc_add_missing_users)
     hass.services.async_register(DOMAIN, "create_group", svc_create_group)
     hass.services.async_register(DOMAIN, "delete_groups", svc_delete_groups)
@@ -5761,6 +6161,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
                 "settings_store",
                 "sync_manager",
                 "sync_queue",
+                "hacs_auto_updater",
                 "_ui_registered",
                 "_panel_registered",
             )
@@ -5780,6 +6181,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
                     except Exception:
                         pass
                     root["sync_queue"]._handle = None  # type: ignore[attr-defined]
+
+            updater = root.get("hacs_auto_updater")
+            if updater and hasattr(updater, "shutdown"):
+                try:
+                    updater.shutdown()
+                except Exception:
+                    pass
 
             if root.pop("_panel_registered", False):
                 _remove_admin_dashboard(hass)

--- a/custom_components/akuvox_ac/services.yaml
+++ b/custom_components/akuvox_ac/services.yaml
@@ -221,6 +221,10 @@ sync_now:
       selector:
         text:
 
+hacs_update_check:
+  name: Check HACS update
+  description: Force a HACS update entity refresh and install the Akuvox Access Control update if one is available.
+
 add_missing_users:
   name: Add missing users
   description: Bulk create only users that do not exist on the device.

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -2293,6 +2293,75 @@ async function forceFullSync(){
   refresh();
 }
 
+function hacsUpdateButtonLabel(status){
+  const result = String(status?.last_result || '').toLowerCase();
+  if (result === 'installed') return 'Update Installed';
+  if (result === 'up_to_date') return 'No Update';
+  if (result === 'entity_not_found') return 'Update Entity Missing';
+  if (result === 'check_failed' || result === 'install_failed') return 'Update Failed';
+  return 'Check Sent';
+}
+
+async function runHacsAutoUpdate(){
+  const btn = document.getElementById('btnHacsAutoUpdate');
+  const originalHtml = btn ? btn.innerHTML : '';
+  if (btn) {
+    btn.setAttribute('disabled', 'disabled');
+    btn.classList.add('disabled');
+    btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Checking...';
+  }
+
+  let ok = false;
+  let lastError = '';
+  let status = null;
+
+  try {
+    const res = await apiPost(actionUrl, { action: 'hacs_update_check' });
+    if (res && typeof res === 'object') {
+      ok = res.ok !== false;
+      status = res.hacs_auto_update || null;
+      if (!ok) lastError = res.error || '';
+    } else if (res === true) {
+      ok = true;
+    }
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    lastError = err?.message || String(err);
+  }
+
+  if (!ok) {
+    try {
+      await callService('akuvox_ac','hacs_update_check', {});
+      ok = true;
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      if (!lastError) lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    alert(`HACS update check failed${lastError ? `: ${lastError}` : ''}`);
+  } else {
+    const result = String(status?.last_result || '').toLowerCase();
+    if (btn) {
+      btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+    }
+    if (result === 'installed') {
+      alert('Update installed. Restart Home Assistant to load it.');
+    } else if (['entity_not_found','check_failed','install_failed'].includes(result)) {
+      alert(status?.last_error || 'HACS update check did not complete.');
+    }
+  }
+
+  if (btn) {
+    setTimeout(() => {
+      btn.innerHTML = originalHtml;
+      btn.removeAttribute('disabled');
+      btn.classList.remove('disabled');
+    }, ok ? 2500 : 0);
+  }
+}
+
 async function rebootAll(){
   let ok = false;
   try {
@@ -2354,6 +2423,8 @@ window.addEventListener('message', (event) => {
     forceFullSync();
   } else if (action === 'sync_now') {
     syncAllNow();
+  } else if (action === 'hacs_update_check' || action === 'hacs_auto_update') {
+    runHacsAutoUpdate();
   }
 });
 
@@ -2362,6 +2433,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btnSyncNowEta')?.addEventListener('click', syncAllNow);
   document.getElementById('btnForceFull')?.addEventListener('click', forceFullSync);
   document.getElementById('btnUpdateAccessEvents')?.addEventListener('click', updateAccessEvents);
+  document.getElementById('btnHacsAutoUpdate')?.addEventListener('click', runHacsAutoUpdate);
   document.getElementById('btnRebootAll')?.addEventListener('click', rebootAll);
   document.getElementById('btnGlobalSettings')?.addEventListener('click', (e) => {
     e.preventDefault();
@@ -2497,6 +2569,7 @@ setInterval(refresh, 5000);
         </div>
         <button id="btnForceFull" class="btn btn-sm btn-outline-light"><i class="bi bi-lightning-charge-fill"></i> Force Full Sync</button>
         <button id="btnUpdateAccessEvents" class="btn btn-sm btn-outline-light"><i class="bi bi-journal-arrow-down"></i> Update Access Events</button>
+        <button id="btnHacsAutoUpdate" class="btn btn-sm btn-outline-light"><i class="bi bi-cloud-arrow-down"></i> Check HACS Update</button>
         <button id="btnRebootAll" class="btn btn-sm btn-outline-light"><i class="bi bi-arrow-repeat"></i> Reboot All</button>
         <button id="btnGlobalSettings" class="btn btn-sm btn-outline-light"><i class="bi bi-gear-wide-connected"></i> Global Settings</button>
       </div>

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -2517,6 +2517,75 @@ async function forceFullSync(){
   refresh();
 }
 
+function hacsUpdateButtonLabel(status){
+  const result = String(status?.last_result || '').toLowerCase();
+  if (result === 'installed') return 'Update Installed';
+  if (result === 'up_to_date') return 'No Update';
+  if (result === 'entity_not_found') return 'Update Entity Missing';
+  if (result === 'check_failed' || result === 'install_failed') return 'Update Failed';
+  return 'Check Sent';
+}
+
+async function runHacsAutoUpdate(){
+  const btn = document.getElementById('btnHacsAutoUpdate');
+  const originalHtml = btn ? btn.innerHTML : '';
+  if (btn) {
+    btn.setAttribute('disabled', 'disabled');
+    btn.classList.add('disabled');
+    btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Checking...';
+  }
+
+  let ok = false;
+  let lastError = '';
+  let status = null;
+
+  try {
+    const res = await apiPost(actionUrl, { action: 'hacs_update_check' });
+    if (res && typeof res === 'object') {
+      ok = res.ok !== false;
+      status = res.hacs_auto_update || null;
+      if (!ok) lastError = res.error || '';
+    } else if (res === true) {
+      ok = true;
+    }
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    lastError = err?.message || String(err);
+  }
+
+  if (!ok) {
+    try {
+      await callService('akuvox_ac','hacs_update_check', {});
+      ok = true;
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      if (!lastError) lastError = err?.message || String(err);
+    }
+  }
+
+  if (!ok) {
+    alert(`HACS update check failed${lastError ? `: ${lastError}` : ''}`);
+  } else {
+    const result = String(status?.last_result || '').toLowerCase();
+    if (btn) {
+      btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+    }
+    if (result === 'installed') {
+      alert('Update installed. Restart Home Assistant to load it.');
+    } else if (['entity_not_found','check_failed','install_failed'].includes(result)) {
+      alert(status?.last_error || 'HACS update check did not complete.');
+    }
+  }
+
+  if (btn) {
+    setTimeout(() => {
+      btn.innerHTML = originalHtml;
+      btn.removeAttribute('disabled');
+      btn.classList.remove('disabled');
+    }, ok ? 2500 : 0);
+  }
+}
+
 async function rebootAll(){
   let ok = false;
   try {
@@ -2578,6 +2647,8 @@ window.addEventListener('message', (event) => {
     forceFullSync();
   } else if (action === 'sync_now') {
     syncAllNow();
+  } else if (action === 'hacs_update_check' || action === 'hacs_auto_update') {
+    runHacsAutoUpdate();
   }
 });
 
@@ -2586,6 +2657,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btnSyncNowEta')?.addEventListener('click', syncAllNow);
   document.getElementById('btnForceFull')?.addEventListener('click', forceFullSync);
   document.getElementById('btnUpdateAccessEvents')?.addEventListener('click', updateAccessEvents);
+  document.getElementById('btnHacsAutoUpdate')?.addEventListener('click', runHacsAutoUpdate);
   document.getElementById('btnRebootAll')?.addEventListener('click', rebootAll);
   document.getElementById('btnGlobalSettings')?.addEventListener('click', (e) => {
     e.preventDefault();
@@ -2721,6 +2793,7 @@ setInterval(refresh, 5000);
         </div>
         <button id="btnForceFull" class="btn btn-sm btn-outline-light"><i class="bi bi-lightning-charge-fill"></i> Force Full Sync</button>
         <button id="btnUpdateAccessEvents" class="btn btn-sm btn-outline-light"><i class="bi bi-journal-arrow-down"></i> Update Access Events</button>
+        <button id="btnHacsAutoUpdate" class="btn btn-sm btn-outline-light"><i class="bi bi-cloud-arrow-down"></i> Check HACS Update</button>
         <button id="btnRebootAll" class="btn btn-sm btn-outline-light"><i class="bi bi-arrow-repeat"></i> Reboot All</button>
         <button id="btnGlobalSettings" class="btn btn-sm btn-outline-light"><i class="bi bi-gear-wide-connected"></i> Global Settings</button>
       </div>

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -560,6 +560,7 @@ let SETTINGS_DATA = {
   min_access_event_limit: 5,
   max_access_event_limit: 200,
   credential_prompts: { ...DEFAULT_CREDENTIAL_PROMPTS },
+  hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
 };
 let PHONES = [];
 let USERS = [];
@@ -578,6 +579,8 @@ let healthSaving = false;
 let healthSavedTimer = null;
 let eventLimitSaving = false;
 let eventLimitSavedTimer = null;
+let hacsUpdateSaving = false;
+let hacsUpdateChecking = false;
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const EXIT_CLONE_SUFFIX = ' - EP';
 const SCHEDULE_DAY_ORDER = [
@@ -768,6 +771,20 @@ function setEventLimitStatus(text, tone = 'muted') {
   if (tone === 'error') el.classList.add('text-danger');
   else el.classList.add('muted');
 }
+function setHacsAutoUpdateStatus(text, tone = 'muted') {
+  const el = document.getElementById('hacsAutoUpdateStatus');
+  if (!el) return;
+  if (!text) {
+    el.textContent = '';
+    el.className = 'visually-hidden small';
+    return;
+  }
+  el.textContent = text;
+  el.className = 'small';
+  if (tone === 'error') el.classList.add('text-danger');
+  else if (tone === 'success') el.classList.add('text-success');
+  else el.classList.add('muted');
+}
 function setAlertsStatus(text, tone = 'muted') {
   const el = document.getElementById('alertsStatus');
   if (!el) return;
@@ -802,6 +819,138 @@ function eventLimitRange(){
   let max = Number.isFinite(maxRaw) ? Math.round(maxRaw) : 200;
   if (max < min) max = min;
   return { min, max };
+}
+
+function hacsAutoUpdateRange(){
+  const minRaw = Number(SETTINGS_DATA?.min_hacs_auto_update_interval_hours);
+  const maxRaw = Number(SETTINGS_DATA?.max_hacs_auto_update_interval_hours);
+  const min = Number.isFinite(minRaw) ? Math.max(1, Math.round(minRaw)) : 1;
+  let max = Number.isFinite(maxRaw) ? Math.round(maxRaw) : 168;
+  if (max < min) max = min;
+  return { min, max };
+}
+
+function coerceHacsBool(value){
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') return ['1','true','yes','on','enabled'].includes(value.trim().toLowerCase());
+  return false;
+}
+
+function sanitizeHacsAutoUpdate(raw){
+  const { min, max } = hacsAutoUpdateRange();
+  const base = {
+    enabled: false,
+    interval_hours: 24,
+    update_entity: '',
+    backup: false,
+    last_checked: null,
+    last_installed: null,
+    last_result: 'disabled',
+    last_error: null,
+    last_entity_id: null,
+    installed_version: null,
+    latest_version: null,
+    active: false,
+  };
+  if (raw && typeof raw === 'object'){
+    base.enabled = coerceHacsBool(raw.enabled);
+    base.backup = coerceHacsBool(raw.backup);
+    const interval = Number(raw.interval_hours);
+    if (Number.isFinite(interval)) base.interval_hours = Math.round(interval);
+    base.update_entity = String(raw.update_entity || '').trim();
+    ['last_checked','last_installed','last_result','last_error','last_entity_id','installed_version','latest_version'].forEach((key) => {
+      if (raw[key] !== undefined && raw[key] !== null && raw[key] !== '') base[key] = String(raw[key]);
+    });
+    base.active = coerceHacsBool(raw.active);
+  }
+  if (base.interval_hours < min) base.interval_hours = min;
+  if (base.interval_hours > max) base.interval_hours = max;
+  if (!base.last_result) base.last_result = base.enabled ? 'enabled' : 'disabled';
+  return base;
+}
+
+function formatHacsDate(value){
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toLocaleString();
+}
+
+function hacsStatusTone(config){
+  const result = String(config?.last_result || '').toLowerCase();
+  if (['check_failed','install_failed','entity_not_found'].includes(result)) return 'error';
+  if (['installed','up_to_date','enabled'].includes(result)) return 'success';
+  return 'muted';
+}
+
+function describeHacsResult(config){
+  const result = String(config?.last_result || '').toLowerCase();
+  if (result === 'installed') return 'Update installed. Restart Home Assistant to load it.';
+  if (result === 'up_to_date') return 'No update available.';
+  if (result === 'check_failed') return 'Update check failed.';
+  if (result === 'install_failed') return 'Update install failed.';
+  if (result === 'entity_not_found') return 'HACS update entity was not found.';
+  if (result === 'disabled') return 'Automatic HACS updates are disabled.';
+  if (config?.enabled) return config?.active ? 'Automatic HACS updates are enabled.' : 'Automatic HACS updates will start after reload.';
+  return 'Automatic HACS updates are disabled.';
+}
+
+function readHacsAutoUpdateForm(){
+  const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
+  const { min, max } = hacsAutoUpdateRange();
+  const toggle = document.getElementById('hacsAutoUpdateToggle');
+  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const entityInput = document.getElementById('hacsAutoUpdateEntity');
+  const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  if (toggle) cfg.enabled = !!toggle.checked;
+  if (backupInput) cfg.backup = !!backupInput.checked;
+  if (entityInput) cfg.update_entity = String(entityInput.value || '').trim();
+  if (intervalInput){
+    const raw = String(intervalInput.value || '').trim();
+    const interval = Number(raw);
+    if (!raw || !Number.isFinite(interval)){
+      throw new Error(`Enter a number between ${min} and ${max}`);
+    }
+    const value = Math.round(interval);
+    if (value < min || value > max){
+      throw new Error(`Enter a number between ${min} and ${max}`);
+    }
+    cfg.interval_hours = value;
+  }
+  return cfg;
+}
+
+function renderHacsAutoUpdate(){
+  const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
+  SETTINGS_DATA.hacs_auto_update = cfg;
+  const { min, max } = hacsAutoUpdateRange();
+  const toggle = document.getElementById('hacsAutoUpdateToggle');
+  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const entityInput = document.getElementById('hacsAutoUpdateEntity');
+  const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+  const meta = document.getElementById('hacsAutoUpdateMeta');
+  if (toggle) toggle.checked = !!cfg.enabled;
+  if (backupInput) backupInput.checked = !!cfg.backup;
+  if (intervalInput){
+    intervalInput.min = String(min);
+    intervalInput.max = String(max);
+    intervalInput.value = String(cfg.interval_hours);
+  }
+  if (entityInput) entityInput.value = cfg.update_entity || '';
+  if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
+  if (meta){
+    const details = [
+      `Last checked: ${formatHacsDate(cfg.last_checked)}`,
+    ];
+    if (cfg.last_installed) details.push(`Last installed: ${formatHacsDate(cfg.last_installed)}`);
+    if (cfg.last_entity_id) details.push(`Entity: ${cfg.last_entity_id}`);
+    if (cfg.installed_version || cfg.latest_version) details.push(`Version: ${cfg.installed_version || 'unknown'} to ${cfg.latest_version || 'unknown'}`);
+    if (cfg.last_error) details.push(`Error: ${cfg.last_error}`);
+    meta.textContent = details.join(' | ');
+  }
+  setHacsAutoUpdateStatus(describeHacsResult(cfg), hacsStatusTone(cfg));
 }
 
 function renderAutoSyncDelay(){
@@ -881,6 +1030,54 @@ async function saveEventLimit(){
     alert('Failed to update event history limit: ' + (err && err.message ? err.message : err));
   } finally {
     eventLimitSaving = false;
+  }
+}
+
+async function saveHacsAutoUpdate(patch = {}){
+  if (hacsUpdateSaving) return;
+  let next;
+  try {
+    next = { ...readHacsAutoUpdateForm(), ...patch };
+  } catch (err) {
+    setHacsAutoUpdateStatus(err && err.message ? err.message : String(err), 'error');
+    return;
+  }
+  SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(next);
+  hacsUpdateSaving = true;
+  setHacsAutoUpdateStatus('Saving...');
+  try {
+    const res = await apiPost(API_SETTINGS, { hacs_auto_update: SETTINGS_DATA.hacs_auto_update });
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+    setHacsAutoUpdateStatus('Saved', 'success');
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to save HACS auto update settings', 'error');
+  } finally {
+    hacsUpdateSaving = false;
+  }
+}
+
+async function runHacsUpdateCheck(){
+  if (hacsUpdateChecking) return;
+  hacsUpdateChecking = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Checking HACS update entity...');
+  try {
+    const res = await callAction('hacs_update_check');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'HACS update check failed', 'error');
+  } finally {
+    hacsUpdateChecking = false;
+    const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+    if (checkBtn) checkBtn.disabled = false;
   }
 }
 
@@ -1908,6 +2105,7 @@ async function loadData(){
       auto_sync_delay_minutes: 30,
       health_check_interval_seconds: 30,
       access_event_limit: 30,
+      hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
       alerts: { targets: {} },
       registry_users: [],
     };
@@ -1981,6 +2179,15 @@ async function loadData(){
       ? { ...settingsResp.capabilities }
       : { alarm_relay: false };
     SETTINGS_DATA.credential_prompts = sanitizeCredentialPrompts(settingsResp?.credential_prompts);
+    const minHacsHours = Number(settingsResp?.min_hacs_auto_update_interval_hours);
+    const maxHacsHours = Number(settingsResp?.max_hacs_auto_update_interval_hours);
+    const safeMinHacsHours = Number.isFinite(minHacsHours) ? Math.max(1, Math.round(minHacsHours)) : 1;
+    const safeMaxHacsHours = Number.isFinite(maxHacsHours)
+      ? Math.max(safeMinHacsHours, Math.round(maxHacsHours))
+      : Math.max(safeMinHacsHours, 168);
+    SETTINGS_DATA.min_hacs_auto_update_interval_hours = safeMinHacsHours;
+    SETTINGS_DATA.max_hacs_auto_update_interval_hours = safeMaxHacsHours;
+    SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(settingsResp?.hacs_auto_update);
     const rawSchedules = settingsResp?.schedules;
     if (rawSchedules && typeof rawSchedules === 'object'){
       SCHEDULES = {};
@@ -1995,6 +2202,7 @@ async function loadData(){
     renderAutoSyncDelay();
     renderHealthInterval();
     renderEventLimit();
+    renderHacsAutoUpdate();
     renderIntegrity();
     renderCredentialPrompts();
     renderDeviceAccess();
@@ -2010,6 +2218,7 @@ async function loadData(){
     renderAutoSyncDelay();
     renderHealthInterval();
     renderEventLimit();
+    renderHacsAutoUpdate();
     renderIntegrity();
     renderCredentialPrompts();
     renderDeviceAccess();
@@ -2096,6 +2305,30 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   eventLimitInput?.addEventListener('change', commitEventLimit);
   eventLimitInput?.addEventListener('blur', commitEventLimit);
+
+  const hacsToggle = document.getElementById('hacsAutoUpdateToggle');
+  hacsToggle?.addEventListener('change', async () => {
+    await saveHacsAutoUpdate({ enabled: !!hacsToggle.checked });
+  });
+  const hacsInterval = document.getElementById('hacsAutoUpdateInterval');
+  const commitHacsAutoUpdate = async () => {
+    await saveHacsAutoUpdate();
+  };
+  hacsInterval?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
+  hacsInterval?.addEventListener('change', commitHacsAutoUpdate);
+  hacsInterval?.addEventListener('blur', commitHacsAutoUpdate);
+  const hacsEntity = document.getElementById('hacsAutoUpdateEntity');
+  hacsEntity?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
+  hacsEntity?.addEventListener('change', commitHacsAutoUpdate);
+  hacsEntity?.addEventListener('blur', commitHacsAutoUpdate);
+  const hacsBackup = document.getElementById('hacsAutoUpdateBackup');
+  hacsBackup?.addEventListener('change', async () => {
+    await saveHacsAutoUpdate({ backup: !!hacsBackup.checked });
+  });
+  document.getElementById('hacsUpdateCheckBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await runHacsUpdateCheck();
+  });
 
   const healthInput = document.getElementById('healthIntervalInput');
   const commitHealthInterval = async () => {
@@ -2266,6 +2499,37 @@ document.addEventListener('DOMContentLoaded', async () => {
         <div id="healthSavedOverlay" class="saved-overlay">Saved</div>
       </div>
       <div id="healthStatus" class="visually-hidden small mt-2"></div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-header text-white">HACS Auto Update</div>
+    <div class="card-body">
+      <p class="muted">Automatically refresh the HACS update entity for this integration and install an available update. Home Assistant still needs a restart after an integration update is installed.</p>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateToggle">
+        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS updates</label>
+      </div>
+      <div class="row g-2 mt-3">
+        <div class="col-md-4">
+          <label class="form-label" for="hacsAutoUpdateInterval">Check every (hours)</label>
+          <input id="hacsAutoUpdateInterval" class="form-control" type="number" min="1" max="168" step="1" />
+        </div>
+        <div class="col-md-8">
+          <label class="form-label" for="hacsAutoUpdateEntity">Update entity</label>
+          <input id="hacsAutoUpdateEntity" class="form-control" placeholder="Auto detect" />
+          <div class="form-text muted">Leave empty to detect the Akuvox HACS update entity automatically.</div>
+        </div>
+      </div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateBackup">
+        <label class="form-check-label" for="hacsAutoUpdateBackup">Request a backup before install when supported</label>
+      </div>
+      <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+        <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>
+        <span id="hacsAutoUpdateStatus" class="visually-hidden small"></span>
+      </div>
+      <div id="hacsAutoUpdateMeta" class="muted small mt-2"></div>
     </div>
   </div>
 

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -562,6 +562,7 @@ let SETTINGS_DATA = {
   min_access_event_limit: 5,
   max_access_event_limit: 200,
   credential_prompts: { ...DEFAULT_CREDENTIAL_PROMPTS },
+  hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
 };
 let PHONES = [];
 let USERS = [];
@@ -580,6 +581,8 @@ let healthSaving = false;
 let healthSavedTimer = null;
 let eventLimitSaving = false;
 let eventLimitSavedTimer = null;
+let hacsUpdateSaving = false;
+let hacsUpdateChecking = false;
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const EXIT_CLONE_SUFFIX = ' - EP';
 const SCHEDULE_DAY_ORDER = [
@@ -770,6 +773,20 @@ function setEventLimitStatus(text, tone = 'muted') {
   if (tone === 'error') el.classList.add('text-danger');
   else el.classList.add('muted');
 }
+function setHacsAutoUpdateStatus(text, tone = 'muted') {
+  const el = document.getElementById('hacsAutoUpdateStatus');
+  if (!el) return;
+  if (!text) {
+    el.textContent = '';
+    el.className = 'visually-hidden small';
+    return;
+  }
+  el.textContent = text;
+  el.className = 'small';
+  if (tone === 'error') el.classList.add('text-danger');
+  else if (tone === 'success') el.classList.add('text-success');
+  else el.classList.add('muted');
+}
 function setAlertsStatus(text, tone = 'muted') {
   const el = document.getElementById('alertsStatus');
   if (!el) return;
@@ -804,6 +821,138 @@ function eventLimitRange(){
   let max = Number.isFinite(maxRaw) ? Math.round(maxRaw) : 200;
   if (max < min) max = min;
   return { min, max };
+}
+
+function hacsAutoUpdateRange(){
+  const minRaw = Number(SETTINGS_DATA?.min_hacs_auto_update_interval_hours);
+  const maxRaw = Number(SETTINGS_DATA?.max_hacs_auto_update_interval_hours);
+  const min = Number.isFinite(minRaw) ? Math.max(1, Math.round(minRaw)) : 1;
+  let max = Number.isFinite(maxRaw) ? Math.round(maxRaw) : 168;
+  if (max < min) max = min;
+  return { min, max };
+}
+
+function coerceHacsBool(value){
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') return ['1','true','yes','on','enabled'].includes(value.trim().toLowerCase());
+  return false;
+}
+
+function sanitizeHacsAutoUpdate(raw){
+  const { min, max } = hacsAutoUpdateRange();
+  const base = {
+    enabled: false,
+    interval_hours: 24,
+    update_entity: '',
+    backup: false,
+    last_checked: null,
+    last_installed: null,
+    last_result: 'disabled',
+    last_error: null,
+    last_entity_id: null,
+    installed_version: null,
+    latest_version: null,
+    active: false,
+  };
+  if (raw && typeof raw === 'object'){
+    base.enabled = coerceHacsBool(raw.enabled);
+    base.backup = coerceHacsBool(raw.backup);
+    const interval = Number(raw.interval_hours);
+    if (Number.isFinite(interval)) base.interval_hours = Math.round(interval);
+    base.update_entity = String(raw.update_entity || '').trim();
+    ['last_checked','last_installed','last_result','last_error','last_entity_id','installed_version','latest_version'].forEach((key) => {
+      if (raw[key] !== undefined && raw[key] !== null && raw[key] !== '') base[key] = String(raw[key]);
+    });
+    base.active = coerceHacsBool(raw.active);
+  }
+  if (base.interval_hours < min) base.interval_hours = min;
+  if (base.interval_hours > max) base.interval_hours = max;
+  if (!base.last_result) base.last_result = base.enabled ? 'enabled' : 'disabled';
+  return base;
+}
+
+function formatHacsDate(value){
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toLocaleString();
+}
+
+function hacsStatusTone(config){
+  const result = String(config?.last_result || '').toLowerCase();
+  if (['check_failed','install_failed','entity_not_found'].includes(result)) return 'error';
+  if (['installed','up_to_date','enabled'].includes(result)) return 'success';
+  return 'muted';
+}
+
+function describeHacsResult(config){
+  const result = String(config?.last_result || '').toLowerCase();
+  if (result === 'installed') return 'Update installed. Restart Home Assistant to load it.';
+  if (result === 'up_to_date') return 'No update available.';
+  if (result === 'check_failed') return 'Update check failed.';
+  if (result === 'install_failed') return 'Update install failed.';
+  if (result === 'entity_not_found') return 'HACS update entity was not found.';
+  if (result === 'disabled') return 'Automatic HACS updates are disabled.';
+  if (config?.enabled) return config?.active ? 'Automatic HACS updates are enabled.' : 'Automatic HACS updates will start after reload.';
+  return 'Automatic HACS updates are disabled.';
+}
+
+function readHacsAutoUpdateForm(){
+  const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
+  const { min, max } = hacsAutoUpdateRange();
+  const toggle = document.getElementById('hacsAutoUpdateToggle');
+  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const entityInput = document.getElementById('hacsAutoUpdateEntity');
+  const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  if (toggle) cfg.enabled = !!toggle.checked;
+  if (backupInput) cfg.backup = !!backupInput.checked;
+  if (entityInput) cfg.update_entity = String(entityInput.value || '').trim();
+  if (intervalInput){
+    const raw = String(intervalInput.value || '').trim();
+    const interval = Number(raw);
+    if (!raw || !Number.isFinite(interval)){
+      throw new Error(`Enter a number between ${min} and ${max}`);
+    }
+    const value = Math.round(interval);
+    if (value < min || value > max){
+      throw new Error(`Enter a number between ${min} and ${max}`);
+    }
+    cfg.interval_hours = value;
+  }
+  return cfg;
+}
+
+function renderHacsAutoUpdate(){
+  const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
+  SETTINGS_DATA.hacs_auto_update = cfg;
+  const { min, max } = hacsAutoUpdateRange();
+  const toggle = document.getElementById('hacsAutoUpdateToggle');
+  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const entityInput = document.getElementById('hacsAutoUpdateEntity');
+  const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+  const meta = document.getElementById('hacsAutoUpdateMeta');
+  if (toggle) toggle.checked = !!cfg.enabled;
+  if (backupInput) backupInput.checked = !!cfg.backup;
+  if (intervalInput){
+    intervalInput.min = String(min);
+    intervalInput.max = String(max);
+    intervalInput.value = String(cfg.interval_hours);
+  }
+  if (entityInput) entityInput.value = cfg.update_entity || '';
+  if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
+  if (meta){
+    const details = [
+      `Last checked: ${formatHacsDate(cfg.last_checked)}`,
+    ];
+    if (cfg.last_installed) details.push(`Last installed: ${formatHacsDate(cfg.last_installed)}`);
+    if (cfg.last_entity_id) details.push(`Entity: ${cfg.last_entity_id}`);
+    if (cfg.installed_version || cfg.latest_version) details.push(`Version: ${cfg.installed_version || 'unknown'} to ${cfg.latest_version || 'unknown'}`);
+    if (cfg.last_error) details.push(`Error: ${cfg.last_error}`);
+    meta.textContent = details.join(' | ');
+  }
+  setHacsAutoUpdateStatus(describeHacsResult(cfg), hacsStatusTone(cfg));
 }
 
 function renderAutoSyncDelay(){
@@ -883,6 +1032,54 @@ async function saveEventLimit(){
     alert('Failed to update event history limit: ' + (err && err.message ? err.message : err));
   } finally {
     eventLimitSaving = false;
+  }
+}
+
+async function saveHacsAutoUpdate(patch = {}){
+  if (hacsUpdateSaving) return;
+  let next;
+  try {
+    next = { ...readHacsAutoUpdateForm(), ...patch };
+  } catch (err) {
+    setHacsAutoUpdateStatus(err && err.message ? err.message : String(err), 'error');
+    return;
+  }
+  SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(next);
+  hacsUpdateSaving = true;
+  setHacsAutoUpdateStatus('Saving...');
+  try {
+    const res = await apiPost(API_SETTINGS, { hacs_auto_update: SETTINGS_DATA.hacs_auto_update });
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+    setHacsAutoUpdateStatus('Saved', 'success');
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to save HACS auto update settings', 'error');
+  } finally {
+    hacsUpdateSaving = false;
+  }
+}
+
+async function runHacsUpdateCheck(){
+  if (hacsUpdateChecking) return;
+  hacsUpdateChecking = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Checking HACS update entity...');
+  try {
+    const res = await callAction('hacs_update_check');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'HACS update check failed', 'error');
+  } finally {
+    hacsUpdateChecking = false;
+    const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+    if (checkBtn) checkBtn.disabled = false;
   }
 }
 
@@ -1913,6 +2110,7 @@ async function loadData(){
       auto_sync_delay_minutes: 30,
       health_check_interval_seconds: 30,
       access_event_limit: 30,
+      hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
       alerts: { targets: {} },
       registry_users: [],
     };
@@ -1986,6 +2184,15 @@ async function loadData(){
       ? { ...settingsResp.capabilities }
       : { alarm_relay: false };
     SETTINGS_DATA.credential_prompts = sanitizeCredentialPrompts(settingsResp?.credential_prompts);
+    const minHacsHours = Number(settingsResp?.min_hacs_auto_update_interval_hours);
+    const maxHacsHours = Number(settingsResp?.max_hacs_auto_update_interval_hours);
+    const safeMinHacsHours = Number.isFinite(minHacsHours) ? Math.max(1, Math.round(minHacsHours)) : 1;
+    const safeMaxHacsHours = Number.isFinite(maxHacsHours)
+      ? Math.max(safeMinHacsHours, Math.round(maxHacsHours))
+      : Math.max(safeMinHacsHours, 168);
+    SETTINGS_DATA.min_hacs_auto_update_interval_hours = safeMinHacsHours;
+    SETTINGS_DATA.max_hacs_auto_update_interval_hours = safeMaxHacsHours;
+    SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(settingsResp?.hacs_auto_update);
     const rawSchedules = settingsResp?.schedules;
     if (rawSchedules && typeof rawSchedules === 'object'){
       SCHEDULES = {};
@@ -2000,6 +2207,7 @@ async function loadData(){
     renderAutoSyncDelay();
     renderHealthInterval();
     renderEventLimit();
+    renderHacsAutoUpdate();
     renderIntegrity();
     renderCredentialPrompts();
     renderDeviceAccess();
@@ -2015,6 +2223,7 @@ async function loadData(){
     renderAutoSyncDelay();
     renderHealthInterval();
     renderEventLimit();
+    renderHacsAutoUpdate();
     renderIntegrity();
     renderCredentialPrompts();
     renderDeviceAccess();
@@ -2144,6 +2353,30 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   eventLimitInput?.addEventListener('change', commitEventLimit);
   eventLimitInput?.addEventListener('blur', commitEventLimit);
+
+  const hacsToggle = document.getElementById('hacsAutoUpdateToggle');
+  hacsToggle?.addEventListener('change', async () => {
+    await saveHacsAutoUpdate({ enabled: !!hacsToggle.checked });
+  });
+  const hacsInterval = document.getElementById('hacsAutoUpdateInterval');
+  const commitHacsAutoUpdate = async () => {
+    await saveHacsAutoUpdate();
+  };
+  hacsInterval?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
+  hacsInterval?.addEventListener('change', commitHacsAutoUpdate);
+  hacsInterval?.addEventListener('blur', commitHacsAutoUpdate);
+  const hacsEntity = document.getElementById('hacsAutoUpdateEntity');
+  hacsEntity?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
+  hacsEntity?.addEventListener('change', commitHacsAutoUpdate);
+  hacsEntity?.addEventListener('blur', commitHacsAutoUpdate);
+  const hacsBackup = document.getElementById('hacsAutoUpdateBackup');
+  hacsBackup?.addEventListener('change', async () => {
+    await saveHacsAutoUpdate({ backup: !!hacsBackup.checked });
+  });
+  document.getElementById('hacsUpdateCheckBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await runHacsUpdateCheck();
+  });
 
   const integrityInput = document.getElementById('integrityInput');
   const commitIntegrity = async () => {
@@ -2281,6 +2514,37 @@ document.addEventListener('DOMContentLoaded', async () => {
         <div id="eventLimitSavedOverlay" class="saved-overlay">Saved</div>
       </div>
       <div id="eventLimitStatus" class="visually-hidden small mt-2"></div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-header">HACS Auto Update</div>
+    <div class="card-body">
+      <p class="muted">Automatically refresh the HACS update entity for this integration and install an available update. Home Assistant still needs a restart after an integration update is installed.</p>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateToggle">
+        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS updates</label>
+      </div>
+      <div class="row g-2 mt-3">
+        <div class="col-md-4">
+          <label class="form-label" for="hacsAutoUpdateInterval">Check every (hours)</label>
+          <input id="hacsAutoUpdateInterval" class="form-control" type="number" min="1" max="168" step="1" />
+        </div>
+        <div class="col-md-8">
+          <label class="form-label" for="hacsAutoUpdateEntity">Update entity</label>
+          <input id="hacsAutoUpdateEntity" class="form-control" placeholder="Auto detect" />
+          <div class="form-text muted">Leave empty to detect the Akuvox HACS update entity automatically.</div>
+        </div>
+      </div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateBackup">
+        <label class="form-check-label" for="hacsAutoUpdateBackup">Request a backup before install when supported</label>
+      </div>
+      <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+        <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>
+        <span id="hacsAutoUpdateStatus" class="visually-hidden small"></span>
+      </div>
+      <div id="hacsAutoUpdateMeta" class="muted small mt-2"></div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Add a managed HACS auto-updater that refreshes the Akuvox HACS update entity and installs an available update.
- Add Global Settings controls for desktop and mobile: enable/disable, interval, optional update entity override, backup request, status, and Check now.
- Add a dashboard `Check HACS Update` button on desktop and mobile to trigger the update cycle instantly.
- Add an `akuvox_ac.hacs_update_check` service and UI action for manual checks.

## Notes
This uses Home Assistant update entities rather than creating a separate HA automation YAML entry, so the feature is owned by the integration settings and cleaned up with the integration lifecycle.

## Validation
- `git diff --check`
- Inline dashboard/settings page scripts parsed with Node `new Function(...)`
- Python/pytest not run: Python is unavailable in this workspace.