### PR TITLE
[codex] Stage versioned HACS update flow

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -3219,33 +3219,77 @@ class AkuvoxUIAction(AkuvoxUIView):
                 _LOGGER.debug("HACS update check failed via UI: %s", service_err)
                 return err(service_err)
 
+        if action == "hacs_update_install":
+            updater = root.get("hacs_auto_updater")
+            if not updater or not hasattr(updater, "async_install_update"):
+                return err("HACS auto updater is unavailable", code=500)
+            try:
+                status = await updater.async_install_update(reason="manual", force=True)
+                return web.json_response({"ok": True, "hacs_auto_update": status})
+            except Exception as service_err:
+                _LOGGER.debug("HACS update install failed via UI: %s", service_err)
+                return err(service_err)
+
         if action == "restart_homeassistant":
             if not _request_can_manage_dashboard_access(request):
                 return err("administrator access required", code=403)
+            updater = root.get("hacs_auto_updater")
             try:
-                await hass.services.async_call(
-                    "homeassistant",
-                    "restart",
-                    {},
-                    blocking=False,
-                    context=ctx,
-                )
-                status = None
-                settings = root.get("settings_store")
-                if settings and hasattr(settings, "update_hacs_auto_update_status"):
-                    try:
-                        status = await settings.update_hacs_auto_update_status(
-                            last_result="restart_requested",
-                            last_error=None,
-                        )
-                    except Exception:
-                        status = None
+                if updater and hasattr(updater, "async_restart_now"):
+                    status = await updater.async_restart_now(reason="manual")
+                else:
+                    await hass.services.async_call(
+                        "homeassistant",
+                        "restart",
+                        {},
+                        blocking=False,
+                        context=ctx,
+                    )
+                    status = None
+                    settings = root.get("settings_store")
+                    if settings and hasattr(settings, "update_hacs_auto_update_status"):
+                        try:
+                            status = await settings.update_hacs_auto_update_status(
+                                last_result="restart_requested",
+                                last_error=None,
+                                restart_scheduled_for=None,
+                            )
+                        except Exception:
+                            status = None
                 response = {"ok": True}
                 if status is not None:
                     response["hacs_auto_update"] = status
                 return web.json_response(response)
             except Exception as service_err:
                 _LOGGER.debug("Home Assistant restart failed via UI: %s", service_err)
+                return err(service_err)
+
+        if action == "schedule_homeassistant_restart":
+            if not _request_can_manage_dashboard_access(request):
+                return err("administrator access required", code=403)
+            updater = root.get("hacs_auto_updater")
+            if not updater or not hasattr(updater, "async_schedule_restart"):
+                return err("HACS auto updater is unavailable", code=500)
+            try:
+                payload_map = payload if isinstance(payload, Mapping) else {}
+                restart_at = payload_map.get("restart_at")
+                status = await updater.async_schedule_restart(restart_at)
+                return web.json_response({"ok": True, "hacs_auto_update": status})
+            except Exception as service_err:
+                _LOGGER.debug("Home Assistant restart schedule failed via UI: %s", service_err)
+                return err(service_err)
+
+        if action == "cancel_homeassistant_restart":
+            if not _request_can_manage_dashboard_access(request):
+                return err("administrator access required", code=403)
+            updater = root.get("hacs_auto_updater")
+            if not updater or not hasattr(updater, "async_cancel_restart"):
+                return err("HACS auto updater is unavailable", code=500)
+            try:
+                status = await updater.async_cancel_restart()
+                return web.json_response({"ok": True, "hacs_auto_update": status})
+            except Exception as service_err:
+                _LOGGER.debug("Home Assistant restart schedule cancel failed via UI: %s", service_err)
                 return err(service_err)
 
         if action in ("force_full_sync", "sync_all"):
@@ -3812,6 +3856,9 @@ class AkuvoxUISettings(HomeAssistantView):
                 "update_entity": "",
                 "backup": False,
                 "last_result": "disabled",
+                "pending_version": None,
+                "pending_version_full": None,
+                "restart_scheduled_for": None,
             }
         )
         updater = root.get("hacs_auto_updater")

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2717,6 +2717,9 @@ class AkuvoxSettingsStore(Store):
         "last_entity_id": None,
         "installed_version": None,
         "latest_version": None,
+        "pending_version": None,
+        "pending_version_full": None,
+        "restart_scheduled_for": None,
     }
     DEFAULT_EXPIRY_REMINDERS = {
         "last_sent": {},
@@ -2912,6 +2915,9 @@ class AkuvoxSettingsStore(Store):
             "last_entity_id",
             "installed_version",
             "latest_version",
+            "pending_version",
+            "pending_version_full",
+            "restart_scheduled_for",
         ):
             value = raw.get(key)
             cfg[key] = str(value).strip() if value not in (None, "") else None
@@ -3232,6 +3238,7 @@ class HacsAutoUpdater:
         self.hass = hass
         self._interval_unsub: Optional[Callable[[], None]] = None
         self._startup_unsub: Optional[Callable[[], None]] = None
+        self._restart_unsub: Optional[Callable[[], None]] = None
         self._lock = asyncio.Lock()
 
     def _root(self) -> Dict[str, Any]:
@@ -3257,6 +3264,7 @@ class HacsAutoUpdater:
 
     def start(self) -> None:
         self.apply_settings()
+        self.apply_restart_schedule()
         if self._startup_unsub is not None:
             return
         try:
@@ -3269,6 +3277,7 @@ class HacsAutoUpdater:
 
     def shutdown(self) -> None:
         self._cancel_interval()
+        self._cancel_restart_schedule()
         if self._startup_unsub:
             try:
                 self._startup_unsub()
@@ -3311,6 +3320,111 @@ class HacsAutoUpdater:
             except Exception:
                 pass
             self._interval_unsub = None
+
+    def _cancel_restart_schedule(self) -> None:
+        if self._restart_unsub:
+            try:
+                self._restart_unsub()
+            except Exception:
+                pass
+            self._restart_unsub = None
+
+    @staticmethod
+    def _parse_restart_time(value: Any) -> Optional[datetime]:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        try:
+            parsed = dt_util.parse_datetime(text)
+        except Exception:
+            parsed = None
+        if parsed is None:
+            try:
+                parsed = datetime.fromisoformat(text)
+            except Exception:
+                return None
+        if parsed.tzinfo is None:
+            try:
+                parsed = parsed.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+            except Exception:
+                parsed = parsed.replace(tzinfo=datetime.now().astimezone().tzinfo)
+        try:
+            return dt_util.as_utc(parsed)
+        except Exception:
+            return parsed
+
+    def apply_restart_schedule(self) -> None:
+        self._cancel_restart_schedule()
+        config = self._config()
+        restart_at = self._parse_restart_time(config.get("restart_scheduled_for"))
+        if restart_at is None:
+            return
+
+        now = dt_util.utcnow()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=restart_at.tzinfo)
+        remaining = (restart_at - now).total_seconds()
+        if remaining <= 0:
+            self.hass.async_create_task(
+                self._record_status(restart_scheduled_for=None)
+            )
+            return
+
+        def _restart_cb(_now):
+            self.hass.async_create_task(self.async_restart_now(reason="scheduled"))
+
+        try:
+            self._restart_unsub = async_call_later(self.hass, remaining, _restart_cb)
+        except Exception:
+            self._restart_unsub = None
+
+    async def async_schedule_restart(self, restart_at: Any) -> Dict[str, Any]:
+        parsed = self._parse_restart_time(restart_at)
+        if parsed is None:
+            raise ValueError("Enter a valid restart date and time.")
+
+        now = dt_util.utcnow()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=parsed.tzinfo)
+        if parsed <= now:
+            raise ValueError("Choose a restart time in the future.")
+
+        status = await self._record_status(
+            last_result="restart_scheduled",
+            last_error=None,
+            restart_scheduled_for=parsed.isoformat(),
+        )
+        self.apply_restart_schedule()
+        return status
+
+    async def async_cancel_restart(self) -> Dict[str, Any]:
+        self._cancel_restart_schedule()
+        return await self._record_status(
+            last_result="installed",
+            last_error=None,
+            restart_scheduled_for=None,
+        )
+
+    async def async_restart_now(self, *, reason: str = "manual") -> Dict[str, Any]:
+        self._cancel_restart_schedule()
+        try:
+            await self.hass.services.async_call(
+                "homeassistant",
+                "restart",
+                {},
+                blocking=False,
+            )
+        except Exception as err:
+            return await self._record_status(
+                last_result="restart_failed",
+                last_error=str(err),
+                restart_scheduled_for=None,
+            )
+        return await self._record_status(
+            last_result="restart_requested",
+            last_error=None,
+            restart_scheduled_for=None,
+        )
 
     def _handle_hass_started(self, _event) -> None:
         self._startup_unsub = None
@@ -3493,6 +3607,29 @@ class HacsAutoUpdater:
         except Exception:
             pass
 
+    async def _create_update_available_notification(
+        self, entity_id: str, *, installed: Any = None, latest: Any = None
+    ) -> None:
+        try:
+            suffix = ""
+            if installed or latest:
+                suffix = f" Current: `{installed or 'unknown'}`. Available: `{latest or 'unknown'}`."
+            await self.hass.services.async_call(
+                "persistent_notification",
+                "create",
+                {
+                    "notification_id": "akuvox_ac_hacs_update_available",
+                    "title": "Akuvox Access Control update available",
+                    "message": (
+                        f"`{entity_id}` has an update available.{suffix} "
+                        "Open the Akuvox dashboard to review and install it."
+                    ),
+                },
+                blocking=False,
+            )
+        except Exception:
+            pass
+
     async def async_run_check(
         self, *, reason: str = "manual", force: bool = False
     ) -> Dict[str, Any]:
@@ -3555,11 +3692,15 @@ class HacsAutoUpdater:
                 "latest_version": latest,
             }
 
-            install_version: Optional[str] = None
+            pending_version_full: Optional[str] = None
             has_update = self._update_available(state)
             if github_latest_sha and not self._versions_match(installed, github_latest_sha):
                 has_update = True
-                install_version = github_latest_sha
+                pending_version_full = github_latest_sha
+            elif has_update and hacs_latest:
+                pending_version_full = self._version_text(hacs_latest)
+
+            pending_version = self._short_version(pending_version_full)
 
             if not has_update:
                 if github_error:
@@ -3567,13 +3708,48 @@ class HacsAutoUpdater:
                         **base_status,
                         last_result="check_failed",
                         last_error=github_error,
+                        pending_version=None,
+                        pending_version_full=None,
                     )
                 return await self._record_status(
                     **base_status,
                     last_result="up_to_date",
                     last_error=None,
+                    pending_version=None,
+                    pending_version_full=None,
                 )
 
+            await self._create_update_available_notification(
+                entity_id,
+                installed=installed,
+                latest=pending_version or latest,
+            )
+            return await self._record_status(
+                **base_status,
+                last_result="update_available",
+                last_error=github_error,
+                pending_version=pending_version,
+                pending_version_full=pending_version_full,
+            )
+
+    async def async_install_update(
+        self, *, reason: str = "manual", force: bool = False
+    ) -> Dict[str, Any]:
+        check_status = await self.async_run_check(reason=f"{reason}_preinstall", force=True)
+        if str(check_status.get("last_result") or "").lower() != "update_available":
+            return check_status
+
+        config = self._config()
+        async with self._lock:
+            entity_id = str(check_status.get("last_entity_id") or "").strip()
+            if not entity_id:
+                return await self._record_status(
+                    last_result="entity_not_found",
+                    last_error="Could not find the HACS update entity for Akuvox Access Control.",
+                    last_entity_id=None,
+                )
+
+            install_version = str(check_status.get("pending_version_full") or "").strip()
             service_data: Dict[str, Any] = {"entity_id": entity_id}
             if install_version:
                 service_data["version"] = install_version
@@ -3589,17 +3765,71 @@ class HacsAutoUpdater:
                 )
             except Exception as err:
                 return await self._record_status(
-                    **base_status,
+                    last_checked=dt_util.now().isoformat(),
+                    last_entity_id=entity_id,
+                    installed_version=check_status.get("installed_version"),
+                    latest_version=check_status.get("latest_version"),
                     last_result="install_failed",
                     last_error=str(err),
                 )
 
+            try:
+                await self.hass.services.async_call(
+                    "homeassistant",
+                    "update_entity",
+                    {"entity_id": entity_id},
+                    blocking=True,
+                )
+            except Exception:
+                pass
+
+            state_after = self.hass.states.get(entity_id)
+            attrs_after = getattr(state_after, "attributes", {}) if state_after is not None else {}
+            installed_after = attrs_after.get("installed_version") or check_status.get("installed_version")
+            latest_after = attrs_after.get("latest_version") or check_status.get("latest_version")
+            pending_short = self._short_version(install_version)
+            confirmed = False
+            if install_version and self._versions_match(installed_after, install_version):
+                confirmed = True
+            elif pending_short and self._versions_match(installed_after, pending_short):
+                confirmed = True
+            elif (
+                not install_version
+                and state_after is not None
+                and not self._update_available(state_after)
+                and installed_after
+                and latest_after
+                and self._versions_match(installed_after, latest_after)
+            ):
+                confirmed = True
+
+            if not confirmed:
+                return await self._record_status(
+                    last_checked=dt_util.now().isoformat(),
+                    last_entity_id=entity_id,
+                    installed_version=installed_after,
+                    latest_version=pending_short or latest_after,
+                    last_result="install_unconfirmed",
+                    last_error=(
+                        "Install command was sent, but HACS still reports "
+                        f"{entity_id} at {installed_after or 'unknown'}."
+                    ),
+                    pending_version=pending_short or check_status.get("pending_version"),
+                    pending_version_full=install_version or check_status.get("pending_version_full"),
+                )
+
             await self._create_restart_notification(entity_id)
             return await self._record_status(
-                **base_status,
+                last_checked=dt_util.now().isoformat(),
+                last_entity_id=entity_id,
+                installed_version=installed_after,
+                latest_version=pending_short or latest_after,
                 last_installed=dt_util.now().isoformat(),
                 last_result="installed",
                 last_error=None,
+                pending_version=None,
+                pending_version_full=None,
+                restart_scheduled_for=None,
             )
 
 
@@ -6610,6 +6840,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         if updater and hasattr(updater, "async_run_check"):
             await updater.async_run_check(reason="service", force=True)
 
+    async def svc_hacs_update_install(call):
+        root = hass.data.get(DOMAIN, {})
+        updater = root.get("hacs_auto_updater") if isinstance(root, dict) else None
+        if updater and hasattr(updater, "async_install_update"):
+            await updater.async_install_update(reason="service", force=True)
+
     async def svc_add_missing_users(call):
         data = call.data if isinstance(call.data, Mapping) else {}
         entry_id = data.get("entry_id")
@@ -6687,6 +6923,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.services.async_register(DOMAIN, "force_full_sync", svc_force_full_sync)
     hass.services.async_register(DOMAIN, "sync_now", svc_sync_now)
     hass.services.async_register(DOMAIN, "hacs_update_check", svc_hacs_update_check)
+    hass.services.async_register(DOMAIN, "hacs_update_install", svc_hacs_update_install)
     hass.services.async_register(DOMAIN, "add_missing_users", svc_add_missing_users)
     hass.services.async_register(DOMAIN, "create_group", svc_create_group)
     hass.services.async_register(DOMAIN, "delete_groups", svc_delete_groups)

--- a/custom_components/akuvox_ac/services.yaml
+++ b/custom_components/akuvox_ac/services.yaml
@@ -223,7 +223,11 @@ sync_now:
 
 hacs_update_check:
   name: Check HACS update
-  description: Force a HACS update entity refresh and install the Akuvox Access Control update if one is available.
+  description: Force a HACS update entity refresh and record whether an Akuvox Access Control update is available.
+
+hacs_update_install:
+  name: Install HACS update
+  description: Install the currently available Akuvox Access Control HACS update after it has been checked.
 
 add_missing_users:
   name: Add missing users

--- a/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
+++ b/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Tuple
 
 from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
@@ -39,8 +40,10 @@ class _States:
 
 
 class _Services:
-    def __init__(self) -> None:
+    def __init__(self, state: _State, *, confirm_install: bool = True) -> None:
         self.calls: List[Tuple[str, str, Dict[str, Any], bool]] = []
+        self._state = state
+        self._confirm_install = confirm_install
 
     async def async_call(
         self,
@@ -52,12 +55,21 @@ class _Services:
         **_: Any,
     ) -> None:
         self.calls.append((domain, service, dict(data or {}), blocking))
+        if domain == "update" and service == "install" and self._confirm_install:
+            version = str((data or {}).get("version") or LATEST_SHA)[:7]
+            self._state.attributes = dict(self._state.attributes)
+            self._state.attributes["installed_version"] = version
+            self._state.attributes["latest_version"] = version
+            self._state.state = "off"
 
 
 class _Hass:
-    def __init__(self, settings: AkuvoxSettingsStore) -> None:
-        self.states = _States(_State())
-        self.services = _Services()
+    def __init__(self, settings: AkuvoxSettingsStore, *, confirm_install: bool = True) -> None:
+        self._state = _State()
+        self._state.state = "off"
+        self._state.attributes = dict(_State.attributes)
+        self.states = _States(self._state)
+        self.services = _Services(self._state, confirm_install=confirm_install)
         self.data = {DOMAIN: {"settings_store": settings}}
 
 
@@ -99,7 +111,7 @@ def _settings_store() -> AkuvoxSettingsStore:
     return store
 
 
-def test_hacs_auto_update_installs_github_head_when_hacs_entity_is_stale(monkeypatch):
+def test_hacs_auto_update_check_detects_github_head_when_hacs_entity_is_stale(monkeypatch):
     store = _settings_store()
     hass = _Hass(store)
     monkeypatch.setattr(
@@ -109,6 +121,28 @@ def test_hacs_auto_update_installs_github_head_when_hacs_entity_is_stale(monkeyp
     )
 
     status = asyncio.run(HacsAutoUpdater(hass).async_run_check(force=True))
+
+    install_calls = [
+        call for call in hass.services.calls if call[0] == "update" and call[1] == "install"
+    ]
+    assert install_calls == []
+    assert status["last_result"] == "update_available"
+    assert status["installed_version"] == "3175ae3"
+    assert status["latest_version"] == "71d1bd2"
+    assert status["pending_version"] == "71d1bd2"
+    assert status["pending_version_full"] == LATEST_SHA
+
+
+def test_hacs_auto_update_install_confirms_github_head(monkeypatch):
+    store = _settings_store()
+    hass = _Hass(store)
+    monkeypatch.setattr(
+        integration_module,
+        "async_get_clientsession",
+        lambda _hass: _GithubSession(),
+    )
+
+    status = asyncio.run(HacsAutoUpdater(hass).async_install_update(force=True))
 
     install_calls = [
         call for call in hass.services.calls if call[0] == "update" and call[1] == "install"
@@ -125,8 +159,49 @@ def test_hacs_auto_update_installs_github_head_when_hacs_entity_is_stale(monkeyp
         )
     ]
     assert status["last_result"] == "installed"
-    assert status["installed_version"] == "3175ae3"
+    assert status["installed_version"] == "71d1bd2"
     assert status["latest_version"] == "71d1bd2"
+    assert status["pending_version"] is None
+
+
+def test_hacs_auto_update_install_requires_hacs_confirmation(monkeypatch):
+    store = _settings_store()
+    hass = _Hass(store, confirm_install=False)
+    monkeypatch.setattr(
+        integration_module,
+        "async_get_clientsession",
+        lambda _hass: _GithubSession(),
+    )
+
+    status = asyncio.run(HacsAutoUpdater(hass).async_install_update(force=True))
+
+    assert status["last_result"] == "install_unconfirmed"
+    assert status["installed_version"] == "3175ae3"
+    assert status["pending_version"] == "71d1bd2"
+
+
+def test_hacs_auto_update_schedules_and_cancels_restart(monkeypatch):
+    store = _settings_store()
+    hass = _Hass(store)
+    scheduled: Dict[str, Any] = {}
+
+    def _schedule(_hass, delay, callback):
+        scheduled["delay"] = delay
+        scheduled["callback"] = callback
+        return lambda: scheduled.__setitem__("cancelled", True)
+
+    monkeypatch.setattr(integration_module, "async_call_later", _schedule)
+
+    restart_at = datetime.now(tz=UTC) + timedelta(minutes=30)
+    status = asyncio.run(HacsAutoUpdater(hass).async_schedule_restart(restart_at.isoformat()))
+
+    assert status["last_result"] == "restart_scheduled"
+    assert status["restart_scheduled_for"]
+    assert scheduled["delay"] > 0
+
+    status = asyncio.run(HacsAutoUpdater(hass).async_cancel_restart())
+
+    assert status["restart_scheduled_for"] is None
 
 
 def test_hacs_auto_update_matches_short_and_full_commit_versions():

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -2332,10 +2332,35 @@ async function forceFullSync(){
 function hacsUpdateButtonLabel(status){
   const result = String(status?.last_result || '').toLowerCase();
   if (result === 'installed') return 'Update Installed';
+  if (result === 'update_available') return 'Update Available';
+  if (result === 'install_unconfirmed') return 'Install Unconfirmed';
+  if (result === 'restart_scheduled') return 'Restart Scheduled';
+  if (result === 'restart_requested') return 'Restart Sent';
   if (result === 'up_to_date') return 'No Update';
   if (result === 'entity_not_found') return 'Update Entity Missing';
-  if (result === 'check_failed' || result === 'install_failed') return 'Update Failed';
+  if (result === 'check_failed' || result === 'install_failed' || result === 'restart_failed') return 'Update Failed';
   return 'Check Sent';
+}
+
+async function promptForHacsRestart(status){
+  if (!status || String(status.last_result || '').toLowerCase() !== 'installed') return status;
+  if (confirm('Update installed. Restart Home Assistant now? Press Cancel to schedule it for later.')) {
+    const restartRes = await apiPost(actionUrl, { action: 'restart_homeassistant' });
+    return restartRes?.hacs_auto_update || status;
+  }
+  const minutesText = prompt('Schedule Home Assistant restart in how many minutes?', '30');
+  if (minutesText === null || String(minutesText).trim() === '') return status;
+  const minutes = Number(minutesText);
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    alert('Enter a positive number of minutes to schedule the restart.');
+    return status;
+  }
+  const restartAt = new Date(Date.now() + Math.round(minutes) * 60 * 1000).toISOString();
+  const scheduleRes = await apiPost(actionUrl, {
+    action: 'schedule_homeassistant_restart',
+    payload: { restart_at: restartAt },
+  });
+  return scheduleRes?.hacs_auto_update || status;
 }
 
 async function runHacsAutoUpdate(){
@@ -2381,10 +2406,35 @@ async function runHacsAutoUpdate(){
     if (btn) {
       btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
     }
-    if (result === 'installed') {
-      alert('Update installed. Restart Home Assistant to load it.');
+    if (result === 'update_available') {
+      const version = status?.pending_version || status?.latest_version || 'the available version';
+      if (confirm(`Install Akuvox Access Control update ${version}?`)) {
+        try {
+          const installRes = await apiPost(actionUrl, { action: 'hacs_update_install' });
+          status = installRes?.hacs_auto_update || status;
+          if (btn) btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+          status = await promptForHacsRestart(status);
+          if (btn) btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+          if (String(status?.last_result || '').toLowerCase() === 'install_unconfirmed') {
+            alert(status?.last_error || 'Install command was sent, but HACS did not confirm the new version.');
+          }
+        } catch (err) {
+          if (handleAuthError(err)) return;
+          alert(`HACS update install failed: ${err?.message || err}`);
+        }
+      }
+    } else if (result === 'installed') {
+      try {
+        status = await promptForHacsRestart(status);
+        if (btn) btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        alert(`Home Assistant restart failed: ${err?.message || err}`);
+      }
     } else if (['entity_not_found','check_failed','install_failed'].includes(result)) {
       alert(status?.last_error || 'HACS update check did not complete.');
+    } else if (result === 'install_unconfirmed') {
+      alert(status?.last_error || 'Install command was sent, but HACS did not confirm the new version.');
     }
   }
 

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -2567,10 +2567,35 @@ async function forceFullSync(){
 function hacsUpdateButtonLabel(status){
   const result = String(status?.last_result || '').toLowerCase();
   if (result === 'installed') return 'Update Installed';
+  if (result === 'update_available') return 'Update Available';
+  if (result === 'install_unconfirmed') return 'Install Unconfirmed';
+  if (result === 'restart_scheduled') return 'Restart Scheduled';
+  if (result === 'restart_requested') return 'Restart Sent';
   if (result === 'up_to_date') return 'No Update';
   if (result === 'entity_not_found') return 'Update Entity Missing';
-  if (result === 'check_failed' || result === 'install_failed') return 'Update Failed';
+  if (result === 'check_failed' || result === 'install_failed' || result === 'restart_failed') return 'Update Failed';
   return 'Check Sent';
+}
+
+async function promptForHacsRestart(status){
+  if (!status || String(status.last_result || '').toLowerCase() !== 'installed') return status;
+  if (confirm('Update installed. Restart Home Assistant now? Press Cancel to schedule it for later.')) {
+    const restartRes = await apiPost(actionUrl, { action: 'restart_homeassistant' });
+    return restartRes?.hacs_auto_update || status;
+  }
+  const minutesText = prompt('Schedule Home Assistant restart in how many minutes?', '30');
+  if (minutesText === null || String(minutesText).trim() === '') return status;
+  const minutes = Number(minutesText);
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    alert('Enter a positive number of minutes to schedule the restart.');
+    return status;
+  }
+  const restartAt = new Date(Date.now() + Math.round(minutes) * 60 * 1000).toISOString();
+  const scheduleRes = await apiPost(actionUrl, {
+    action: 'schedule_homeassistant_restart',
+    payload: { restart_at: restartAt },
+  });
+  return scheduleRes?.hacs_auto_update || status;
 }
 
 async function runHacsAutoUpdate(){
@@ -2616,10 +2641,35 @@ async function runHacsAutoUpdate(){
     if (btn) {
       btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
     }
-    if (result === 'installed') {
-      alert('Update installed. Restart Home Assistant to load it.');
+    if (result === 'update_available') {
+      const version = status?.pending_version || status?.latest_version || 'the available version';
+      if (confirm(`Install Akuvox Access Control update ${version}?`)) {
+        try {
+          const installRes = await apiPost(actionUrl, { action: 'hacs_update_install' });
+          status = installRes?.hacs_auto_update || status;
+          if (btn) btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+          status = await promptForHacsRestart(status);
+          if (btn) btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+          if (String(status?.last_result || '').toLowerCase() === 'install_unconfirmed') {
+            alert(status?.last_error || 'Install command was sent, but HACS did not confirm the new version.');
+          }
+        } catch (err) {
+          if (handleAuthError(err)) return;
+          alert(`HACS update install failed: ${err?.message || err}`);
+        }
+      }
+    } else if (result === 'installed') {
+      try {
+        status = await promptForHacsRestart(status);
+        if (btn) btn.innerHTML = `<i class="bi bi-arrow-repeat"></i> ${hacsUpdateButtonLabel(status)}`;
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        alert(`Home Assistant restart failed: ${err?.message || err}`);
+      }
     } else if (['entity_not_found','check_failed','install_failed'].includes(result)) {
       alert(status?.last_error || 'HACS update check did not complete.');
+    } else if (result === 'install_unconfirmed') {
+      alert(status?.last_error || 'Install command was sent, but HACS did not confirm the new version.');
     }
   }
 

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -620,7 +620,9 @@ let eventLimitSaving = false;
 let eventLimitSavedTimer = null;
 let hacsUpdateSaving = false;
 let hacsUpdateChecking = false;
+let hacsUpdateInstalling = false;
 let hacsRestarting = false;
+let hacsRestartScheduling = false;
 let dashboardAccessSaving = false;
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const EXIT_CLONE_SUFFIX = ' - EP';
@@ -824,6 +826,7 @@ function setHacsAutoUpdateStatus(text, tone = 'muted') {
   el.className = 'small';
   if (tone === 'error') el.classList.add('text-danger');
   else if (tone === 'success') el.classList.add('text-success');
+  else if (tone === 'warning') el.classList.add('text-warning');
   else el.classList.add('muted');
 }
 function setAlertsStatus(text, tone = 'muted') {
@@ -900,6 +903,9 @@ function sanitizeHacsAutoUpdate(raw){
     last_entity_id: null,
     installed_version: null,
     latest_version: null,
+    pending_version: null,
+    pending_version_full: null,
+    restart_scheduled_for: null,
     active: false,
   };
   if (raw && typeof raw === 'object'){
@@ -908,7 +914,7 @@ function sanitizeHacsAutoUpdate(raw){
     const interval = Number(raw.interval_hours);
     if (Number.isFinite(interval)) base.interval_hours = Math.round(interval);
     base.update_entity = String(raw.update_entity || '').trim();
-    ['last_checked','last_installed','last_result','last_error','last_entity_id','installed_version','latest_version'].forEach((key) => {
+    ['last_checked','last_installed','last_result','last_error','last_entity_id','installed_version','latest_version','pending_version','pending_version_full','restart_scheduled_for'].forEach((key) => {
       if (raw[key] !== undefined && raw[key] !== null && raw[key] !== '') base[key] = String(raw[key]);
     });
     base.active = coerceHacsBool(raw.active);
@@ -926,24 +932,39 @@ function formatHacsDate(value){
   return date.toLocaleString();
 }
 
+function hacsLocalDateTimeValue(date){
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function defaultHacsRestartValue(){
+  return hacsLocalDateTimeValue(new Date(Date.now() + 30 * 60 * 1000));
+}
+
 function hacsStatusTone(config){
   const result = String(config?.last_result || '').toLowerCase();
-  if (['check_failed','install_failed','entity_not_found'].includes(result)) return 'error';
-  if (['installed','restart_requested','up_to_date','enabled'].includes(result)) return 'success';
+  if (['check_failed','install_failed','install_unconfirmed','restart_failed','entity_not_found'].includes(result)) return 'error';
+  if (['installed','restart_requested','restart_scheduled','up_to_date','enabled'].includes(result)) return 'success';
+  if (result === 'update_available') return 'warning';
   return 'muted';
 }
 
 function describeHacsResult(config){
   const result = String(config?.last_result || '').toLowerCase();
+  if (result === 'update_available') return 'Update available. Review and install when ready.';
   if (result === 'installed') return 'Update installed. Restart Home Assistant to load it.';
   if (result === 'restart_requested') return 'Restart requested. Home Assistant is restarting...';
+  if (result === 'restart_scheduled') return 'Restart scheduled.';
   if (result === 'up_to_date') return 'No update available.';
   if (result === 'check_failed') return 'Update check failed.';
   if (result === 'install_failed') return 'Update install failed.';
+  if (result === 'install_unconfirmed') return 'Install command sent, but HACS has not confirmed the new version.';
+  if (result === 'restart_failed') return 'Home Assistant restart failed.';
   if (result === 'entity_not_found') return 'HACS update entity was not found.';
-  if (result === 'disabled') return 'Automatic HACS updates are disabled.';
-  if (config?.enabled) return config?.active ? 'Automatic HACS updates are enabled.' : 'Automatic HACS updates will start after reload.';
-  return 'Automatic HACS updates are disabled.';
+  if (result === 'disabled') return 'Automatic HACS update checks are disabled.';
+  if (config?.enabled) return config?.active ? 'Automatic HACS update checks are enabled.' : 'Automatic HACS update checks will start after reload.';
+  return 'Automatic HACS update checks are disabled.';
 }
 
 function readHacsAutoUpdateForm(){
@@ -980,9 +1001,16 @@ function renderHacsAutoUpdate(){
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
   const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+  const installBtn = document.getElementById('hacsUpdateInstallBtn');
   const restartBtn = document.getElementById('hacsRestartNowBtn');
+  const scheduleWrap = document.getElementById('hacsRestartScheduleWrap');
+  const scheduleInput = document.getElementById('hacsRestartScheduleAt');
+  const scheduleBtn = document.getElementById('hacsRestartScheduleBtn');
+  const cancelScheduleBtn = document.getElementById('hacsRestartCancelScheduleBtn');
   const meta = document.getElementById('hacsAutoUpdateMeta');
-  const updateInstalled = String(cfg.last_result || '').toLowerCase() === 'installed';
+  const result = String(cfg.last_result || '').toLowerCase();
+  const updateAvailable = result === 'update_available';
+  const updateInstalled = ['installed','restart_scheduled','restart_failed'].includes(result);
   const canRestart = !!(SETTINGS_DATA.dashboard_access?.can_manage || SETTINGS_DATA.dashboard_access?.current_user_is_admin);
   if (toggle) toggle.checked = !!cfg.enabled;
   if (backupInput) backupInput.checked = !!cfg.backup;
@@ -993,17 +1021,37 @@ function renderHacsAutoUpdate(){
   }
   if (entityInput) entityInput.value = cfg.update_entity || '';
   if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
+  if (installBtn) {
+    installBtn.classList.toggle('d-none', !updateAvailable);
+    installBtn.disabled = hacsUpdateInstalling;
+  }
   if (restartBtn) {
     restartBtn.classList.toggle('d-none', !(canRestart && (updateInstalled || hacsRestarting)));
     restartBtn.disabled = hacsRestarting;
+  }
+  if (scheduleWrap) {
+    scheduleWrap.classList.toggle('d-none', !(canRestart && updateInstalled));
+  }
+  if (scheduleInput) {
+    if (!scheduleInput.value || cfg.restart_scheduled_for) {
+      const parsed = cfg.restart_scheduled_for ? new Date(cfg.restart_scheduled_for) : null;
+      scheduleInput.value = parsed && !Number.isNaN(parsed.getTime()) ? hacsLocalDateTimeValue(parsed) : defaultHacsRestartValue();
+    }
+  }
+  if (scheduleBtn) scheduleBtn.disabled = hacsRestartScheduling;
+  if (cancelScheduleBtn) {
+    cancelScheduleBtn.classList.toggle('d-none', !cfg.restart_scheduled_for);
+    cancelScheduleBtn.disabled = hacsRestartScheduling;
   }
   if (meta){
     const details = [
       `Last checked: ${formatHacsDate(cfg.last_checked)}`,
     ];
     if (cfg.last_installed) details.push(`Last installed: ${formatHacsDate(cfg.last_installed)}`);
+    if (cfg.pending_version) details.push(`Pending: ${cfg.pending_version}`);
     if (cfg.last_entity_id) details.push(`Entity: ${cfg.last_entity_id}`);
     if (cfg.installed_version || cfg.latest_version) details.push(`Version: ${cfg.installed_version || 'unknown'} to ${cfg.latest_version || 'unknown'}`);
+    if (cfg.restart_scheduled_for) details.push(`Restart scheduled: ${formatHacsDate(cfg.restart_scheduled_for)}`);
     if (cfg.last_error) details.push(`Error: ${cfg.last_error}`);
     meta.textContent = details.join(' | ');
   }
@@ -1138,9 +1186,38 @@ async function runHacsUpdateCheck(){
   }
 }
 
-async function restartHomeAssistantNow(){
+async function installHacsUpdate(){
+  if (hacsUpdateInstalling) return;
+  const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
+  const version = cfg.pending_version || cfg.latest_version || 'the available version';
+  if (!confirm(`Install Akuvox Access Control update ${version}?`)) {
+    return;
+  }
+  hacsUpdateInstalling = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Installing HACS update...');
+  try {
+    const res = await callAction('hacs_update_install');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+    const result = String(SETTINGS_DATA.hacs_auto_update?.last_result || '').toLowerCase();
+    if (result === 'installed' && confirm('Update installed. Restart Home Assistant now? Press Cancel to schedule it for later.')) {
+      await restartHomeAssistantNow({ skipConfirm: true });
+    }
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'HACS update install failed', 'error');
+  } finally {
+    hacsUpdateInstalling = false;
+    renderHacsAutoUpdate();
+  }
+}
+
+async function restartHomeAssistantNow(options = {}){
   if (hacsRestarting) return;
-  if (!confirm('Restart Home Assistant now? The dashboard will disconnect while Home Assistant restarts.')) {
+  if (!options.skipConfirm && !confirm('Restart Home Assistant now? The dashboard will disconnect while Home Assistant restarts.')) {
     return;
   }
   hacsRestarting = true;
@@ -1158,6 +1235,59 @@ async function restartHomeAssistantNow(){
     renderHacsAutoUpdate();
     if (handleAuthError(err)) return;
     setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to restart Home Assistant', 'error');
+  }
+}
+
+async function scheduleHomeAssistantRestart(){
+  if (hacsRestartScheduling) return;
+  const input = document.getElementById('hacsRestartScheduleAt');
+  const raw = String(input?.value || '').trim();
+  if (!raw) {
+    setHacsAutoUpdateStatus('Choose when Home Assistant should restart.', 'error');
+    return;
+  }
+  const restartAt = new Date(raw);
+  if (Number.isNaN(restartAt.getTime()) || restartAt <= new Date()) {
+    setHacsAutoUpdateStatus('Choose a restart time in the future.', 'error');
+    return;
+  }
+  hacsRestartScheduling = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Scheduling Home Assistant restart...');
+  try {
+    const res = await callAction('schedule_homeassistant_restart', { restart_at: restartAt.toISOString() });
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to schedule Home Assistant restart', 'error');
+  } finally {
+    hacsRestartScheduling = false;
+    renderHacsAutoUpdate();
+  }
+}
+
+async function cancelHomeAssistantRestart(){
+  if (hacsRestartScheduling) return;
+  hacsRestartScheduling = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Cancelling scheduled restart...');
+  try {
+    const res = await callAction('cancel_homeassistant_restart');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    const input = document.getElementById('hacsRestartScheduleAt');
+    if (input) input.value = defaultHacsRestartValue();
+    renderHacsAutoUpdate();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to cancel scheduled restart', 'error');
+  } finally {
+    hacsRestartScheduling = false;
+    renderHacsAutoUpdate();
   }
 }
 
@@ -2514,9 +2644,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     ev.preventDefault();
     await runHacsUpdateCheck();
   });
+  document.getElementById('hacsUpdateInstallBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await installHacsUpdate();
+  });
   document.getElementById('hacsRestartNowBtn')?.addEventListener('click', async (ev) => {
     ev.preventDefault();
     await restartHomeAssistantNow();
+  });
+  document.getElementById('hacsRestartScheduleBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await scheduleHomeAssistantRestart();
+  });
+  document.getElementById('hacsRestartCancelScheduleBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await cancelHomeAssistantRestart();
   });
 
   document.getElementById('dashboardAccessUsers')?.addEventListener('change', async (ev) => {
@@ -2710,10 +2852,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   <div class="card mt-3">
     <div class="card-header text-white">HACS Auto Update</div>
     <div class="card-body">
-      <p class="muted">Automatically refresh the HACS update entity for this integration and install an available update. Home Assistant still needs a restart after an integration update is installed.</p>
+      <p class="muted">Automatically refresh the HACS update entity for this integration. When an update is found, review it here before installing. Home Assistant still needs a restart after an integration update is installed.</p>
       <div class="form-check form-switch">
         <input class="form-check-input" type="checkbox" id="hacsAutoUpdateToggle">
-        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS updates</label>
+        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS update checks</label>
       </div>
       <div class="row g-2 mt-3">
         <div class="col-md-4">
@@ -2732,8 +2874,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       </div>
       <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
         <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>
+        <button id="hacsUpdateInstallBtn" class="btn btn-success btn-sm d-none" type="button"><i class="bi bi-cloud-arrow-down me-1"></i>Install update</button>
         <button id="hacsRestartNowBtn" class="btn btn-warning btn-sm d-none" type="button"><i class="bi bi-power me-1"></i>Restart Home Assistant</button>
         <span id="hacsAutoUpdateStatus" class="visually-hidden small"></span>
+      </div>
+      <div id="hacsRestartScheduleWrap" class="row g-2 align-items-end mt-2 d-none">
+        <div class="col-md-5">
+          <label class="form-label" for="hacsRestartScheduleAt">Schedule restart for later</label>
+          <input id="hacsRestartScheduleAt" class="form-control" type="datetime-local" />
+        </div>
+        <div class="col-md-auto d-flex flex-wrap gap-2">
+          <button id="hacsRestartScheduleBtn" class="btn btn-outline-warning btn-sm" type="button"><i class="bi bi-clock me-1"></i>Schedule restart</button>
+          <button id="hacsRestartCancelScheduleBtn" class="btn btn-outline-secondary btn-sm d-none" type="button"><i class="bi bi-x-circle me-1"></i>Cancel scheduled restart</button>
+        </div>
       </div>
       <div id="hacsAutoUpdateMeta" class="muted small mt-2"></div>
     </div>

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -622,7 +622,9 @@ let eventLimitSaving = false;
 let eventLimitSavedTimer = null;
 let hacsUpdateSaving = false;
 let hacsUpdateChecking = false;
+let hacsUpdateInstalling = false;
 let hacsRestarting = false;
+let hacsRestartScheduling = false;
 let dashboardAccessSaving = false;
 const BUILTIN_SCHEDULES = new Set(['24/7 Access', 'No Access']);
 const EXIT_CLONE_SUFFIX = ' - EP';
@@ -826,6 +828,7 @@ function setHacsAutoUpdateStatus(text, tone = 'muted') {
   el.className = 'small';
   if (tone === 'error') el.classList.add('text-danger');
   else if (tone === 'success') el.classList.add('text-success');
+  else if (tone === 'warning') el.classList.add('text-warning');
   else el.classList.add('muted');
 }
 function setAlertsStatus(text, tone = 'muted') {
@@ -902,6 +905,9 @@ function sanitizeHacsAutoUpdate(raw){
     last_entity_id: null,
     installed_version: null,
     latest_version: null,
+    pending_version: null,
+    pending_version_full: null,
+    restart_scheduled_for: null,
     active: false,
   };
   if (raw && typeof raw === 'object'){
@@ -910,7 +916,7 @@ function sanitizeHacsAutoUpdate(raw){
     const interval = Number(raw.interval_hours);
     if (Number.isFinite(interval)) base.interval_hours = Math.round(interval);
     base.update_entity = String(raw.update_entity || '').trim();
-    ['last_checked','last_installed','last_result','last_error','last_entity_id','installed_version','latest_version'].forEach((key) => {
+    ['last_checked','last_installed','last_result','last_error','last_entity_id','installed_version','latest_version','pending_version','pending_version_full','restart_scheduled_for'].forEach((key) => {
       if (raw[key] !== undefined && raw[key] !== null && raw[key] !== '') base[key] = String(raw[key]);
     });
     base.active = coerceHacsBool(raw.active);
@@ -928,24 +934,39 @@ function formatHacsDate(value){
   return date.toLocaleString();
 }
 
+function hacsLocalDateTimeValue(date){
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function defaultHacsRestartValue(){
+  return hacsLocalDateTimeValue(new Date(Date.now() + 30 * 60 * 1000));
+}
+
 function hacsStatusTone(config){
   const result = String(config?.last_result || '').toLowerCase();
-  if (['check_failed','install_failed','entity_not_found'].includes(result)) return 'error';
-  if (['installed','restart_requested','up_to_date','enabled'].includes(result)) return 'success';
+  if (['check_failed','install_failed','install_unconfirmed','restart_failed','entity_not_found'].includes(result)) return 'error';
+  if (['installed','restart_requested','restart_scheduled','up_to_date','enabled'].includes(result)) return 'success';
+  if (result === 'update_available') return 'warning';
   return 'muted';
 }
 
 function describeHacsResult(config){
   const result = String(config?.last_result || '').toLowerCase();
+  if (result === 'update_available') return 'Update available. Review and install when ready.';
   if (result === 'installed') return 'Update installed. Restart Home Assistant to load it.';
   if (result === 'restart_requested') return 'Restart requested. Home Assistant is restarting...';
+  if (result === 'restart_scheduled') return 'Restart scheduled.';
   if (result === 'up_to_date') return 'No update available.';
   if (result === 'check_failed') return 'Update check failed.';
   if (result === 'install_failed') return 'Update install failed.';
+  if (result === 'install_unconfirmed') return 'Install command sent, but HACS has not confirmed the new version.';
+  if (result === 'restart_failed') return 'Home Assistant restart failed.';
   if (result === 'entity_not_found') return 'HACS update entity was not found.';
-  if (result === 'disabled') return 'Automatic HACS updates are disabled.';
-  if (config?.enabled) return config?.active ? 'Automatic HACS updates are enabled.' : 'Automatic HACS updates will start after reload.';
-  return 'Automatic HACS updates are disabled.';
+  if (result === 'disabled') return 'Automatic HACS update checks are disabled.';
+  if (config?.enabled) return config?.active ? 'Automatic HACS update checks are enabled.' : 'Automatic HACS update checks will start after reload.';
+  return 'Automatic HACS update checks are disabled.';
 }
 
 function readHacsAutoUpdateForm(){
@@ -982,9 +1003,16 @@ function renderHacsAutoUpdate(){
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
   const checkBtn = document.getElementById('hacsUpdateCheckBtn');
+  const installBtn = document.getElementById('hacsUpdateInstallBtn');
   const restartBtn = document.getElementById('hacsRestartNowBtn');
+  const scheduleWrap = document.getElementById('hacsRestartScheduleWrap');
+  const scheduleInput = document.getElementById('hacsRestartScheduleAt');
+  const scheduleBtn = document.getElementById('hacsRestartScheduleBtn');
+  const cancelScheduleBtn = document.getElementById('hacsRestartCancelScheduleBtn');
   const meta = document.getElementById('hacsAutoUpdateMeta');
-  const updateInstalled = String(cfg.last_result || '').toLowerCase() === 'installed';
+  const result = String(cfg.last_result || '').toLowerCase();
+  const updateAvailable = result === 'update_available';
+  const updateInstalled = ['installed','restart_scheduled','restart_failed'].includes(result);
   const canRestart = !!(SETTINGS_DATA.dashboard_access?.can_manage || SETTINGS_DATA.dashboard_access?.current_user_is_admin);
   if (toggle) toggle.checked = !!cfg.enabled;
   if (backupInput) backupInput.checked = !!cfg.backup;
@@ -995,17 +1023,37 @@ function renderHacsAutoUpdate(){
   }
   if (entityInput) entityInput.value = cfg.update_entity || '';
   if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
+  if (installBtn) {
+    installBtn.classList.toggle('d-none', !updateAvailable);
+    installBtn.disabled = hacsUpdateInstalling;
+  }
   if (restartBtn) {
     restartBtn.classList.toggle('d-none', !(canRestart && (updateInstalled || hacsRestarting)));
     restartBtn.disabled = hacsRestarting;
+  }
+  if (scheduleWrap) {
+    scheduleWrap.classList.toggle('d-none', !(canRestart && updateInstalled));
+  }
+  if (scheduleInput) {
+    if (!scheduleInput.value || cfg.restart_scheduled_for) {
+      const parsed = cfg.restart_scheduled_for ? new Date(cfg.restart_scheduled_for) : null;
+      scheduleInput.value = parsed && !Number.isNaN(parsed.getTime()) ? hacsLocalDateTimeValue(parsed) : defaultHacsRestartValue();
+    }
+  }
+  if (scheduleBtn) scheduleBtn.disabled = hacsRestartScheduling;
+  if (cancelScheduleBtn) {
+    cancelScheduleBtn.classList.toggle('d-none', !cfg.restart_scheduled_for);
+    cancelScheduleBtn.disabled = hacsRestartScheduling;
   }
   if (meta){
     const details = [
       `Last checked: ${formatHacsDate(cfg.last_checked)}`,
     ];
     if (cfg.last_installed) details.push(`Last installed: ${formatHacsDate(cfg.last_installed)}`);
+    if (cfg.pending_version) details.push(`Pending: ${cfg.pending_version}`);
     if (cfg.last_entity_id) details.push(`Entity: ${cfg.last_entity_id}`);
     if (cfg.installed_version || cfg.latest_version) details.push(`Version: ${cfg.installed_version || 'unknown'} to ${cfg.latest_version || 'unknown'}`);
+    if (cfg.restart_scheduled_for) details.push(`Restart scheduled: ${formatHacsDate(cfg.restart_scheduled_for)}`);
     if (cfg.last_error) details.push(`Error: ${cfg.last_error}`);
     meta.textContent = details.join(' | ');
   }
@@ -1140,9 +1188,38 @@ async function runHacsUpdateCheck(){
   }
 }
 
-async function restartHomeAssistantNow(){
+async function installHacsUpdate(){
+  if (hacsUpdateInstalling) return;
+  const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
+  const version = cfg.pending_version || cfg.latest_version || 'the available version';
+  if (!confirm(`Install Akuvox Access Control update ${version}?`)) {
+    return;
+  }
+  hacsUpdateInstalling = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Installing HACS update...');
+  try {
+    const res = await callAction('hacs_update_install');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+    const result = String(SETTINGS_DATA.hacs_auto_update?.last_result || '').toLowerCase();
+    if (result === 'installed' && confirm('Update installed. Restart Home Assistant now? Press Cancel to schedule it for later.')) {
+      await restartHomeAssistantNow({ skipConfirm: true });
+    }
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'HACS update install failed', 'error');
+  } finally {
+    hacsUpdateInstalling = false;
+    renderHacsAutoUpdate();
+  }
+}
+
+async function restartHomeAssistantNow(options = {}){
   if (hacsRestarting) return;
-  if (!confirm('Restart Home Assistant now? The dashboard will disconnect while Home Assistant restarts.')) {
+  if (!options.skipConfirm && !confirm('Restart Home Assistant now? The dashboard will disconnect while Home Assistant restarts.')) {
     return;
   }
   hacsRestarting = true;
@@ -1160,6 +1237,59 @@ async function restartHomeAssistantNow(){
     renderHacsAutoUpdate();
     if (handleAuthError(err)) return;
     setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to restart Home Assistant', 'error');
+  }
+}
+
+async function scheduleHomeAssistantRestart(){
+  if (hacsRestartScheduling) return;
+  const input = document.getElementById('hacsRestartScheduleAt');
+  const raw = String(input?.value || '').trim();
+  if (!raw) {
+    setHacsAutoUpdateStatus('Choose when Home Assistant should restart.', 'error');
+    return;
+  }
+  const restartAt = new Date(raw);
+  if (Number.isNaN(restartAt.getTime()) || restartAt <= new Date()) {
+    setHacsAutoUpdateStatus('Choose a restart time in the future.', 'error');
+    return;
+  }
+  hacsRestartScheduling = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Scheduling Home Assistant restart...');
+  try {
+    const res = await callAction('schedule_homeassistant_restart', { restart_at: restartAt.toISOString() });
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    renderHacsAutoUpdate();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to schedule Home Assistant restart', 'error');
+  } finally {
+    hacsRestartScheduling = false;
+    renderHacsAutoUpdate();
+  }
+}
+
+async function cancelHomeAssistantRestart(){
+  if (hacsRestartScheduling) return;
+  hacsRestartScheduling = true;
+  renderHacsAutoUpdate();
+  setHacsAutoUpdateStatus('Cancelling scheduled restart...');
+  try {
+    const res = await callAction('cancel_homeassistant_restart');
+    if (res && res.hacs_auto_update){
+      SETTINGS_DATA.hacs_auto_update = sanitizeHacsAutoUpdate(res.hacs_auto_update);
+    }
+    const input = document.getElementById('hacsRestartScheduleAt');
+    if (input) input.value = defaultHacsRestartValue();
+    renderHacsAutoUpdate();
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    setHacsAutoUpdateStatus(err && err.message ? err.message : 'Failed to cancel scheduled restart', 'error');
+  } finally {
+    hacsRestartScheduling = false;
+    renderHacsAutoUpdate();
   }
 }
 
@@ -2562,9 +2692,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     ev.preventDefault();
     await runHacsUpdateCheck();
   });
+  document.getElementById('hacsUpdateInstallBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await installHacsUpdate();
+  });
   document.getElementById('hacsRestartNowBtn')?.addEventListener('click', async (ev) => {
     ev.preventDefault();
     await restartHomeAssistantNow();
+  });
+  document.getElementById('hacsRestartScheduleBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await scheduleHomeAssistantRestart();
+  });
+  document.getElementById('hacsRestartCancelScheduleBtn')?.addEventListener('click', async (ev) => {
+    ev.preventDefault();
+    await cancelHomeAssistantRestart();
   });
 
   document.getElementById('dashboardAccessUsers')?.addEventListener('change', async (ev) => {
@@ -2725,10 +2867,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   <div class="card mt-3">
     <div class="card-header">HACS Auto Update</div>
     <div class="card-body">
-      <p class="muted">Automatically refresh the HACS update entity for this integration and install an available update. Home Assistant still needs a restart after an integration update is installed.</p>
+      <p class="muted">Automatically refresh the HACS update entity for this integration. When an update is found, review it here before installing. Home Assistant still needs a restart after an integration update is installed.</p>
       <div class="form-check form-switch">
         <input class="form-check-input" type="checkbox" id="hacsAutoUpdateToggle">
-        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS updates</label>
+        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS update checks</label>
       </div>
       <div class="row g-2 mt-3">
         <div class="col-md-4">
@@ -2747,8 +2889,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       </div>
       <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
         <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>
+        <button id="hacsUpdateInstallBtn" class="btn btn-success btn-sm d-none" type="button"><i class="bi bi-cloud-arrow-down me-1"></i>Install update</button>
         <button id="hacsRestartNowBtn" class="btn btn-warning btn-sm d-none" type="button"><i class="bi bi-power me-1"></i>Restart Home Assistant</button>
         <span id="hacsAutoUpdateStatus" class="visually-hidden small"></span>
+      </div>
+      <div id="hacsRestartScheduleWrap" class="row g-2 align-items-end mt-2 d-none">
+        <div class="col-md-5">
+          <label class="form-label" for="hacsRestartScheduleAt">Schedule restart for later</label>
+          <input id="hacsRestartScheduleAt" class="form-control" type="datetime-local" />
+        </div>
+        <div class="col-md-auto d-flex flex-wrap gap-2">
+          <button id="hacsRestartScheduleBtn" class="btn btn-outline-warning btn-sm" type="button"><i class="bi bi-clock me-1"></i>Schedule restart</button>
+          <button id="hacsRestartCancelScheduleBtn" class="btn btn-outline-secondary btn-sm d-none" type="button"><i class="bi bi-x-circle me-1"></i>Cancel scheduled restart</button>
+        </div>
       </div>
       <div id="hacsAutoUpdateMeta" class="muted small mt-2"></div>
     </div>


### PR DESCRIPTION
## Summary
- Split the HACS update process into explicit check and install stages so a check no longer claims an update was installed.
- Verify the HACS update entity reports the expected installed version before showing restart options; otherwise mark the install as unconfirmed.
- Add restart-now, schedule-restart, and cancel-scheduled-restart handling in the settings UI and dashboard quick update flow.
- Move the updater to GitHub release tags/version numbers instead of commit hashes, with `3.1.0` as the starting integration version.
- Bootstrap the first `v3.1.0` release when no `v*` tag exists, then use semantic-release rules so patch changes become `3.1.1` and larger feature changes become `3.2.0`.

## Validation
- `git diff --check`
- `python -m py_compile custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_hacs_auto_update.py` using the bundled Codex Python runtime
- `node -c scripts/set-release-version.cjs`
- JSON parse check for `.releaserc.json`, `package.json`, and `custom_components/akuvox_ac/manifest.json`
- Direct Python validation of release-version HACS check/install/unconfirmed flows using Home Assistant stubs
- Embedded script syntax check for `settings.html`, `settings-mob.html`, `index.html`, and `index-mob.html` using the bundled Codex Node runtime

## Not Run
- `pytest custom_components/akuvox_ac/tests/test_hacs_auto_update.py` because the bundled Python runtime does not include `pytest`, and system `python`/`py` are not installed.