### PR TITLE
[codex] Use release versions for HACS updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Bootstrap 3.1.0 release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! git tag --list 'v*' | grep -q '^v'; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag v3.1.0
+            git push origin v3.1.0
+            gh release create v3.1.0 --title "v3.1.0" --notes "Initial versioned release for Akuvox Access Control."
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run semantic-release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,8 +2,42 @@
   "branches": ["main"],
   "tagFormat": "v${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "breaking": true, "release": "minor" },
+          { "type": "major", "release": "minor" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "type": "chore", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "node scripts/set-release-version.cjs ${nextRelease.version}"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "custom_components/akuvox_ac/manifest.json",
+          "custom_components/akuvox_ac/const.py"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
     "@semantic-release/github"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ README.md
 This integration supports **config flow** (Settings → Devices & services → Add Integration → search for *Akuvox Access Control*).
 Follow the on‑screen steps. See the in‑integration options and services for details.
 
+## Release Versioning
+Releases start at `v3.1.0`. The integration manifest and dashboard version label are updated by the release workflow so HACS and Home Assistant show release versions instead of commit hashes.
+
+- Small fixes and routine changes use patch versions, for example `3.1.0` → `3.1.1`.
+- Larger feature changes use minor versions, for example `3.1.x` → `3.2.0`.
+- Use `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `build:`, or `ci:` commits for patch releases.
+- Use `feat:` or `major:` commits for the next minor release.
+
 ## Notes
 - Web assets (in `custom_components/akuvox_ac/www/`) are served via `/api/AK_AC/...` and require Home Assistant authentication (cookie session or long‑lived token).
 - Uploaded face images are stored in the Home Assistant config at `config/akuvox_ac/FaceData/` and are preserved across updates.

--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -3,8 +3,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "akuvox_ac"
 
-INTEGRATION_VERSION = "0.1.0b0"
-INTEGRATION_VERSION_LABEL = "0.1.0 (Beta)"
+INTEGRATION_VERSION = "3.1.0"
+INTEGRATION_VERSION_LABEL = "3.1.0"
 
 # Bump when you change stored config structure
 ENTRY_VERSION = 3

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -3224,7 +3224,7 @@ class HacsAutoUpdater:
 
     REPOSITORY = "DJGLTD/AK_Access_ctrl"
     DEFAULT_BRANCH = "main"
-    GITHUB_COMMIT_URL = f"https://api.github.com/repos/{REPOSITORY}/commits/{DEFAULT_BRANCH}"
+    GITHUB_RELEASE_URL = f"https://api.github.com/repos/{REPOSITORY}/releases/latest"
     MATCHERS = (
         "djgltd/ak_access_ctrl",
         "ak_access_ctrl",
@@ -3509,45 +3509,63 @@ class HacsAutoUpdater:
 
     def _update_available(self, state: Any) -> bool:
         state_value = str(getattr(state, "state", "") or "").strip().lower()
-        if state_value == "on":
-            return True
-        if state_value == "off":
-            return False
-
         attrs = getattr(state, "attributes", {}) or {}
         installed = str(attrs.get("installed_version") or "").strip()
         latest = str(attrs.get("latest_version") or "").strip()
         skipped = str(attrs.get("skipped_version") or "").strip()
-        return bool(latest and installed and latest != installed and latest != skipped)
+        if not latest or not installed:
+            return False
+        if not self._is_release_version(latest):
+            return False
+        if self._versions_match(latest, installed):
+            return False
+        if skipped and self._versions_match(latest, skipped):
+            return False
+        if state_value == "off":
+            return False
+        return True
 
     @staticmethod
     def _version_text(version: Any) -> str:
         return str(version or "").strip()
 
     @classmethod
-    def _short_version(cls, version: Any) -> Optional[str]:
+    def _is_release_version(cls, version: Any) -> bool:
+        text = cls._version_text(version)
+        return bool(re.fullmatch(r"v?\d+(?:\.\d+){1,2}(?:[-+][0-9A-Za-z.-]+)?", text))
+
+    @classmethod
+    def _display_version(cls, version: Any) -> Optional[str]:
         text = cls._version_text(version)
         if not text:
             return None
-        if re.fullmatch(r"[0-9a-fA-F]{7,40}", text):
-            return text[:7].lower()
+        if cls._is_release_version(text):
+            return text[1:] if text.lower().startswith("v") else text
+        return text
+
+    @classmethod
+    def _comparable_version(cls, version: Any) -> str:
+        text = cls._version_text(version).lower()
+        if not text:
+            return ""
+        if text.startswith("v") and len(text) > 1 and text[1].isdigit():
+            text = text[1:]
+        match = re.fullmatch(r"(\d+)\.(\d+)(?:\.(\d+))?([\-+][0-9a-z.-]+)?", text)
+        if match:
+            patch = match.group(3) if match.group(3) is not None else "0"
+            suffix = match.group(4) or ""
+            return f"{int(match.group(1))}.{int(match.group(2))}.{int(patch)}{suffix}"
         return text
 
     @classmethod
     def _versions_match(cls, left: Any, right: Any) -> bool:
-        left_text = cls._version_text(left).lower()
-        right_text = cls._version_text(right).lower()
+        left_text = cls._comparable_version(left)
+        right_text = cls._comparable_version(right)
         if not left_text or not right_text:
             return False
-        if left_text == right_text:
-            return True
-        if re.fullmatch(r"[0-9a-f]{7,40}", left_text) and re.fullmatch(
-            r"[0-9a-f]{7,40}", right_text
-        ):
-            return left_text.startswith(right_text) or right_text.startswith(left_text)
-        return False
+        return left_text == right_text
 
-    async def _fetch_latest_github_sha(self) -> Optional[str]:
+    async def _fetch_latest_github_release(self) -> Optional[Tuple[str, str]]:
         session = async_get_clientsession(self.hass)
         if asyncio.iscoroutine(session):
             session = await session
@@ -3555,7 +3573,7 @@ class HacsAutoUpdater:
             return None
 
         response_cm = session.get(
-            self.GITHUB_COMMIT_URL,
+            self.GITHUB_RELEASE_URL,
             headers={
                 "Accept": "application/vnd.github+json",
                 "User-Agent": "HomeAssistant-Akuvox-Access-Control",
@@ -3564,22 +3582,25 @@ class HacsAutoUpdater:
         )
         async with response_cm as response:
             status = int(getattr(response, "status", 0) or 0)
+            if status == 404:
+                return None
             if status >= 400:
                 body = ""
                 try:
                     body = await response.text()
                 except Exception:
                     body = ""
-                message = f"GitHub latest commit check failed with HTTP {status}"
+                message = f"GitHub latest release check failed with HTTP {status}"
                 if body:
                     message = f"{message}: {body[:200]}"
                 raise RuntimeError(message)
             payload = await response.json()
 
-        sha = str((payload or {}).get("sha") or "").strip().lower()
-        if not re.fullmatch(r"[0-9a-f]{40}", sha):
-            raise RuntimeError("GitHub latest commit response did not include a valid SHA.")
-        return sha
+        tag = str((payload or {}).get("tag_name") or "").strip()
+        version = self._display_version(tag)
+        if not tag or not version:
+            raise RuntimeError("GitHub latest release response did not include a valid tag.")
+        return tag, version
 
     async def _record_status(self, **updates: Any) -> Dict[str, Any]:
         settings = self._settings_store()
@@ -3675,15 +3696,21 @@ class HacsAutoUpdater:
             attrs = getattr(state, "attributes", {}) or {}
             installed = attrs.get("installed_version")
             hacs_latest = attrs.get("latest_version")
-            latest = hacs_latest
-            github_latest_sha: Optional[str] = None
+            hacs_latest_version = (
+                self._display_version(hacs_latest) if self._is_release_version(hacs_latest) else None
+            )
+            latest = hacs_latest_version
+            github_latest_tag: Optional[str] = None
+            github_latest_version: Optional[str] = None
             github_error: Optional[str] = None
             try:
-                github_latest_sha = await self._fetch_latest_github_sha()
+                latest_release = await self._fetch_latest_github_release()
+                if latest_release:
+                    github_latest_tag, github_latest_version = latest_release
             except Exception as err:
                 github_error = str(err)
-            if github_latest_sha:
-                latest = self._short_version(github_latest_sha)
+            if github_latest_version:
+                latest = github_latest_version
 
             base_status = {
                 "last_checked": checked_at,
@@ -3694,13 +3721,13 @@ class HacsAutoUpdater:
 
             pending_version_full: Optional[str] = None
             has_update = self._update_available(state)
-            if github_latest_sha and not self._versions_match(installed, github_latest_sha):
+            if github_latest_version and not self._versions_match(installed, github_latest_version):
                 has_update = True
-                pending_version_full = github_latest_sha
-            elif has_update and hacs_latest:
+                pending_version_full = github_latest_tag or github_latest_version
+            elif has_update and hacs_latest_version:
                 pending_version_full = self._version_text(hacs_latest)
 
-            pending_version = self._short_version(pending_version_full)
+            pending_version = self._display_version(pending_version_full)
 
             if not has_update:
                 if github_error:
@@ -3787,11 +3814,11 @@ class HacsAutoUpdater:
             attrs_after = getattr(state_after, "attributes", {}) if state_after is not None else {}
             installed_after = attrs_after.get("installed_version") or check_status.get("installed_version")
             latest_after = attrs_after.get("latest_version") or check_status.get("latest_version")
-            pending_short = self._short_version(install_version)
+            pending_display = self._display_version(install_version)
             confirmed = False
             if install_version and self._versions_match(installed_after, install_version):
                 confirmed = True
-            elif pending_short and self._versions_match(installed_after, pending_short):
+            elif pending_display and self._versions_match(installed_after, pending_display):
                 confirmed = True
             elif (
                 not install_version
@@ -3808,13 +3835,13 @@ class HacsAutoUpdater:
                     last_checked=dt_util.now().isoformat(),
                     last_entity_id=entity_id,
                     installed_version=installed_after,
-                    latest_version=pending_short or latest_after,
+                    latest_version=pending_display or latest_after,
                     last_result="install_unconfirmed",
                     last_error=(
                         "Install command was sent, but HACS still reports "
                         f"{entity_id} at {installed_after or 'unknown'}."
                     ),
-                    pending_version=pending_short or check_status.get("pending_version"),
+                    pending_version=pending_display or check_status.get("pending_version"),
                     pending_version_full=install_version or check_status.get("pending_version_full"),
                 )
 
@@ -3823,7 +3850,7 @@ class HacsAutoUpdater:
                 last_checked=dt_util.now().isoformat(),
                 last_entity_id=entity_id,
                 installed_version=installed_after,
-                latest_version=pending_short or latest_after,
+                latest_version=pending_display or latest_after,
                 last_installed=dt_util.now().isoformat(),
                 last_result="installed",
                 last_error=None,

--- a/custom_components/akuvox_ac/manifest.json
+++ b/custom_components/akuvox_ac/manifest.json
@@ -1,11 +1,15 @@
 {
   "domain": "akuvox_ac",
   "name": "Akuvox Access Control",
-  "version": "0.1.0b0",
-  "codeowners": ["@you"],
+  "version": "3.1.0",
+  "codeowners": [
+    "@you"
+  ],
   "config_flow": true,
   "import_executor": true,
   "iot_class": "local_polling",
-  "loggers": ["custom_components.akuvox_ac"],
+  "loggers": [
+    "custom_components.akuvox_ac"
+  ],
   "requirements": []
 }

--- a/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
+++ b/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
@@ -14,7 +14,8 @@ from custom_components.akuvox_ac.integration import (  # noqa: E402
 )
 
 
-LATEST_SHA = "71d1bd2556e9377b183e73b73a8fda88fdfa89cc"
+LATEST_TAG = "v3.2.0"
+LATEST_VERSION = "3.2.0"
 
 
 class _State:
@@ -23,8 +24,8 @@ class _State:
     attributes = {
         "friendly_name": "Akuvox Access Control update",
         "repository": "DJGLTD/AK_Access_ctrl",
-        "installed_version": "3175ae3",
-        "latest_version": "3175ae3",
+        "installed_version": "3.1.0",
+        "latest_version": "3.1.0",
     }
 
 
@@ -56,7 +57,7 @@ class _Services:
     ) -> None:
         self.calls.append((domain, service, dict(data or {}), blocking))
         if domain == "update" and service == "install" and self._confirm_install:
-            version = str((data or {}).get("version") or LATEST_SHA)[:7]
+            version = HacsAutoUpdater._display_version((data or {}).get("version") or LATEST_TAG)
             self._state.attributes = dict(self._state.attributes)
             self._state.attributes["installed_version"] = version
             self._state.attributes["latest_version"] = version
@@ -83,7 +84,7 @@ class _GithubResponse:
         return None
 
     async def json(self) -> Dict[str, str]:
-        return {"sha": LATEST_SHA}
+        return {"tag_name": LATEST_TAG}
 
 
 class _GithubSession:
@@ -111,7 +112,7 @@ def _settings_store() -> AkuvoxSettingsStore:
     return store
 
 
-def test_hacs_auto_update_check_detects_github_head_when_hacs_entity_is_stale(monkeypatch):
+def test_hacs_auto_update_check_detects_latest_release_when_hacs_entity_is_stale(monkeypatch):
     store = _settings_store()
     hass = _Hass(store)
     monkeypatch.setattr(
@@ -127,13 +128,13 @@ def test_hacs_auto_update_check_detects_github_head_when_hacs_entity_is_stale(mo
     ]
     assert install_calls == []
     assert status["last_result"] == "update_available"
-    assert status["installed_version"] == "3175ae3"
-    assert status["latest_version"] == "71d1bd2"
-    assert status["pending_version"] == "71d1bd2"
-    assert status["pending_version_full"] == LATEST_SHA
+    assert status["installed_version"] == "3.1.0"
+    assert status["latest_version"] == LATEST_VERSION
+    assert status["pending_version"] == LATEST_VERSION
+    assert status["pending_version_full"] == LATEST_TAG
 
 
-def test_hacs_auto_update_install_confirms_github_head(monkeypatch):
+def test_hacs_auto_update_install_confirms_latest_release(monkeypatch):
     store = _settings_store()
     hass = _Hass(store)
     monkeypatch.setattr(
@@ -153,14 +154,14 @@ def test_hacs_auto_update_install_confirms_github_head(monkeypatch):
             "install",
             {
                 "entity_id": "update.akuvox_access_control_update",
-                "version": LATEST_SHA,
+                "version": LATEST_TAG,
             },
             True,
         )
     ]
     assert status["last_result"] == "installed"
-    assert status["installed_version"] == "71d1bd2"
-    assert status["latest_version"] == "71d1bd2"
+    assert status["installed_version"] == LATEST_VERSION
+    assert status["latest_version"] == LATEST_VERSION
     assert status["pending_version"] is None
 
 
@@ -176,8 +177,8 @@ def test_hacs_auto_update_install_requires_hacs_confirmation(monkeypatch):
     status = asyncio.run(HacsAutoUpdater(hass).async_install_update(force=True))
 
     assert status["last_result"] == "install_unconfirmed"
-    assert status["installed_version"] == "3175ae3"
-    assert status["pending_version"] == "71d1bd2"
+    assert status["installed_version"] == "3.1.0"
+    assert status["pending_version"] == LATEST_VERSION
 
 
 def test_hacs_auto_update_schedules_and_cancels_restart(monkeypatch):
@@ -204,6 +205,8 @@ def test_hacs_auto_update_schedules_and_cancels_restart(monkeypatch):
     assert status["restart_scheduled_for"] is None
 
 
-def test_hacs_auto_update_matches_short_and_full_commit_versions():
-    assert HacsAutoUpdater._versions_match("71d1bd2", LATEST_SHA) is True
-    assert HacsAutoUpdater._versions_match("3175ae3", LATEST_SHA) is False
+def test_hacs_auto_update_matches_release_versions():
+    assert HacsAutoUpdater._versions_match("v3.1.0", "3.1") is True
+    assert HacsAutoUpdater._versions_match("3.1.1", "v3.1.1") is True
+    assert HacsAutoUpdater._versions_match("3.1.1", "3.2.0") is False
+    assert HacsAutoUpdater._versions_match("71d1bd2", "3.2.0") is False

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "ak_access_ctrl-release",
   "private": true,
   "devDependencies": {
-    "semantic-release": "^25.0.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/exec": "^7.1.0",
+    "@semantic-release/git": "^10.0.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
-    "@semantic-release/github": "^12.0.0"
+    "@semantic-release/github": "^12.0.0",
+    "semantic-release": "^25.0.0"
   }
 }

--- a/scripts/set-release-version.cjs
+++ b/scripts/set-release-version.cjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const version = String(process.argv[2] || "").trim();
+if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error("Usage: node scripts/set-release-version.cjs <semver>");
+  process.exit(1);
+}
+
+const root = path.resolve(__dirname, "..");
+const manifestPath = path.join(root, "custom_components", "akuvox_ac", "manifest.json");
+const constPath = path.join(root, "custom_components", "akuvox_ac", "const.py");
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+manifest.version = version;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+let constants = fs.readFileSync(constPath, "utf8");
+constants = constants.replace(
+  /^INTEGRATION_VERSION = ".*"$/m,
+  `INTEGRATION_VERSION = "${version}"`,
+);
+constants = constants.replace(
+  /^INTEGRATION_VERSION_LABEL = ".*"$/m,
+  `INTEGRATION_VERSION_LABEL = "${version}"`,
+);
+fs.writeFileSync(constPath, constants);


### PR DESCRIPTION
## Summary
- Set the integration starting version to `3.1.0` in the manifest and dashboard version constants.
- Move the HACS updater from GitHub commit SHA checks to latest GitHub release tag checks, displaying `v3.2.0` as `3.2.0` and ignoring commit-like values as installable versions.
- Add release workflow support to bootstrap the first `v3.1.0` release when no `v*` tag exists.
- Configure semantic-release rules so patch/routine commits produce `3.1.1` style versions, while `feat:` or `major:` changes produce `3.2.0` style minor releases.
- Add a release-version script so future releases update both `manifest.json` and `const.py` before publishing.

## Validation
- `git diff --check`
- `python -m py_compile custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_hacs_auto_update.py` using the bundled Codex Python runtime
- `node -c scripts/set-release-version.cjs`
- JSON parse check for `.releaserc.json`, `package.json`, and `custom_components/akuvox_ac/manifest.json`
- Direct Python validation of release-version HACS check/install/unconfirmed flows using Home Assistant stubs

## Not Run
- `pytest custom_components/akuvox_ac/tests/test_hacs_auto_update.py` because the bundled Python runtime does not include `pytest`, and system `python`/`py` are not installed.