### PR TITLE
[codex] Fix automatic patch version releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,31 +3,13 @@
   "tagFormat": "v${version}",
   "plugins": [
     [
-      "@semantic-release/commit-analyzer",
-      {
-        "releaseRules": [
-          { "breaking": true, "release": "minor" },
-          { "type": "major", "release": "minor" },
-          { "type": "feat", "release": "minor" },
-          { "type": "fix", "release": "patch" },
-          { "type": "perf", "release": "patch" },
-          { "type": "refactor", "release": "patch" },
-          { "type": "docs", "release": "patch" },
-          { "type": "style", "release": "patch" },
-          { "type": "test", "release": "patch" },
-          { "type": "build", "release": "patch" },
-          { "type": "ci", "release": "patch" },
-          { "type": "chore", "release": "patch" }
-        ]
-      }
-    ],
-    "@semantic-release/release-notes-generator",
-    [
       "@semantic-release/exec",
       {
+        "analyzeCommitsCmd": "node scripts/analyze-release.cjs",
         "prepareCmd": "node scripts/set-release-version.cjs ${nextRelease.version}"
       }
     ],
+    "@semantic-release/release-notes-generator",
     [
       "@semantic-release/git",
       {

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Releases start at `v3.1.0`. The integration manifest and dashboard version label
 
 - Small fixes and routine changes use patch versions, for example `3.1.0` → `3.1.1`.
 - Larger feature changes use minor versions, for example `3.1.x` → `3.2.0`.
-- Use `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `build:`, or `ci:` commits for patch releases.
-- Use `feat:` or `major:` commits for the next minor release.
+- Every merged PR or direct commit to `main` creates at least a patch release.
+- Use `feat:`, `[minor]`, `[feature]`, or `[major]` in the PR title or commit message for the next minor release.
 
 ## Notes
 - Web assets (in `custom_components/akuvox_ac/www/`) are served via `/api/AK_AC/...` and require Home Assistant authentication (cookie session or long‑lived token).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ak_access_ctrl-release",
   "private": true,
   "devDependencies": {
-    "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/release-notes-generator": "^14.1.0",

--- a/scripts/analyze-release.cjs
+++ b/scripts/analyze-release.cjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("node:child_process");
+
+function git(args, { allowFailure = false } = {}) {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    if (allowFailure) return "";
+    const error = String(result.stderr || result.stdout || "").trim();
+    throw new Error(error || `git ${args.join(" ")} failed`);
+  }
+  return String(result.stdout || "").trim();
+}
+
+function latestVersionTag() {
+  return git(
+    ["describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"],
+    { allowFailure: true },
+  );
+}
+
+function commitsSinceLatestTag() {
+  const tag = latestVersionTag();
+  const range = tag ? `${tag}..HEAD` : "HEAD";
+  const raw = git(["log", "--format=%H%x1f%s%x1f%B%x1e", range], {
+    allowFailure: true,
+  });
+  if (!raw) return [];
+
+  return raw
+    .split("\x1e")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [hash = "", subject = "", body = ""] = entry.split("\x1f");
+      return { hash: hash.trim(), subject: subject.trim(), body: body.trim() };
+    });
+}
+
+function isReleaseCommit(commit) {
+  const text = `${commit.subject}\n${commit.body}`;
+  return /(^|\n)chore\(release\):\s+\d+\.\d+\.\d+/i.test(text);
+}
+
+function requestsMinorRelease(commit) {
+  const text = `${commit.subject}\n${commit.body}`;
+  return (
+    /(^|\n)BREAKING CHANGE:/i.test(text)
+    || /(^|\n)(feat|feature|major)(\([^)]+\))?!?:/i.test(text)
+    || /\[(minor|feature|major)\]/i.test(text)
+    || /#(minor|feature|major)\b/i.test(text)
+  );
+}
+
+const commits = commitsSinceLatestTag().filter((commit) => !isReleaseCommit(commit));
+
+if (commits.length === 0) {
+  process.exit(0);
+}
+
+if (commits.some(requestsMinorRelease)) {
+  console.log("minor");
+  process.exit(0);
+}
+
+console.log("patch");


### PR DESCRIPTION
## Summary
- Replace conventional-commit-only release analysis with a repo script that defaults every real commit since the latest `v*` tag to a patch release.
- Keep minor releases available by marking a PR title or commit message with `feat:`, `[minor]`, `[feature]`, or `[major]`.
- Document the automatic patch release behavior in the README.

## Why
PR #353 merged as a normal commit title, so the semantic-release commit analyzer did not see a conventional `fix:`/`feat:` type and did not create `3.1.1`. This makes merged PRs produce a patch release by default.

## Validation
- `git diff --check`
- JSON parse check for `.releaserc.json` and `package.json`
- `node --check scripts/analyze-release.cjs`
- `node scripts/analyze-release.cjs` returned `patch` against the current `v3.1.0` tag