### PR TITLE
[codex] Restore dashboard shell access

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -2756,7 +2756,7 @@ class AkuvoxStaticAssets(HomeAssistantView):
 class AkuvoxDashboardView(HomeAssistantView):
     url = "/akuvox-ac/{slug:.*}"
     name = "akuvox_ac:dashboard"
-    requires_auth = True
+    requires_auth = False
 
     async def get(self, request: web.Request, slug: str = ""):
         clean = (slug or "").strip().strip("/").lower()


### PR DESCRIPTION
## Summary
- Restore `/akuvox-ac/*` dashboard shell serving without Home Assistant's `requires_auth` middleware.
- Keep the previous signed API retry hardening in place so dashboard API calls no longer strip `authSig` and retry with stale bearer tokens.

## Why
The Home Assistant sidebar iframe loads `/akuvox-ac/` without a bearer header. Marking the shell route as `requires_auth=True` made HA reject the iframe request itself with `401: Unauthorized`, which also created `homeassistant.components.http.ban` log entries for `/akuvox-ac/`.

## Validation
- `python -m py_compile custom_components/akuvox_ac/http.py`
- `git diff --check`