### PR TITLE
[codex] Fix HACS auto update latest detection

### DIFF
--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2998,6 +2998,8 @@ class HacsAutoUpdater:
     """Managed HACS update checker for this custom integration."""
 
     REPOSITORY = "DJGLTD/AK_Access_ctrl"
+    DEFAULT_BRANCH = "main"
+    GITHUB_COMMIT_URL = f"https://api.github.com/repos/{REPOSITORY}/commits/{DEFAULT_BRANCH}"
     MATCHERS = (
         "djgltd/ak_access_ctrl",
         "ak_access_ctrl",
@@ -3185,6 +3187,67 @@ class HacsAutoUpdater:
         skipped = str(attrs.get("skipped_version") or "").strip()
         return bool(latest and installed and latest != installed and latest != skipped)
 
+    @staticmethod
+    def _version_text(version: Any) -> str:
+        return str(version or "").strip()
+
+    @classmethod
+    def _short_version(cls, version: Any) -> Optional[str]:
+        text = cls._version_text(version)
+        if not text:
+            return None
+        if re.fullmatch(r"[0-9a-fA-F]{7,40}", text):
+            return text[:7].lower()
+        return text
+
+    @classmethod
+    def _versions_match(cls, left: Any, right: Any) -> bool:
+        left_text = cls._version_text(left).lower()
+        right_text = cls._version_text(right).lower()
+        if not left_text or not right_text:
+            return False
+        if left_text == right_text:
+            return True
+        if re.fullmatch(r"[0-9a-f]{7,40}", left_text) and re.fullmatch(
+            r"[0-9a-f]{7,40}", right_text
+        ):
+            return left_text.startswith(right_text) or right_text.startswith(left_text)
+        return False
+
+    async def _fetch_latest_github_sha(self) -> Optional[str]:
+        session = async_get_clientsession(self.hass)
+        if asyncio.iscoroutine(session):
+            session = await session
+        if session is None or not hasattr(session, "get"):
+            return None
+
+        response_cm = session.get(
+            self.GITHUB_COMMIT_URL,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "HomeAssistant-Akuvox-Access-Control",
+            },
+            timeout=20,
+        )
+        async with response_cm as response:
+            status = int(getattr(response, "status", 0) or 0)
+            if status >= 400:
+                body = ""
+                try:
+                    body = await response.text()
+                except Exception:
+                    body = ""
+                message = f"GitHub latest commit check failed with HTTP {status}"
+                if body:
+                    message = f"{message}: {body[:200]}"
+                raise RuntimeError(message)
+            payload = await response.json()
+
+        sha = str((payload or {}).get("sha") or "").strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{40}", sha):
+            raise RuntimeError("GitHub latest commit response did not include a valid SHA.")
+        return sha
+
     async def _record_status(self, **updates: Any) -> Dict[str, Any]:
         settings = self._settings_store()
         if settings and hasattr(settings, "update_hacs_auto_update_status"):
@@ -3255,7 +3318,17 @@ class HacsAutoUpdater:
 
             attrs = getattr(state, "attributes", {}) or {}
             installed = attrs.get("installed_version")
-            latest = attrs.get("latest_version")
+            hacs_latest = attrs.get("latest_version")
+            latest = hacs_latest
+            github_latest_sha: Optional[str] = None
+            github_error: Optional[str] = None
+            try:
+                github_latest_sha = await self._fetch_latest_github_sha()
+            except Exception as err:
+                github_error = str(err)
+            if github_latest_sha:
+                latest = self._short_version(github_latest_sha)
+
             base_status = {
                 "last_checked": checked_at,
                 "last_entity_id": entity_id,
@@ -3263,7 +3336,19 @@ class HacsAutoUpdater:
                 "latest_version": latest,
             }
 
-            if not self._update_available(state):
+            install_version: Optional[str] = None
+            has_update = self._update_available(state)
+            if github_latest_sha and not self._versions_match(installed, github_latest_sha):
+                has_update = True
+                install_version = github_latest_sha
+
+            if not has_update:
+                if github_error:
+                    return await self._record_status(
+                        **base_status,
+                        last_result="check_failed",
+                        last_error=github_error,
+                    )
                 return await self._record_status(
                     **base_status,
                     last_result="up_to_date",
@@ -3271,6 +3356,8 @@ class HacsAutoUpdater:
                 )
 
             service_data: Dict[str, Any] = {"entity_id": entity_id}
+            if install_version:
+                service_data["version"] = install_version
             if config.get("backup"):
                 service_data["backup"] = True
 

--- a/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
+++ b/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
@@ -1,0 +1,134 @@
+import asyncio
+from typing import Any, Dict, List, Tuple
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac import integration as integration_module  # noqa: E402
+from custom_components.akuvox_ac.const import DOMAIN  # noqa: E402
+from custom_components.akuvox_ac.integration import (  # noqa: E402
+    AkuvoxSettingsStore,
+    HacsAutoUpdater,
+)
+
+
+LATEST_SHA = "71d1bd2556e9377b183e73b73a8fda88fdfa89cc"
+
+
+class _State:
+    entity_id = "update.akuvox_access_control_update"
+    state = "off"
+    attributes = {
+        "friendly_name": "Akuvox Access Control update",
+        "repository": "DJGLTD/AK_Access_ctrl",
+        "installed_version": "3175ae3",
+        "latest_version": "3175ae3",
+    }
+
+
+class _States:
+    def __init__(self, state: _State) -> None:
+        self._state = state
+
+    def async_all(self, domain: str | None = None) -> List[_State]:
+        return [self._state] if domain in (None, "update") else []
+
+    def get(self, entity_id: str) -> _State | None:
+        return self._state if entity_id == self._state.entity_id else None
+
+
+class _Services:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, str, Dict[str, Any], bool]] = []
+
+    async def async_call(
+        self,
+        domain: str,
+        service: str,
+        data: Dict[str, Any] | None = None,
+        *,
+        blocking: bool = False,
+        **_: Any,
+    ) -> None:
+        self.calls.append((domain, service, dict(data or {}), blocking))
+
+
+class _Hass:
+    def __init__(self, settings: AkuvoxSettingsStore) -> None:
+        self.states = _States(_State())
+        self.services = _Services()
+        self.data = {DOMAIN: {"settings_store": settings}}
+
+
+class _GithubResponse:
+    status = 200
+
+    async def __aenter__(self) -> "_GithubResponse":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def json(self) -> Dict[str, str]:
+        return {"sha": LATEST_SHA}
+
+
+class _GithubSession:
+    def get(self, *_: Any, **__: Any) -> _GithubResponse:
+        return _GithubResponse()
+
+
+def _settings_store() -> AkuvoxSettingsStore:
+    store = object.__new__(AkuvoxSettingsStore)
+    store.data = {
+        "hacs_auto_update": {
+            "enabled": True,
+            "interval_hours": 24,
+            "update_entity": "",
+            "backup": False,
+            "last_result": "enabled",
+        }
+    }
+    store.saved = 0
+
+    async def _async_save():
+        store.saved += 1
+
+    store.async_save = _async_save
+    return store
+
+
+def test_hacs_auto_update_installs_github_head_when_hacs_entity_is_stale(monkeypatch):
+    store = _settings_store()
+    hass = _Hass(store)
+    monkeypatch.setattr(
+        integration_module,
+        "async_get_clientsession",
+        lambda _hass: _GithubSession(),
+    )
+
+    status = asyncio.run(HacsAutoUpdater(hass).async_run_check(force=True))
+
+    install_calls = [
+        call for call in hass.services.calls if call[0] == "update" and call[1] == "install"
+    ]
+    assert install_calls == [
+        (
+            "update",
+            "install",
+            {
+                "entity_id": "update.akuvox_access_control_update",
+                "version": LATEST_SHA,
+            },
+            True,
+        )
+    ]
+    assert status["last_result"] == "installed"
+    assert status["installed_version"] == "3175ae3"
+    assert status["latest_version"] == "71d1bd2"
+
+
+def test_hacs_auto_update_matches_short_and_full_commit_versions():
+    assert HacsAutoUpdater._versions_match("71d1bd2", LATEST_SHA) is True
+    assert HacsAutoUpdater._versions_match("3175ae3", LATEST_SHA) is False


### PR DESCRIPTION
## Summary

- Checks the GitHub `main` commit directly during the HACS auto-update cycle.
- Uses the GitHub commit SHA as the install target when HACS' update entity still reports stale `installed_version`/`latest_version` values.
- Records the GitHub short SHA in the dashboard status so the dashboard can show `3175ae3` to `71d1bd2` instead of `3175ae3` to `3175ae3`.
- Adds a unit test covering the stale-HACS-entity case.

## Root cause

The existing updater called `homeassistant.update_entity` and then trusted the HACS update entity. In the reported case, the HACS entity still had both `installed_version` and `latest_version` as `3175ae3`, so the updater returned `up_to_date` before asking HACS to install anything.

## Validation

- Ran `git diff --check` against `origin/main..HEAD`.
- Added `test_hacs_auto_update_installs_github_head_when_hacs_entity_is_stale`.
- Python/pytest were not run because `python` and `py` are not installed on this machine.

## Notes

HACS documents that `update.install` supports a full commit SHA as the version value. This PR uses the full SHA from GitHub for installation, while showing the short SHA in the dashboard status.