### PR TITLE
[codex] Add user expiry reminders

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1496,6 +1496,9 @@ DASHBOARD_ROUTES: Dict[str, str] = {
     "temp-user-mob": "temp_user-mob",
     "temp_user-mob": "temp_user-mob",
     "temp_user-mob.html": "temp_user-mob",
+    "expiry-review": "expiry_review",
+    "expiry_review": "expiry_review",
+    "expiry_review.html": "expiry_review",
     "settings": "settings",
     "settings.html": "settings",
     "settings-mob": "settings-mob",
@@ -2982,7 +2985,7 @@ class AkuvoxUIView(HomeAssistantView):
                             "access_level": prof.get("access_level") or "",
                             "access_start": access_start.isoformat() if access_start else "",
                             "access_end": access_end.isoformat() if access_end else "",
-                            "access_expired": bool(access_end and access_end <= today),
+                            "access_expired": bool(access_end and access_end < today),
                             "access_in_future": bool(access_start and access_start > today),
                             "temporary": bool(prof.get("temporary")),
                             "temporary_one_time": bool(prof.get("temporary_one_time")),
@@ -3106,6 +3109,76 @@ class AkuvoxUIAction(AkuvoxUIView):
                 days = payload.get("days") or []
                 root["sync_manager"].set_auto_reboot(t, days)
                 return web.json_response({"ok": True})
+            except Exception as e:
+                return err(e)
+
+        if action == "extend_user_access":
+            raw_user_id = payload.get("id") or payload.get("user_id")
+            user_id = normalize_user_id(raw_user_id) or str(raw_user_id or "").strip()
+            if not user_id:
+                return err("user id is required")
+            access_end = _parse_access_date(payload.get("access_end"))
+            if not access_end:
+                return err("access_end is required")
+
+            users_store = root.get("users_store")
+            if not users_store:
+                return err("users store unavailable", code=500)
+            try:
+                profile = users_store.get(user_id) or {}
+            except Exception:
+                profile = {}
+            if not isinstance(profile, dict):
+                profile = {}
+
+            schedule_name = None
+            schedule_id = None
+            status = str(profile.get("status") or "").strip().lower()
+            if (
+                status == "deleted"
+                or str(profile.get("schedule_id") or "").strip() == "1002"
+                or str(profile.get("schedule_name") or "").strip().lower() == "no access"
+            ):
+                schedule_name = "24/7 Access"
+                schedule_id = "1001"
+
+            try:
+                await users_store.upsert_profile(
+                    user_id,
+                    access_end=access_end.isoformat(),
+                    status="active",
+                    schedule_name=schedule_name,
+                    schedule_id=schedule_id,
+                    temporary_used_at="",
+                )
+                queue = root.get("sync_queue")
+                if queue:
+                    queue.mark_change(
+                        None,
+                        delay_minutes=0,
+                        full=True,
+                        trigger=f"extend user access: {user_id}",
+                    )
+                return web.json_response(
+                    {"ok": True, "id": user_id, "access_end": access_end.isoformat()}
+                )
+            except Exception as e:
+                return err(e)
+
+        if action == "revoke_user_access":
+            raw_user_id = payload.get("id") or payload.get("user_id")
+            user_id = normalize_user_id(raw_user_id) or str(raw_user_id or "").strip()
+            if not user_id:
+                return err("user id is required")
+            try:
+                await hass.services.async_call(
+                    DOMAIN,
+                    "delete_user",
+                    {"id": user_id},
+                    blocking=True,
+                    context=ctx,
+                )
+                return web.json_response({"ok": True, "id": user_id})
             except Exception as e:
                 return err(e)
 
@@ -4335,6 +4408,7 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
                     {
                         "device_offline": bool(config.get("device_offline")),
                         "integrity_failed": bool(config.get("integrity_failed")),
+                        "access_expiring": bool(config.get("access_expiring")),
                         "any_denied": bool(config.get("any_denied")),
                         "granted_any": bool(granted.get("any")),
                         "granted_users": granted_users,

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -8,6 +8,7 @@ import re
 import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Callable, Set, Coroutine
+from urllib.parse import urlencode
 
 from homeassistant.const import Platform
 
@@ -2717,6 +2718,9 @@ class AkuvoxSettingsStore(Store):
         "installed_version": None,
         "latest_version": None,
     }
+    DEFAULT_EXPIRY_REMINDERS = {
+        "last_sent": {},
+    }
 
     def __init__(self, hass: HomeAssistant):
         super().__init__(hass, 1, f"{DOMAIN}_settings.json")
@@ -2733,6 +2737,7 @@ class AkuvoxSettingsStore(Store):
             "access_history_limit": DEFAULT_ACCESS_HISTORY_LIMIT,
             "hacs_auto_update": dict(self.DEFAULT_HACS_AUTO_UPDATE),
             "dashboard_access": {"allowed_user_ids": []},
+            "expiry_reminders": {"last_sent": {}},
         }
 
     async def async_load(self):
@@ -2771,6 +2776,9 @@ class AkuvoxSettingsStore(Store):
         targets = alerts.get("targets") if isinstance(alerts, dict) else {}
         alerts["targets"] = self._sanitize_alert_targets(targets)
         self.data["alerts"] = alerts
+        self.data["expiry_reminders"] = self._sanitize_expiry_reminders(
+            self.data.get("expiry_reminders")
+        )
 
         try:
             history_limit = self._normalize_diagnostics_history_limit(
@@ -3081,6 +3089,7 @@ class AkuvoxSettingsStore(Store):
                 if isinstance(cfg, dict):
                     data["device_offline"] = bool(cfg.get("device_offline"))
                     data["integrity_failed"] = bool(cfg.get("integrity_failed"))
+                    data["access_expiring"] = bool(cfg.get("access_expiring"))
                     data["any_denied"] = bool(cfg.get("any_denied"))
                     granted_cfg = cfg.get("granted") if isinstance(cfg.get("granted"), dict) else {}
                     if not granted_cfg and isinstance(cfg.get("granted_users"), list):
@@ -3091,6 +3100,7 @@ class AkuvoxSettingsStore(Store):
                 else:
                     data["device_offline"] = False
                     data["integrity_failed"] = False
+                    data["access_expiring"] = False
                     data["any_denied"] = False
                     granted_cfg = {}
 
@@ -3143,6 +3153,40 @@ class AkuvoxSettingsStore(Store):
             await self.set_alert_targets(updated)
         return changed
 
+    def _sanitize_expiry_reminders(self, raw: Any) -> Dict[str, Any]:
+        last_sent: Dict[str, str] = {}
+        if isinstance(raw, dict):
+            raw_last_sent = raw.get("last_sent")
+            if isinstance(raw_last_sent, dict):
+                for key, value in raw_last_sent.items():
+                    canonical = normalize_user_id(key) or str(key or "").strip()
+                    normalized_date = _normalize_access_date(value)
+                    if canonical and normalized_date:
+                        last_sent[canonical] = normalized_date
+        return {"last_sent": last_sent}
+
+    def get_expiry_reminders(self) -> Dict[str, Any]:
+        return self._sanitize_expiry_reminders(self.data.get("expiry_reminders"))
+
+    def expiry_reminder_sent(self, user_id: Any, access_end: Any) -> bool:
+        canonical = normalize_user_id(user_id) or str(user_id or "").strip()
+        normalized_date = _normalize_access_date(access_end)
+        if not canonical or not normalized_date:
+            return False
+        last_sent = self.get_expiry_reminders().get("last_sent") or {}
+        return str(last_sent.get(canonical) or "") == normalized_date
+
+    async def mark_expiry_reminder_sent(self, user_id: Any, access_end: Any) -> None:
+        canonical = normalize_user_id(user_id) or str(user_id or "").strip()
+        normalized_date = _normalize_access_date(access_end)
+        if not canonical or not normalized_date:
+            return
+        state = self.get_expiry_reminders()
+        last_sent = state.setdefault("last_sent", {})
+        last_sent[canonical] = normalized_date
+        self.data["expiry_reminders"] = self._sanitize_expiry_reminders(state)
+        await self.async_save()
+
     def targets_for_event(self, event_type: str, *, user_id: Optional[str] = None) -> List[str]:
         mapping = self.get_alert_targets()
         out: List[str] = []
@@ -3151,6 +3195,8 @@ class AkuvoxSettingsStore(Store):
             if event_type == "device_offline" and cfg.get("device_offline"):
                 out.append(target)
             elif event_type == "integrity_failed" and cfg.get("integrity_failed"):
+                out.append(target)
+            elif event_type == "access_expiring" and cfg.get("access_expiring"):
                 out.append(target)
             elif event_type == "any_denied" and cfg.get("any_denied"):
                 out.append(target)
@@ -4072,6 +4118,7 @@ class SyncManager:
         self._integrity_unsub = None
         self._temp_cleanup_unsub = None
         self._temp_midnight_unsub = None
+        self._expiry_reminder_unsub = None
         self._temp_cleanup_lock = asyncio.Lock()
         self._integrity_minutes = 15
         self._apply_integrity_interval(self._integrity_minutes)
@@ -4097,6 +4144,13 @@ class SyncManager:
             hass,
             self._temporary_cleanup_midnight,
             hour=0,
+            minute=0,
+            second=0,
+        )
+        self._expiry_reminder_unsub = async_track_time_change(
+            hass,
+            self._access_expiry_reminder_morning,
+            hour=8,
             minute=0,
             second=0,
         )
@@ -4229,8 +4283,16 @@ class SyncManager:
     async def _temporary_cleanup_interval(self, now):
         await self._cleanup_temporary_users(reason="interval")
 
+    async def _startup_user_cleanup(self) -> None:
+        await self._cleanup_temporary_users(reason="startup")
+        await self._cleanup_expired_access_users(reason="startup")
+
     async def _temporary_cleanup_midnight(self, now):
         await self._cleanup_temporary_users(reason="midnight")
+        await self._cleanup_expired_access_users(reason="midnight")
+
+    async def _access_expiry_reminder_morning(self, now):
+        await self._send_access_expiry_reminders()
 
     async def _expire_temporary_user(
         self,
@@ -4311,7 +4373,7 @@ class SyncManager:
 
                 if reason == "midnight":
                     access_end = _parse_access_date(profile.get("access_end"))
-                    if access_end and access_end <= today:
+                    if access_end and access_end < today:
                         to_expire.append((str(key), False))
 
             if not to_expire:
@@ -4324,6 +4386,226 @@ class SyncManager:
                     today=today,
                     used=used,
                 )
+
+    @staticmethod
+    def _profile_can_expire(profile: Mapping[str, Any]) -> bool:
+        if not isinstance(profile, Mapping):
+            return False
+        if _profile_is_empty_reserved(profile):
+            return False
+        status = str(profile.get("status") or "").strip().lower()
+        return status != "deleted"
+
+    async def _delete_expired_access_user(
+        self,
+        key: str,
+        profile: Mapping[str, Any],
+        *,
+        today: date,
+        reason: str,
+    ) -> None:
+        users_store = self._users_store()
+        if not users_store:
+            return
+
+        canonical = normalize_user_id(key) or str(key or "").strip()
+        if not canonical:
+            return
+
+        access_end = _parse_access_date(profile.get("access_end")) or today
+        name = str(profile.get("name") or canonical).strip()
+        phone = str(profile.get("phone") or "").strip()
+
+        try:
+            await users_store.upsert_profile(
+                canonical,
+                status="deleted",
+                groups=["No Access"],
+                schedule_name="No Access",
+                schedule_id="1002",
+                access_end=access_end.isoformat(),
+            )
+        except Exception:
+            return
+
+        self._remove_face_files_for_user({canonical, str(key or "").strip()})
+        await self._prune_stale_alert_users()
+
+        for _entry_id, coord, api, _opts in self._devices():
+            try:
+                if name or phone:
+                    await self._delete_contacts(api, name=name, phone=phone)
+            except Exception:
+                pass
+            try:
+                id_records = await _lookup_device_user_ids_by_ha_key(
+                    api,
+                    canonical,
+                    allow_non_ha_group=True,
+                )
+            except Exception:
+                id_records = []
+            for rec in id_records or []:
+                try:
+                    await _delete_user_every_way(api, rec)
+                except Exception:
+                    pass
+            try:
+                coord._append_event(
+                    f"Expired user removed: {name or canonical} ({reason})"
+                )  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            try:
+                await coord.async_request_refresh()
+            except Exception:
+                pass
+
+        try:
+            sync_queue = self._root().get("sync_queue")
+            if sync_queue:
+                sync_queue.mark_change(
+                    None,
+                    delay_minutes=0,
+                    full=True,
+                    trigger=f"expired user cleanup: {canonical}",
+                )
+        except Exception:
+            pass
+
+    def _remove_face_files_for_user(self, user_ids: Iterable[str]) -> None:
+        cleaned_ids = {str(item or "").strip() for item in user_ids if str(item or "").strip()}
+        if not cleaned_ids:
+            return
+
+        face_dirs: List[Path] = []
+        try:
+            face_dirs.append(face_storage_dir(self.hass))
+        except Exception:
+            pass
+        face_dirs.append(Path(__file__).parent / "www" / "FaceData")
+        try:
+            face_dirs.append(Path(self.hass.config.path("www")) / "AK_Access_ctrl" / "FaceData")
+        except Exception:
+            pass
+
+        for base in face_dirs:
+            try:
+                resolved_base = base.resolve()
+            except Exception:
+                continue
+            for ext in FACE_FILE_EXTENSIONS:
+                for user_id in cleaned_ids:
+                    try:
+                        candidate = (resolved_base / f"{user_id}.{ext}").resolve()
+                        candidate.relative_to(resolved_base)
+                    except Exception:
+                        continue
+                    if candidate.exists():
+                        try:
+                            candidate.unlink()
+                        except Exception:
+                            pass
+
+    async def _cleanup_expired_access_users(self, *, reason: str) -> None:
+        if self._temp_cleanup_lock.locked():
+            return
+
+        async with self._temp_cleanup_lock:
+            users_store = self._users_store()
+            if not users_store:
+                return
+            try:
+                profiles = users_store.all() or {}
+            except Exception:
+                return
+
+            today = dt_util.now().date()
+            to_delete: List[Tuple[str, Mapping[str, Any]]] = []
+            for key, profile in profiles.items():
+                if not self._profile_can_expire(profile):
+                    continue
+                access_end = _parse_access_date(profile.get("access_end"))
+                if access_end and access_end < today:
+                    to_delete.append((str(key), profile))
+
+            for key, profile in to_delete:
+                await self._delete_expired_access_user(
+                    key,
+                    profile,
+                    today=today,
+                    reason=reason,
+                )
+
+    async def _send_access_expiry_reminders(self) -> None:
+        settings = self._settings_store()
+        users_store = self._users_store()
+        if not settings or not users_store:
+            return
+        if not hasattr(settings, "targets_for_event"):
+            return
+
+        try:
+            targets = list(settings.targets_for_event("access_expiring"))
+        except Exception:
+            targets = []
+        if not targets:
+            return
+
+        try:
+            profiles = users_store.all() or {}
+        except Exception:
+            return
+
+        today = dt_util.now().date()
+        for key, profile in profiles.items():
+            if not self._profile_can_expire(profile):
+                continue
+            access_end = _parse_access_date(profile.get("access_end"))
+            if access_end != today:
+                continue
+
+            canonical = normalize_user_id(key) or str(key or "").strip()
+            if not canonical:
+                continue
+            if hasattr(settings, "expiry_reminder_sent"):
+                try:
+                    if settings.expiry_reminder_sent(canonical, access_end):
+                        continue
+                except Exception:
+                    pass
+
+            name = str(profile.get("name") or canonical).strip()
+            review_url = "/akuvox-ac/expiry-review?" + urlencode(
+                {
+                    "id": canonical,
+                    "name": name,
+                    "access_end": access_end.isoformat(),
+                }
+            )
+            message = f"{name}'s Access expires today, Would you like to extend"
+            sent = False
+            for target in targets:
+                try:
+                    await self.hass.services.async_call(
+                        "notify",
+                        target,
+                        {
+                            "title": "Akuvox: Access expires today",
+                            "message": message,
+                            "data": {"url": review_url},
+                        },
+                        blocking=False,
+                    )
+                    sent = True
+                except Exception:
+                    pass
+
+            if sent and hasattr(settings, "mark_expiry_reminder_sent"):
+                try:
+                    await settings.mark_expiry_reminder_sent(canonical, access_end)
+                except Exception:
+                    pass
 
     async def _bump_face_error_count(self, ha_key: str) -> int:
         users_store = self._users_store()
@@ -5469,7 +5751,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if "sync_manager" not in root:
         root["sync_manager"] = SyncManager(hass)
         hass.async_create_task(
-            root["sync_manager"]._cleanup_temporary_users(reason="startup")
+            root["sync_manager"]._startup_user_cleanup()
         )
 
     if "sync_queue" not in root:

--- a/custom_components/akuvox_ac/tests/test_notify_on_access.py
+++ b/custom_components/akuvox_ac/tests/test_notify_on_access.py
@@ -13,7 +13,7 @@ from custom_components.akuvox_ac.integration import (  # noqa: E402
 
 def _settings_store(targets: Dict[str, Any]) -> AkuvoxSettingsStore:
     store = object.__new__(AkuvoxSettingsStore)
-    store.data = {"alerts": {"targets": targets}}
+    store.data = {"alerts": {"targets": targets}, "expiry_reminders": {"last_sent": {}}}
     store.saved = 0
 
     async def _async_save():
@@ -75,6 +75,29 @@ def test_settings_store_treats_legacy_user_list_as_specific():
     assert store.targets_for_event("user_granted", user_id="ha-012") == [
         "mobile_app_lees_iphone"
     ]
+
+
+def test_settings_store_targets_access_expiring_alerts():
+    store = _settings_store(
+        {
+            "mobile_app_lees_iphone": {"access_expiring": True},
+            "mobile_app_verns_iphone": {"access_expiring": False},
+        }
+    )
+
+    assert store.targets_for_event("access_expiring") == ["mobile_app_lees_iphone"]
+
+
+def test_settings_store_tracks_expiry_reminder_sent_date():
+    store = _settings_store({})
+
+    assert store.expiry_reminder_sent("ha-004", "2026-05-21") is False
+
+    asyncio.run(store.mark_expiry_reminder_sent("ha-004", "2026-05-21"))
+
+    assert store.expiry_reminder_sent("HA004", "2026-05-21") is True
+    assert store.expiry_reminder_sent("HA004", "2026-05-22") is False
+    assert store.saved == 1
 
 
 def test_sync_notify_on_access_targets_replaces_per_user_targets():

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -1859,6 +1859,7 @@ function renderNotificationRules(rules = NOTIFICATION_RULES){
     const bits = [];
     if (target.device_offline) bits.push('device offline');
     if (target.integrity_failed) bits.push('integrity failed');
+    if (target.access_expiring) bits.push('access expiring today');
     if (target.any_denied) bits.push('any denied access');
     if (target.granted_any) bits.push('any gate open');
     const users = Array.isArray(target.granted_users) ? target.granted_users.filter(Boolean) : [];

--- a/custom_components/akuvox_ac/www/diagnostics.html
+++ b/custom_components/akuvox_ac/www/diagnostics.html
@@ -1859,6 +1859,7 @@ function renderNotificationRules(rules = NOTIFICATION_RULES){
     const bits = [];
     if (target.device_offline) bits.push('device offline');
     if (target.integrity_failed) bits.push('integrity failed');
+    if (target.access_expiring) bits.push('access expiring today');
     if (target.any_denied) bits.push('any denied access');
     if (target.granted_any) bits.push('any gate open');
     const users = Array.isArray(target.granted_users) ? target.granted_users.filter(Boolean) : [];

--- a/custom_components/akuvox_ac/www/expiry_review.html
+++ b/custom_components/akuvox_ac/www/expiry_review.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Access Expiry</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet" />
+  <style>
+    :root{ --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#a5b5cc; --accent:#2ff0c4; }
+    body{ background:var(--bg); color:var(--text); font-family:system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+    .container-narrow{ max-width:720px; margin:0 auto; padding:1.5rem; }
+    .card{ background:var(--card); border:1px solid var(--border); }
+    .muted{ color:var(--muted); }
+    .form-label{ color:#fff; }
+    .btn-outline-accent{ border-color:rgba(47,240,196,.5); color:var(--text); }
+    .btn-outline-accent:hover{ background:rgba(47,240,196,.2); border-color:var(--accent); color:var(--text); }
+    .status{ min-height:1.5rem; }
+  </style>
+</head>
+<body>
+<script>
+(function(){
+  const qs = new URLSearchParams(location.search);
+  const qsToken = qs.get('token');
+  if (qsToken) sessionStorage.setItem('akuvox_ll_token', qsToken);
+})();
+
+const QUERY = new URLSearchParams(location.search);
+const USER_ID = QUERY.get('id') || QUERY.get('user_id') || '';
+const QUERY_NAME = QUERY.get('name') || '';
+const QUERY_ACCESS_END = QUERY.get('access_end') || '';
+const API_STATE = signedPath('state', '/api/akuvox_ac/ui/state');
+const API_ACTION = signedPath('action', '/api/akuvox_ac/ui/action');
+const REJECTED_TOKENS = new Set();
+
+function signedPath(key, fallback){
+  let signed = {};
+  try { signed = window.AK_AC_SIGNED_PATHS || {}; } catch (err) {}
+  try {
+    const raw = sessionStorage.getItem('akuvox_signed_paths') || localStorage.getItem('akuvox_signed_paths');
+    if (raw) signed = { ...signed, ...JSON.parse(raw) };
+  } catch (err) {}
+  return signed[key] || fallback;
+}
+
+function isSignedPath(url){
+  return typeof url === 'string' && /[?&]authSig=/.test(url);
+}
+
+function clearSignedPathCache(){
+  try { sessionStorage.removeItem('akuvox_signed_paths'); } catch (err) {}
+  try { localStorage.removeItem('akuvox_signed_paths'); } catch (err) {}
+  try { window.AK_AC_SIGNED_PATHS = {}; } catch (err) {}
+}
+
+function stripAuthSig(url){
+  try {
+    const parsed = new URL(url, window.location.origin);
+    parsed.searchParams.delete('authSig');
+    return parsed.pathname + parsed.search + parsed.hash;
+  } catch (err) {
+    return url;
+  }
+}
+
+function scanTokenStorage(storage){
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem('hassTokens');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const token = parsed?.access_token || parsed?.accessToken || parsed?.token?.access_token;
+        if (token) return token;
+      } catch (err) {
+        if (typeof raw === 'string' && raw.trim()) return raw.trim();
+      }
+    }
+    for (const key of Object.keys(storage)) {
+      if (!/auth|token|hass/i.test(key)) continue;
+      try {
+        const parsed = JSON.parse(storage.getItem(key));
+        const token = parsed?.access_token || parsed?.accessToken || parsed?.token?.access_token;
+        if (token) return token;
+      } catch (err) {}
+    }
+  } catch (err) {}
+  return null;
+}
+
+function getAuthToken(){
+  const windows = [window];
+  try { if (window.parent && window.parent !== window) windows.push(window.parent); } catch (err) {}
+  for (const win of windows) {
+    const token = scanTokenStorage(win.sessionStorage) || scanTokenStorage(win.localStorage);
+    if (token) {
+      try { sessionStorage.setItem('akuvox_ll_token', token); } catch (err) {}
+      return token;
+    }
+  }
+  try { return sessionStorage.getItem('akuvox_ll_token') || localStorage.getItem('akuvox_ll_token'); } catch (err) {}
+  return null;
+}
+
+function nextBearerToken(){
+  const token = getAuthToken();
+  if (!token || REJECTED_TOKENS.has(token)) return null;
+  return token;
+}
+
+async function fetchWithAuth(url, options = {}){
+  const signedRequest = isSignedPath(url);
+  const token = signedRequest ? null : nextBearerToken();
+  if (!signedRequest && !token) return new Response('authentication required', { status: 401 });
+  const headers = { ...(options.headers || {}) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  let res = await fetch(url, { ...options, headers, credentials:'same-origin' });
+  if ((res.status === 401 || res.status === 403) && signedRequest) {
+    clearSignedPathCache();
+    const retryToken = nextBearerToken();
+    if (retryToken) {
+      res = await fetch(stripAuthSig(url), {
+        ...options,
+        headers: { ...(options.headers || {}), Authorization:`Bearer ${retryToken}` },
+        credentials:'same-origin'
+      });
+      if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
+    }
+  }
+  if (token && (res.status === 401 || res.status === 403)) REJECTED_TOKENS.add(token);
+  return res;
+}
+
+async function apiGet(url){
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error(await res.text() || `Request failed: ${res.status}`);
+  return res.json();
+}
+
+async function apiAction(action, payload){
+  const res = await fetchWithAuth(API_ACTION, {
+    method:'POST',
+    headers:{ 'Content-Type':'application/json' },
+    body:JSON.stringify({ action, payload: payload || {} })
+  });
+  if (!res.ok) throw new Error(await res.text() || `Action failed: ${res.status}`);
+  return res.json().catch(() => ({}));
+}
+
+function escapeHtml(value){
+  const lookup = { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' };
+  return String(value ?? '').replace(/[&<>"']/g, ch => lookup[ch] ?? ch);
+}
+
+function buildHref(slug, params = {}){
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    search.set(key, value);
+  });
+  const token = sessionStorage.getItem('akuvox_ll_token');
+  if (token) search.set('token', token);
+  return `/akuvox-ac/${String(slug || '').replace(/_/g, '-')}${search.toString() ? `?${search}` : ''}`;
+}
+
+function openInApp(view, params = {}, options = {}){
+  try {
+    if (window.parent && window.parent !== window) {
+      const msg = { type:'akuvox-nav', view:String(view || ''), slug:String(view || ''), params };
+      if (options.replaceState) msg.replaceState = true;
+      window.parent.postMessage(msg, window.location.origin);
+      return;
+    }
+  } catch (err) {}
+  window.location.href = buildHref(view, params);
+}
+
+function setStatus(message, ok = true){
+  const el = document.getElementById('status');
+  if (!el) return;
+  el.textContent = message || '';
+  el.className = ok ? 'status text-success' : 'status text-danger';
+}
+
+function quickDate(days){
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+async function loadUser(){
+  const title = document.getElementById('userTitle');
+  const meta = document.getElementById('userMeta');
+  const input = document.getElementById('accessEnd');
+  if (!USER_ID) {
+    setStatus('Missing user id.', false);
+    return;
+  }
+  let user = null;
+  try {
+    const state = await apiGet(API_STATE);
+    const users = Array.isArray(state?.registry_users) ? state.registry_users : [];
+    user = users.find(item => String(item.id || '').toUpperCase() === USER_ID.toUpperCase()) || null;
+  } catch (err) {
+    setStatus(err?.message || 'Unable to load user.', false);
+  }
+  const name = user?.name || QUERY_NAME || USER_ID;
+  const accessEnd = user?.access_end || QUERY_ACCESS_END || '';
+  title.textContent = name;
+  meta.textContent = `${USER_ID}${accessEnd ? ` · current expiry ${accessEnd}` : ''}`;
+  input.value = accessEnd || quickDate(7);
+  input.min = new Date().toISOString().slice(0, 10);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('btnBack')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openInApp('index');
+  });
+  document.querySelectorAll('[data-quick-days]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.getElementById('accessEnd').value = quickDate(Number(btn.dataset.quickDays || 0));
+    });
+  });
+  document.getElementById('extendForm')?.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const accessEnd = document.getElementById('accessEnd').value;
+    if (!accessEnd) {
+      setStatus('Choose an expiry date.', false);
+      return;
+    }
+    try {
+      await apiAction('extend_user_access', { id: USER_ID, access_end: accessEnd });
+      setStatus('Access expiry updated. Syncing to devices shortly.', true);
+    } catch (err) {
+      setStatus(err?.message || 'Failed to update access.', false);
+    }
+  });
+  document.getElementById('revokeBtn')?.addEventListener('click', async () => {
+    if (!confirm('Revoke access now?')) return;
+    try {
+      await apiAction('revoke_user_access', { id: USER_ID });
+      setStatus('Access revoked. Syncing to devices shortly.', true);
+      setTimeout(() => openInApp('index', {}, { replaceState:true }), 800);
+    } catch (err) {
+      setStatus(err?.message || 'Failed to revoke access.', false);
+    }
+  });
+  loadUser();
+});
+</script>
+
+<div class="container-narrow">
+  <div class="card p-4">
+    <div class="d-flex justify-content-between gap-3 align-items-start mb-4">
+      <div>
+        <h2 class="mb-1" id="userTitle">Access Expiry</h2>
+        <div class="muted" id="userMeta"></div>
+      </div>
+      <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
+    </div>
+
+    <form id="extendForm">
+      <label class="form-label" for="accessEnd">Access End</label>
+      <input class="form-control" id="accessEnd" type="date" required />
+      <div class="d-flex flex-wrap gap-2 mt-3">
+        <button class="btn btn-outline-accent btn-sm" type="button" data-quick-days="1">Tomorrow</button>
+        <button class="btn btn-outline-accent btn-sm" type="button" data-quick-days="7">+1 week</button>
+        <button class="btn btn-outline-accent btn-sm" type="button" data-quick-days="30">+30 days</button>
+      </div>
+      <div class="status mt-3" id="status"></div>
+      <div class="d-flex flex-wrap gap-2 mt-3">
+        <button class="btn btn-success" type="submit"><i class="bi bi-calendar-plus"></i> Update expiry</button>
+        <button class="btn btn-outline-danger" type="button" id="revokeBtn"><i class="bi bi-slash-circle"></i> Revoke access now</button>
+      </div>
+    </form>
+  </div>
+</div>
+</body>
+</html>

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -799,7 +799,7 @@ function computeAccessState(startStr, endStr){
   return {
     startDate,
     endDate,
-    expired: !!(endDate && endDate <= today),
+    expired: !!(endDate && endDate < today),
     notStarted: !!(startDate && startDate > today)
   };
 }

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -858,7 +858,7 @@ function computeAccessState(startStr, endStr){
   return {
     startDate,
     endDate,
-    expired: !!(endDate && endDate <= today),
+    expired: !!(endDate && endDate < today),
     notStarted: !!(startDate && startDate > today)
   };
 }

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -1215,6 +1215,7 @@ function ensureTargetDefaults(target){
     ALERT_TARGETS[target] = {
       device_offline: false,
       integrity_failed: false,
+      access_expiring: false,
       any_denied: false,
       granted: { any: false, specific: false, users: [] }
     };
@@ -1222,6 +1223,7 @@ function ensureTargetDefaults(target){
     const cfg = ALERT_TARGETS[target];
     if (typeof cfg.device_offline !== 'boolean') cfg.device_offline = Boolean(cfg.device_offline);
     if (typeof cfg.integrity_failed !== 'boolean') cfg.integrity_failed = Boolean(cfg.integrity_failed);
+    if (typeof cfg.access_expiring !== 'boolean') cfg.access_expiring = Boolean(cfg.access_expiring);
     if (typeof cfg.any_denied !== 'boolean') cfg.any_denied = Boolean(cfg.any_denied);
     if (!cfg.granted || typeof cfg.granted !== 'object') cfg.granted = { any: false, specific: false, users: [] };
     if (typeof cfg.granted.any !== 'boolean') cfg.granted.any = Boolean(cfg.granted.any);
@@ -1496,6 +1498,10 @@ function renderAlerts(){
           <label class="form-check-label">Device Integrity Check Failed</label>
         </div>
         <div class="form-check mt-2">
+          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="access_expiring" ${cfg.access_expiring ? 'checked' : ''}>
+          <label class="form-check-label">User Access Expiring Today</label>
+        </div>
+        <div class="form-check mt-2">
           <input class="form-check-input" type="checkbox" data-target="${service}" data-field="any_denied" ${cfg.any_denied ? 'checked' : ''}>
           <label class="form-check-label">Any User Denied Access</label>
         </div>
@@ -1551,6 +1557,7 @@ function renderAlerts(){
       const checked = input.checked;
       if (field === 'device_offline') cfg.device_offline = checked;
       else if (field === 'integrity_failed') cfg.integrity_failed = checked;
+      else if (field === 'access_expiring') cfg.access_expiring = checked;
       else if (field === 'any_denied') cfg.any_denied = checked;
       else if (field === 'granted_any') cfg.granted.any = checked;
       else if (field === 'granted_specific') {

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -1217,6 +1217,7 @@ function ensureTargetDefaults(target){
     ALERT_TARGETS[target] = {
       device_offline: false,
       integrity_failed: false,
+      access_expiring: false,
       any_denied: false,
       granted: { any: false, specific: false, users: [] }
     };
@@ -1224,6 +1225,7 @@ function ensureTargetDefaults(target){
     const cfg = ALERT_TARGETS[target];
     if (typeof cfg.device_offline !== 'boolean') cfg.device_offline = Boolean(cfg.device_offline);
     if (typeof cfg.integrity_failed !== 'boolean') cfg.integrity_failed = Boolean(cfg.integrity_failed);
+    if (typeof cfg.access_expiring !== 'boolean') cfg.access_expiring = Boolean(cfg.access_expiring);
     if (typeof cfg.any_denied !== 'boolean') cfg.any_denied = Boolean(cfg.any_denied);
     if (!cfg.granted || typeof cfg.granted !== 'object') cfg.granted = { any: false, specific: false, users: [] };
     if (typeof cfg.granted.any !== 'boolean') cfg.granted.any = Boolean(cfg.granted.any);
@@ -1498,6 +1500,10 @@ function renderAlerts(){
           <label class="form-check-label">Device Integrity Check Failed</label>
         </div>
         <div class="form-check mt-2">
+          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="access_expiring" ${cfg.access_expiring ? 'checked' : ''}>
+          <label class="form-check-label">User Access Expiring Today</label>
+        </div>
+        <div class="form-check mt-2">
           <input class="form-check-input" type="checkbox" data-target="${service}" data-field="any_denied" ${cfg.any_denied ? 'checked' : ''}>
           <label class="form-check-label">Any User Denied Access</label>
         </div>
@@ -1553,6 +1559,7 @@ function renderAlerts(){
       const checked = input.checked;
       if (field === 'device_offline') cfg.device_offline = checked;
       else if (field === 'integrity_failed') cfg.integrity_failed = checked;
+      else if (field === 'access_expiring') cfg.access_expiring = checked;
       else if (field === 'any_denied') cfg.any_denied = checked;
       else if (field === 'granted_any') cfg.granted.any = checked;
       else if (field === 'granted_specific') {

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -972,7 +972,7 @@ function computeAccessState(startStr, endStr){
   return {
     startDate,
     endDate,
-    expired: !!(endDate && endDate <= today),
+    expired: !!(endDate && endDate < today),
     notStarted: !!(startDate && startDate > today)
   };
 }

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -1464,7 +1464,7 @@ function computeAccessState(startStr, endStr){
   return {
     startDate,
     endDate,
-    expired: !!(endDate && endDate <= today),
+    expired: !!(endDate && endDate < today),
     notStarted: !!(startDate && startDate > today)
   };
 }

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -1466,7 +1466,7 @@ function computeAccessState(startStr, endStr){
   return {
     startDate,
     endDate,
-    expired: !!(endDate && endDate <= today),
+    expired: !!(endDate && endDate < today),
     notStarted: !!(startDate && startDate > today)
   };
 }


### PR DESCRIPTION
## Summary

- Runs a startup and midnight cleanup for users whose access end date has passed, marking them deleted, removing them from devices, pruning notify targets, and clearing face assets.
- Sends an 8am mobile reminder for users whose access expires today using the new `User Access Expiring Today` alert-target rule.
- Adds `/akuvox-ac/expiry-review` so notification taps can update the expiry date or revoke access immediately.
- Treats `access_end` as valid through the selected day, so users are removed after the day has passed rather than before the 8am reminder can fire.

## Validation

- Passed: `git diff --cached --check`
- Not run: focused pytest suite because `python` and `py` are not installed on this machine.