### PR TITLE
[codex] Prevent dashboard auth retries from triggering bans

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -2721,6 +2721,15 @@ class AkuvoxStaticAssets(HomeAssistantView):
                         return web.FileResponse(candidate)
 
         asset = _static_asset(path)
+        if not is_face_request and asset.suffix.lower() == ".html":
+            route_key = clean.lower().strip("/")
+            if not route_key:
+                route_key = "index"
+            if route_key.endswith(".html"):
+                route_key = route_key[:-5]
+            if route_key in DASHBOARD_ROUTES:
+                raise web.HTTPFound(f"/akuvox-ac/{route_key}")
+
         if is_face_request:
             rel = clean[8:].lstrip("/")
             if rel:
@@ -2747,7 +2756,7 @@ class AkuvoxStaticAssets(HomeAssistantView):
 class AkuvoxDashboardView(HomeAssistantView):
     url = "/akuvox-ac/{slug:.*}"
     name = "akuvox_ac:dashboard"
-    requires_auth = False
+    requires_auth = True
 
     async def get(self, request: web.Request, slug: str = ""):
         clean = (slug or "").strip().strip("/").lower()

--- a/custom_components/akuvox_ac/www/device_edit-mob.html
+++ b/custom_components/akuvox_ac/www/device_edit-mob.html
@@ -422,15 +422,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/device_edit.html
+++ b/custom_components/akuvox_ac/www/device_edit.html
@@ -425,15 +425,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/device_management-mob.html
+++ b/custom_components/akuvox_ac/www/device_management-mob.html
@@ -373,15 +373,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
     REJECTED_TOKENS.add(bearer);

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -436,16 +436,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
     const response = await fetch(url, merged);
     if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
       clearSignedPathCache();
-      const retryToken = nextBearerToken();
-      if (retryToken) {
-        const retryHeaders = new Headers(options.headers || {});
-        retryHeaders.set('Authorization', 'Bearer ' + retryToken);
-        const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, ...SAME_ORIGIN });
-        if (retryResponse.status === 401 || retryResponse.status === 403) {
-          REJECTED_TOKENS.add(retryToken);
-        }
-        return retryResponse;
-      }
+      return response;
     }
     if (response.status === 401 || response.status === 403) {
       if (token) REJECTED_TOKENS.add(token);

--- a/custom_components/akuvox_ac/www/diagnostics.html
+++ b/custom_components/akuvox_ac/www/diagnostics.html
@@ -436,16 +436,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
     const response = await fetch(url, merged);
     if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
       clearSignedPathCache();
-      const retryToken = nextBearerToken();
-      if (retryToken) {
-        const retryHeaders = new Headers(options.headers || {});
-        retryHeaders.set('Authorization', 'Bearer ' + retryToken);
-        const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, ...SAME_ORIGIN });
-        if (retryResponse.status === 401 || retryResponse.status === 403) {
-          REJECTED_TOKENS.add(retryToken);
-        }
-        return retryResponse;
-      }
+      return response;
     }
     if (response.status === 401 || response.status === 403) {
       if (token) REJECTED_TOKENS.add(token);

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -356,15 +356,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
     REJECTED_TOKENS.add(bearer);

--- a/custom_components/akuvox_ac/www/event_history.html
+++ b/custom_components/akuvox_ac/www/event_history.html
@@ -356,15 +356,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
     REJECTED_TOKENS.add(bearer);

--- a/custom_components/akuvox_ac/www/expiry_review.html
+++ b/custom_components/akuvox_ac/www/expiry_review.html
@@ -118,15 +118,6 @@ async function fetchWithAuth(url, options = {}){
   let res = await fetch(url, { ...options, headers, credentials:'same-origin' });
   if ((res.status === 401 || res.status === 403) && signedRequest) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      res = await fetch(stripAuthSig(url), {
-        ...options,
-        headers: { ...(options.headers || {}), Authorization:`Bearer ${retryToken}` },
-        credentials:'same-origin'
-      });
-      if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-    }
   }
   if (token && (res.status === 401 || res.status === 403)) REJECTED_TOKENS.add(token);
   return res;

--- a/custom_components/akuvox_ac/www/face_rec-mob.html
+++ b/custom_components/akuvox_ac/www/face_rec-mob.html
@@ -190,15 +190,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/face_rec.html
+++ b/custom_components/akuvox_ac/www/face_rec.html
@@ -190,15 +190,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -1232,17 +1232,9 @@ async function postJson(url, body = {}){
     throw error;
   }
   if ((response.status === 401 || response.status === 403) && signedRequest) {
+
     clearSignedPathCache();
-    const retryToken = getUsableToken();
-    if (retryToken) {
-      response = await fetch(stripAuthSig(url), {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: new Headers({ 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + retryToken }),
-        body: JSON.stringify(body)
-      });
-      if (response.status === 401 || response.status === 403) REJECTED_TOKENS.add(retryToken);
-    }
+
   }
   if (!response.ok) {
     let text = '';
@@ -1364,14 +1356,6 @@ async function fetchVersion(){
     });
     if ((res.status === 401 || res.status === 403) && signedRequest) {
       clearSignedPathCache();
-      const retryToken = getUsableToken();
-      if (retryToken) {
-        res = await fetch(stripAuthSig(API_STATE), {
-          credentials: 'same-origin',
-          headers: { 'Authorization': 'Bearer ' + retryToken }
-        });
-        if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-      }
     }
     if (!res.ok) throw new Error(await res.text());
     const data = await res.json();

--- a/custom_components/akuvox_ac/www/head.html
+++ b/custom_components/akuvox_ac/www/head.html
@@ -1228,14 +1228,6 @@ async function fetchVersion(){
     });
     if ((res.status === 401 || res.status === 403) && signedRequest) {
       clearSignedPathCache();
-      const retryToken = getUsableToken();
-      if (retryToken) {
-        res = await fetch(stripAuthSig(API_STATE), {
-          credentials: 'same-origin',
-          headers: { 'Authorization': 'Bearer ' + retryToken }
-        });
-        if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-      }
     }
     if (!res.ok) throw new Error(await res.text());
     const data = await res.json();

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -388,15 +388,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -409,15 +409,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/schedules-mob.html
+++ b/custom_components/akuvox_ac/www/schedules-mob.html
@@ -327,15 +327,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/schedules.html
+++ b/custom_components/akuvox_ac/www/schedules.html
@@ -327,15 +327,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -373,15 +373,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -374,15 +374,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/temp_user-mob.html
+++ b/custom_components/akuvox_ac/www/temp_user-mob.html
@@ -214,16 +214,6 @@ async function callService(service, data) {
   });
   if ((res.status === 401 || res.status === 403) && signedRequest) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      res = await fetch(stripAuthSig(url), {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${retryToken}` },
-        body: JSON.stringify(data || {})
-      });
-      if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-    }
   }
   if (!res.ok) {
     if (token && (res.status === 401 || res.status === 403)) REJECTED_TOKENS.add(token);
@@ -249,15 +239,6 @@ async function fetchWithAuth(url, options = {}) {
   let res = await fetch(url, { ...options, headers, credentials: 'same-origin' });
   if ((res.status === 401 || res.status === 403) && signedRequest) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      res = await fetch(stripAuthSig(url), {
-        ...options,
-        headers: { ...(options.headers || {}), Authorization: `Bearer ${retryToken}` },
-        credentials: 'same-origin'
-      });
-      if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-    }
   }
   if (token && (res.status === 401 || res.status === 403)) REJECTED_TOKENS.add(token);
   return res;

--- a/custom_components/akuvox_ac/www/temp_user.html
+++ b/custom_components/akuvox_ac/www/temp_user.html
@@ -197,16 +197,6 @@ async function callService(service, data) {
   });
   if ((res.status === 401 || res.status === 403) && signedRequest) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      res = await fetch(stripAuthSig(url), {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${retryToken}` },
-        body: JSON.stringify(data || {})
-      });
-      if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-    }
   }
   if (!res.ok) {
     if (token && (res.status === 401 || res.status === 403)) REJECTED_TOKENS.add(token);
@@ -232,15 +222,6 @@ async function fetchWithAuth(url, options = {}) {
   let res = await fetch(url, { ...options, headers, credentials: 'same-origin' });
   if ((res.status === 401 || res.status === 403) && signedRequest) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      res = await fetch(stripAuthSig(url), {
-        ...options,
-        headers: { ...(options.headers || {}), Authorization: `Bearer ${retryToken}` },
-        credentials: 'same-origin'
-      });
-      if (res.status === 401 || res.status === 403) REJECTED_TOKENS.add(retryToken);
-    }
   }
   if (token && (res.status === 401 || res.status === 403)) REJECTED_TOKENS.add(token);
   return res;

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -423,15 +423,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}) {
   const response = await fetch(url, { ...options, headers, credentials: 'same-origin' });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)) {
     REJECTED_TOKENS.add(bearer);

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -534,15 +534,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -534,15 +534,7 @@ async function fetchWithAuth(url, options = {}, { allowRetry = true } = {}){
   const response = await fetch(url, { ...SAME_ORIGIN, ...options, headers });
   if (allowRetry && signedRequest && (response.status === 401 || response.status === 403)) {
     clearSignedPathCache();
-    const retryToken = nextBearerToken();
-    if (retryToken) {
-      const retryHeaders = { ...originalHeaders, 'Authorization': 'Bearer ' + retryToken };
-      const retryResponse = await fetch(stripAuthSig(url), { ...options, headers: retryHeaders, credentials: 'same-origin' });
-      if (retryResponse.status === 401 || retryResponse.status === 403) {
-        REJECTED_TOKENS.add(retryToken);
-      }
-      return retryResponse;
-    }
+    return response;
   }
 
   if (allowRetry && usedBearer && (response.status === 401 || response.status === 403)){


### PR DESCRIPTION
## Summary
- Require Home Assistant authentication on the `/akuvox-ac/*` dashboard shell so signed API paths are generated from a valid HA session.
- Redirect legacy `/api/AK_AC/*.html` dashboard page requests to the authenticated `/akuvox-ac/*` route.
- Stop dashboard pages retrying failed signed URLs by stripping `authSig` and sending a discovered bearer token.

## Why
The HA ban log for `/api/akuvox_ac/ui/state` can be caused by the frontend retrying a signed API request as a plain `/api/...` request with a stale or invalid bearer token. Home Assistant treats that as invalid authentication and logs it via `homeassistant.components.http.ban`.

## Validation
- `python -m py_compile custom_components/akuvox_ac/http.py`
- `git diff --check`
- JS parse check across all dashboard HTML files
- Verified no remaining `fetch(stripAuthSig(...))` bearer-token retry paths in dashboard HTML