### PR TITLE
[codex] Add restart button after HACS update

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -3146,6 +3146,35 @@ class AkuvoxUIAction(AkuvoxUIView):
                 _LOGGER.debug("HACS update check failed via UI: %s", service_err)
                 return err(service_err)
 
+        if action == "restart_homeassistant":
+            if not _request_can_manage_dashboard_access(request):
+                return err("administrator access required", code=403)
+            try:
+                await hass.services.async_call(
+                    "homeassistant",
+                    "restart",
+                    {},
+                    blocking=False,
+                    context=ctx,
+                )
+                status = None
+                settings = root.get("settings_store")
+                if settings and hasattr(settings, "update_hacs_auto_update_status"):
+                    try:
+                        status = await settings.update_hacs_auto_update_status(
+                            last_result="restart_requested",
+                            last_error=None,
+                        )
+                    except Exception:
+                        status = None
+                response = {"ok": True}
+                if status is not None:
+                    response["hacs_auto_update"] = status
+                return web.json_response(response)
+            except Exception as service_err:
+                _LOGGER.debug("Home Assistant restart failed via UI: %s", service_err)
+                return err(service_err)
+
         if action in ("force_full_sync", "sync_all"):
             queue = root.get("sync_queue")
             manager = root.get("sync_manager")

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -620,6 +620,7 @@ let eventLimitSaving = false;
 let eventLimitSavedTimer = null;
 let hacsUpdateSaving = false;
 let hacsUpdateChecking = false;
+let hacsRestarting = false;
 let dashboardAccessSaving = false;
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const EXIT_CLONE_SUFFIX = ' - EP';
@@ -928,13 +929,14 @@ function formatHacsDate(value){
 function hacsStatusTone(config){
   const result = String(config?.last_result || '').toLowerCase();
   if (['check_failed','install_failed','entity_not_found'].includes(result)) return 'error';
-  if (['installed','up_to_date','enabled'].includes(result)) return 'success';
+  if (['installed','restart_requested','up_to_date','enabled'].includes(result)) return 'success';
   return 'muted';
 }
 
 function describeHacsResult(config){
   const result = String(config?.last_result || '').toLowerCase();
   if (result === 'installed') return 'Update installed. Restart Home Assistant to load it.';
+  if (result === 'restart_requested') return 'Restart requested. Home Assistant is restarting...';
   if (result === 'up_to_date') return 'No update available.';
   if (result === 'check_failed') return 'Update check failed.';
   if (result === 'install_failed') return 'Update install failed.';
@@ -978,7 +980,10 @@ function renderHacsAutoUpdate(){
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
   const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+  const restartBtn = document.getElementById('hacsRestartNowBtn');
   const meta = document.getElementById('hacsAutoUpdateMeta');
+  const updateInstalled = String(cfg.last_result || '').toLowerCase() === 'installed';
+  const canRestart = !!(SETTINGS_DATA.dashboard_access?.can_manage || SETTINGS_DATA.dashboard_access?.current_user_is_admin);
   if (toggle) toggle.checked = !!cfg.enabled;
   if (backupInput) backupInput.checked = !!cfg.backup;
   if (intervalInput){
@@ -988,6 +993,10 @@ function renderHacsAutoUpdate(){
   }
   if (entityInput) entityInput.value = cfg.update_entity || '';
   if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
+  if (restartBtn) {
+    restartBtn.classList.toggle('d-none', !(canRestart && (updateInstalled || hacsRestarting)));
+    restartBtn.disabled = hacsRestarting;
+  }
   if (meta){
     const details = [
       `Last checked: ${formatHacsDate(cfg.last_checked)}`,
@@ -1126,6 +1135,29 @@ async function runHacsUpdateCheck(){
     hacsUpdateChecking = false;
     const checkBtn = document.getElementById('hacsUpdateCheckBtn');
     if (checkBtn) checkBtn.disabled = false;
+  }
+}
+
+async function restartHomeAssistantNow(){
+  if (hacsRestarting) return;
+  if (!confirm('Restart Home Assistant now? The dashboard will disconnect while Home Assistant restarts.')) {
+    return;
+  }
+  hacsRestarting = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Restarting Home Assistant...');
+  try {
+    const res = await callAction('restart_homeassistant');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+    setHacsAutoUpdateStatus('Restart requested. Home Assistant is restarting...', 'success');
+  } catch (err) {
+    hacsRestarting = false;
+    renderHacsAutoUpdate();
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to restart Home Assistant', 'error');
   }
 }
 
@@ -2475,6 +2507,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     ev.preventDefault();
     await runHacsUpdateCheck();
   });
+  document.getElementById('hacsRestartNowBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await restartHomeAssistantNow();
+  });
 
   document.getElementById('dashboardAccessUsers')?.addEventListener('change', async (ev) => {
     const target = ev.target;
@@ -2689,6 +2725,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       </div>
       <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
         <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>
+        <button id="hacsRestartNowBtn" class="btn btn-warning btn-sm d-none" type="button"><i class="bi bi-power me-1"></i>Restart Home Assistant</button>
         <span id="hacsAutoUpdateStatus" class="visually-hidden small"></span>
       </div>
       <div id="hacsAutoUpdateMeta" class="muted small mt-2"></div>

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -622,6 +622,7 @@ let eventLimitSaving = false;
 let eventLimitSavedTimer = null;
 let hacsUpdateSaving = false;
 let hacsUpdateChecking = false;
+let hacsRestarting = false;
 let dashboardAccessSaving = false;
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const EXIT_CLONE_SUFFIX = ' - EP';
@@ -930,13 +931,14 @@ function formatHacsDate(value){
 function hacsStatusTone(config){
   const result = String(config?.last_result || '').toLowerCase();
   if (['check_failed','install_failed','entity_not_found'].includes(result)) return 'error';
-  if (['installed','up_to_date','enabled'].includes(result)) return 'success';
+  if (['installed','restart_requested','up_to_date','enabled'].includes(result)) return 'success';
   return 'muted';
 }
 
 function describeHacsResult(config){
   const result = String(config?.last_result || '').toLowerCase();
   if (result === 'installed') return 'Update installed. Restart Home Assistant to load it.';
+  if (result === 'restart_requested') return 'Restart requested. Home Assistant is restarting...';
   if (result === 'up_to_date') return 'No update available.';
   if (result === 'check_failed') return 'Update check failed.';
   if (result === 'install_failed') return 'Update install failed.';
@@ -980,7 +982,10 @@ function renderHacsAutoUpdate(){
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
   const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+  const restartBtn = document.getElementById('hacsRestartNowBtn');
   const meta = document.getElementById('hacsAutoUpdateMeta');
+  const updateInstalled = String(cfg.last_result || '').toLowerCase() === 'installed';
+  const canRestart = !!(SETTINGS_DATA.dashboard_access?.can_manage || SETTINGS_DATA.dashboard_access?.current_user_is_admin);
   if (toggle) toggle.checked = !!cfg.enabled;
   if (backupInput) backupInput.checked = !!cfg.backup;
   if (intervalInput){
@@ -990,6 +995,10 @@ function renderHacsAutoUpdate(){
   }
   if (entityInput) entityInput.value = cfg.update_entity || '';
   if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
+  if (restartBtn) {
+    restartBtn.classList.toggle('d-none', !(canRestart && (updateInstalled || hacsRestarting)));
+    restartBtn.disabled = hacsRestarting;
+  }
   if (meta){
     const details = [
       `Last checked: ${formatHacsDate(cfg.last_checked)}`,
@@ -1128,6 +1137,29 @@ async function runHacsUpdateCheck(){
     hacsUpdateChecking = false;
     const checkBtn = document.getElementById('hacsUpdateCheckBtn');
     if (checkBtn) checkBtn.disabled = false;
+  }
+}
+
+async function restartHomeAssistantNow(){
+  if (hacsRestarting) return;
+  if (!confirm('Restart Home Assistant now? The dashboard will disconnect while Home Assistant restarts.')) {
+    return;
+  }
+  hacsRestarting = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Restarting Home Assistant...');
+  try {
+    const res = await callAction('restart_homeassistant');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+    setHacsAutoUpdateStatus('Restart requested. Home Assistant is restarting...', 'success');
+  } catch (err) {
+    hacsRestarting = false;
+    renderHacsAutoUpdate();
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to restart Home Assistant', 'error');
   }
 }
 
@@ -2523,6 +2555,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     ev.preventDefault();
     await runHacsUpdateCheck();
   });
+  document.getElementById('hacsRestartNowBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await restartHomeAssistantNow();
+  });
 
   document.getElementById('dashboardAccessUsers')?.addEventListener('change', async (ev) => {
     const target = ev.target;
@@ -2704,6 +2740,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       </div>
       <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
         <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>
+        <button id="hacsRestartNowBtn" class="btn btn-warning btn-sm d-none" type="button"><i class="bi bi-power me-1"></i>Restart Home Assistant</button>
         <span id="hacsAutoUpdateStatus" class="visually-hidden small"></span>
       </div>
       <div id="hacsAutoUpdateMeta" class="muted small mt-2"></div>


### PR DESCRIPTION
## Summary

- Adds a `Restart Home Assistant` button to the HACS Auto Update card after an update is successfully installed.
- Shows the restart button only to Home Assistant admins and only while the HACS updater status is `installed`.
- Adds a protected dashboard API action that calls `homeassistant.restart` and rejects non-admin users.
- Marks the updater status as `restart_requested` after the restart call is accepted, so the installed-update prompt does not keep asking for another restart.

## Validation

- Ran `git diff --check`.
- Parsed the inline scripts in `settings.html` and `settings-mob.html` with `new Function(...)`.
- Python/pytest were not run because `python` and `py` are not installed on this machine.