### PR TITLE
[codex] Schedule HACS auto updates

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -3950,6 +3950,9 @@ class AkuvoxUISettings(HomeAssistantView):
             else {
                 "enabled": False,
                 "interval_hours": 24,
+                "check_time": "02:00",
+                "auto_install": False,
+                "restart_after_install": False,
                 "update_entity": "",
                 "backup": False,
                 "last_result": "disabled",
@@ -3991,6 +3994,7 @@ class AkuvoxUISettings(HomeAssistantView):
                 "hacs_auto_update": hacs_auto_update,
                 "min_hacs_auto_update_interval_hours": 1,
                 "max_hacs_auto_update_interval_hours": 168,
+                "default_hacs_auto_update_check_time": "02:00",
                 "groups": groups,
                 "dashboard_access": dashboard_access,
             }

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2708,6 +2708,9 @@ class AkuvoxSettingsStore(Store):
     DEFAULT_HACS_AUTO_UPDATE = {
         "enabled": False,
         "interval_hours": 24,
+        "check_time": "02:00",
+        "auto_install": False,
+        "restart_after_install": False,
         "update_entity": "",
         "backup": False,
         "last_checked": None,
@@ -2893,6 +2896,17 @@ class AkuvoxSettingsStore(Store):
             return self.MAX_HACS_AUTO_UPDATE_HOURS
         return value
 
+    def _normalize_hacs_auto_update_time(self, value: Any) -> str:
+        text = str(value or "").strip()
+        match = re.fullmatch(r"(\d{1,2}):(\d{2})", text)
+        if not match:
+            return str(self.DEFAULT_HACS_AUTO_UPDATE["check_time"])
+        hour = int(match.group(1))
+        minute = int(match.group(2))
+        if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+            return str(self.DEFAULT_HACS_AUTO_UPDATE["check_time"])
+        return f"{hour:02d}:{minute:02d}"
+
     def _sanitize_hacs_auto_update(self, raw: Any) -> Dict[str, Any]:
         cfg = dict(self.DEFAULT_HACS_AUTO_UPDATE)
         if not isinstance(raw, dict):
@@ -2900,11 +2914,18 @@ class AkuvoxSettingsStore(Store):
 
         enabled = _coerce_bool(raw.get("enabled"))
         backup = _coerce_bool(raw.get("backup"))
+        auto_install = _coerce_bool(raw.get("auto_install"))
+        restart_after_install = _coerce_bool(raw.get("restart_after_install"))
         cfg["enabled"] = bool(enabled) if enabled is not None else False
         cfg["backup"] = bool(backup) if backup is not None else False
+        cfg["auto_install"] = bool(auto_install) if auto_install is not None else False
+        cfg["restart_after_install"] = (
+            bool(restart_after_install) if restart_after_install is not None else False
+        )
         cfg["interval_hours"] = self._normalize_hacs_auto_update_hours(
             raw.get("interval_hours")
         )
+        cfg["check_time"] = self._normalize_hacs_auto_update_time(raw.get("check_time"))
         cfg["update_entity"] = str(raw.get("update_entity") or "").strip()
 
         for key in (
@@ -3291,24 +3312,18 @@ class HacsAutoUpdater:
         if not config.get("enabled"):
             return
 
-        hours = config.get("interval_hours", 24)
-        try:
-            hours = int(hours)
-        except Exception:
-            hours = 24
-        hours = max(
-            AkuvoxSettingsStore.MIN_HACS_AUTO_UPDATE_HOURS,
-            min(AkuvoxSettingsStore.MAX_HACS_AUTO_UPDATE_HOURS, hours),
-        )
+        hour, minute = self._check_time_parts(config)
 
         def _schedule(_now):
-            self.hass.async_create_task(self.async_run_check(reason="scheduled"))
+            self.hass.async_create_task(self.async_run_scheduled_update(reason="scheduled"))
 
         try:
-            self._interval_unsub = async_track_time_interval(
+            self._interval_unsub = async_track_time_change(
                 self.hass,
                 _schedule,
-                timedelta(hours=hours),
+                hour=hour,
+                minute=minute,
+                second=0,
             )
         except Exception:
             self._interval_unsub = None
@@ -3433,7 +3448,33 @@ class HacsAutoUpdater:
             return
         if self._last_check_is_fresh(config):
             return
-        self.hass.async_create_task(self.async_run_check(reason="startup"))
+        if not self._startup_check_due(config):
+            return
+        self.hass.async_create_task(self.async_run_scheduled_update(reason="startup"))
+
+    @staticmethod
+    def _check_time_parts(config: Mapping[str, Any]) -> Tuple[int, int]:
+        text = str(
+            config.get("check_time")
+            or AkuvoxSettingsStore.DEFAULT_HACS_AUTO_UPDATE["check_time"]
+        ).strip()
+        match = re.fullmatch(r"(\d{1,2}):(\d{2})", text)
+        if not match:
+            text = str(AkuvoxSettingsStore.DEFAULT_HACS_AUTO_UPDATE["check_time"])
+            match = re.fullmatch(r"(\d{1,2}):(\d{2})", text)
+        if not match:
+            return 2, 0
+        hour = int(match.group(1))
+        minute = int(match.group(2))
+        if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+            return 2, 0
+        return hour, minute
+
+    def _startup_check_due(self, config: Mapping[str, Any]) -> bool:
+        now = dt_util.now()
+        hour, minute = self._check_time_parts(config)
+        scheduled_today = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        return now >= scheduled_today
 
     def _last_check_is_fresh(self, config: Mapping[str, Any]) -> bool:
         last_checked = str(config.get("last_checked") or "").strip()
@@ -3446,14 +3487,14 @@ class HacsAutoUpdater:
         if parsed is None or parsed.tzinfo is None:
             return False
         try:
-            hours = int(config.get("interval_hours", 24) or 24)
+            now = dt_util.now()
         except Exception:
-            hours = 24
-        hours = max(
-            AkuvoxSettingsStore.MIN_HACS_AUTO_UPDATE_HOURS,
-            min(AkuvoxSettingsStore.MAX_HACS_AUTO_UPDATE_HOURS, hours),
-        )
-        return dt_util.now() - parsed < timedelta(hours=hours)
+            return False
+        try:
+            parsed = parsed.astimezone(now.tzinfo) if now.tzinfo else parsed
+        except Exception:
+            pass
+        return parsed.date() == now.date()
 
     def _score_update_entity(self, state: Any) -> int:
         attrs = getattr(state, "attributes", {}) or {}
@@ -3650,6 +3691,25 @@ class HacsAutoUpdater:
             )
         except Exception:
             pass
+
+    async def async_run_scheduled_update(
+        self, *, reason: str = "scheduled"
+    ) -> Dict[str, Any]:
+        status = await self.async_run_check(reason=reason)
+        if str(status.get("last_result") or "").lower() != "update_available":
+            return status
+
+        config = self._config()
+        if not config.get("auto_install"):
+            return status
+
+        install_status = await self.async_install_update(reason=reason, force=True)
+        if (
+            str(install_status.get("last_result") or "").lower() == "installed"
+            and self._config().get("restart_after_install")
+        ):
+            return await self.async_restart_now(reason=f"{reason}_auto_restart")
+        return install_status
 
     async def async_run_check(
         self, *, reason: str = "manual", force: bool = False

--- a/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
+++ b/custom_components/akuvox_ac/tests/test_hacs_auto_update.py
@@ -98,6 +98,9 @@ def _settings_store() -> AkuvoxSettingsStore:
         "hacs_auto_update": {
             "enabled": True,
             "interval_hours": 24,
+            "check_time": "02:00",
+            "auto_install": False,
+            "restart_after_install": False,
             "update_entity": "",
             "backup": False,
             "last_result": "enabled",
@@ -110,6 +113,52 @@ def _settings_store() -> AkuvoxSettingsStore:
 
     store.async_save = _async_save
     return store
+
+
+def test_hacs_auto_update_sanitizes_daily_schedule_options():
+    store = object.__new__(AkuvoxSettingsStore)
+
+    cfg = store._sanitize_hacs_auto_update(
+        {
+            "enabled": "yes",
+            "check_time": "2:05",
+            "auto_install": "on",
+            "restart_after_install": 1,
+        }
+    )
+
+    assert cfg["enabled"] is True
+    assert cfg["check_time"] == "02:05"
+    assert cfg["auto_install"] is True
+    assert cfg["restart_after_install"] is True
+
+    invalid = store._sanitize_hacs_auto_update({"check_time": "25:99"})
+
+    assert invalid["check_time"] == "02:00"
+
+
+def test_hacs_auto_update_schedules_daily_check(monkeypatch):
+    store = _settings_store()
+    store.data["hacs_auto_update"]["check_time"] = "03:15"
+    hass = _Hass(store)
+    scheduled: Dict[str, Any] = {}
+
+    def _track_time_change(_hass, callback, *, hour=None, minute=None, second=None):
+        scheduled["callback"] = callback
+        scheduled["hour"] = hour
+        scheduled["minute"] = minute
+        scheduled["second"] = second
+        return lambda: scheduled.__setitem__("cancelled", True)
+
+    monkeypatch.setattr(integration_module, "async_track_time_change", _track_time_change)
+
+    updater = HacsAutoUpdater(hass)
+    updater.apply_settings()
+
+    assert scheduled["hour"] == 3
+    assert scheduled["minute"] == 15
+    assert scheduled["second"] == 0
+    assert updater.status()["active"] is True
 
 
 def test_hacs_auto_update_check_detects_latest_release_when_hacs_entity_is_stale(monkeypatch):
@@ -163,6 +212,32 @@ def test_hacs_auto_update_install_confirms_latest_release(monkeypatch):
     assert status["installed_version"] == LATEST_VERSION
     assert status["latest_version"] == LATEST_VERSION
     assert status["pending_version"] is None
+
+
+def test_hacs_auto_update_scheduled_install_can_restart(monkeypatch):
+    store = _settings_store()
+    store.data["hacs_auto_update"]["auto_install"] = True
+    store.data["hacs_auto_update"]["restart_after_install"] = True
+    hass = _Hass(store)
+    monkeypatch.setattr(
+        integration_module,
+        "async_get_clientsession",
+        lambda _hass: _GithubSession(),
+    )
+
+    status = asyncio.run(HacsAutoUpdater(hass).async_run_scheduled_update())
+
+    install_calls = [
+        call for call in hass.services.calls if call[0] == "update" and call[1] == "install"
+    ]
+    restart_calls = [
+        call
+        for call in hass.services.calls
+        if call[0] == "homeassistant" and call[1] == "restart"
+    ]
+    assert install_calls
+    assert restart_calls
+    assert status["last_result"] == "restart_requested"
 
 
 def test_hacs_auto_update_install_requires_hacs_confirmation(monkeypatch):

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -575,7 +575,7 @@ let SETTINGS_DATA = {
   min_access_event_limit: 5,
   max_access_event_limit: 200,
   credential_prompts: { ...DEFAULT_CREDENTIAL_PROMPTS },
-  hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
+  hacs_auto_update: { enabled: false, check_time: '02:00', auto_install: false, restart_after_install: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
   dashboard_access: { can_manage: false, allowed_user_ids: [], users: [] },
 };
 let PHONES = [];
@@ -866,11 +866,25 @@ function coerceHacsBool(value){
   return false;
 }
 
+function normalizeHacsCheckTime(value){
+  const fallback = String(SETTINGS_DATA?.default_hacs_auto_update_check_time || '02:00');
+  const text = String(value || '').trim();
+  const match = text.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return fallback;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return fallback;
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
 function sanitizeHacsAutoUpdate(raw){
   const { min, max } = hacsAutoUpdateRange();
   const base = {
     enabled: false,
     interval_hours: 24,
+    check_time: normalizeHacsCheckTime(),
+    auto_install: false,
+    restart_after_install: false,
     update_entity: '',
     backup: false,
     last_checked: null,
@@ -888,6 +902,9 @@ function sanitizeHacsAutoUpdate(raw){
   if (raw && typeof raw === 'object'){
     base.enabled = coerceHacsBool(raw.enabled);
     base.backup = coerceHacsBool(raw.backup);
+    base.auto_install = coerceHacsBool(raw.auto_install);
+    base.restart_after_install = coerceHacsBool(raw.restart_after_install);
+    base.check_time = normalizeHacsCheckTime(raw.check_time);
     const interval = Number(raw.interval_hours);
     if (Number.isFinite(interval)) base.interval_hours = Math.round(interval);
     base.update_entity = String(raw.update_entity || '').trim();
@@ -946,25 +963,24 @@ function describeHacsResult(config){
 
 function readHacsAutoUpdateForm(){
   const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
-  const { min, max } = hacsAutoUpdateRange();
   const toggle = document.getElementById('hacsAutoUpdateToggle');
-  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const timeInput = document.getElementById('hacsAutoUpdateTime');
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  const autoInstallInput = document.getElementById('hacsAutoUpdateAutoInstall');
+  const restartAfterInstallInput = document.getElementById('hacsAutoUpdateRestartAfterInstall');
   if (toggle) cfg.enabled = !!toggle.checked;
   if (backupInput) cfg.backup = !!backupInput.checked;
+  if (autoInstallInput) cfg.auto_install = !!autoInstallInput.checked;
+  if (restartAfterInstallInput) cfg.restart_after_install = cfg.auto_install && !!restartAfterInstallInput.checked;
   if (entityInput) cfg.update_entity = String(entityInput.value || '').trim();
-  if (intervalInput){
-    const raw = String(intervalInput.value || '').trim();
-    const interval = Number(raw);
-    if (!raw || !Number.isFinite(interval)){
-      throw new Error(`Enter a number between ${min} and ${max}`);
+  if (timeInput){
+    const raw = String(timeInput.value || '').trim();
+    const normalized = normalizeHacsCheckTime(raw);
+    if (!raw || normalized !== raw){
+      throw new Error('Enter a valid check time.');
     }
-    const value = Math.round(interval);
-    if (value < min || value > max){
-      throw new Error(`Enter a number between ${min} and ${max}`);
-    }
-    cfg.interval_hours = value;
+    cfg.check_time = normalized;
   }
   return cfg;
 }
@@ -972,11 +988,12 @@ function readHacsAutoUpdateForm(){
 function renderHacsAutoUpdate(){
   const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
   SETTINGS_DATA.hacs_auto_update = cfg;
-  const { min, max } = hacsAutoUpdateRange();
   const toggle = document.getElementById('hacsAutoUpdateToggle');
-  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const timeInput = document.getElementById('hacsAutoUpdateTime');
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  const autoInstallInput = document.getElementById('hacsAutoUpdateAutoInstall');
+  const restartAfterInstallInput = document.getElementById('hacsAutoUpdateRestartAfterInstall');
   const checkBtn = document.getElementById('hacsUpdateCheckBtn');
   const installBtn = document.getElementById('hacsUpdateInstallBtn');
   const restartBtn = document.getElementById('hacsRestartNowBtn');
@@ -991,10 +1008,13 @@ function renderHacsAutoUpdate(){
   const canRestart = !!(SETTINGS_DATA.dashboard_access?.can_manage || SETTINGS_DATA.dashboard_access?.current_user_is_admin);
   if (toggle) toggle.checked = !!cfg.enabled;
   if (backupInput) backupInput.checked = !!cfg.backup;
-  if (intervalInput){
-    intervalInput.min = String(min);
-    intervalInput.max = String(max);
-    intervalInput.value = String(cfg.interval_hours);
+  if (autoInstallInput) autoInstallInput.checked = !!cfg.auto_install;
+  if (restartAfterInstallInput) {
+    restartAfterInstallInput.checked = !!cfg.restart_after_install;
+    restartAfterInstallInput.disabled = !cfg.auto_install;
+  }
+  if (timeInput){
+    timeInput.value = cfg.check_time;
   }
   if (entityInput) entityInput.value = cfg.update_entity || '';
   if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
@@ -1022,6 +1042,9 @@ function renderHacsAutoUpdate(){
   }
   if (meta){
     const details = [
+      `Check at: ${cfg.check_time}`,
+      `Auto install: ${cfg.auto_install ? 'on' : 'off'}`,
+      `Auto restart: ${cfg.restart_after_install ? 'on' : 'off'}`,
       `Last checked: ${formatHacsDate(cfg.last_checked)}`,
     ];
     if (cfg.last_installed) details.push(`Last installed: ${formatHacsDate(cfg.last_installed)}`);
@@ -2393,7 +2416,7 @@ async function loadData(){
       auto_sync_delay_minutes: 15,
       health_check_interval_seconds: 30,
       access_event_limit: 30,
-      hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
+      hacs_auto_update: { enabled: false, check_time: '02:00', auto_install: false, restart_after_install: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
       dashboard_access: { can_manage: false, allowed_user_ids: [], users: [] },
       alerts: { targets: {} },
       registry_users: [],
@@ -2602,13 +2625,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   hacsToggle?.addEventListener('change', async () => {
     await saveHacsAutoUpdate({ enabled: !!hacsToggle.checked });
   });
-  const hacsInterval = document.getElementById('hacsAutoUpdateInterval');
+  const hacsTime = document.getElementById('hacsAutoUpdateTime');
   const commitHacsAutoUpdate = async () => {
     await saveHacsAutoUpdate();
   };
-  hacsInterval?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
-  hacsInterval?.addEventListener('change', commitHacsAutoUpdate);
-  hacsInterval?.addEventListener('blur', commitHacsAutoUpdate);
+  hacsTime?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
+  hacsTime?.addEventListener('change', commitHacsAutoUpdate);
+  hacsTime?.addEventListener('blur', commitHacsAutoUpdate);
   const hacsEntity = document.getElementById('hacsAutoUpdateEntity');
   hacsEntity?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
   hacsEntity?.addEventListener('change', commitHacsAutoUpdate);
@@ -2616,6 +2639,18 @@ document.addEventListener('DOMContentLoaded', async () => {
   const hacsBackup = document.getElementById('hacsAutoUpdateBackup');
   hacsBackup?.addEventListener('change', async () => {
     await saveHacsAutoUpdate({ backup: !!hacsBackup.checked });
+  });
+  const hacsAutoInstall = document.getElementById('hacsAutoUpdateAutoInstall');
+  hacsAutoInstall?.addEventListener('change', async () => {
+    const autoInstall = !!hacsAutoInstall.checked;
+    await saveHacsAutoUpdate({
+      auto_install: autoInstall,
+      restart_after_install: autoInstall && !!document.getElementById('hacsAutoUpdateRestartAfterInstall')?.checked,
+    });
+  });
+  const hacsRestartAfterInstall = document.getElementById('hacsAutoUpdateRestartAfterInstall');
+  hacsRestartAfterInstall?.addEventListener('change', async () => {
+    await saveHacsAutoUpdate({ restart_after_install: !!hacsRestartAfterInstall.checked });
   });
   document.getElementById('hacsUpdateCheckBtn')?.addEventListener('click', async (ev) => {
     ev.preventDefault();
@@ -2829,15 +2864,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   <div class="card mt-3">
     <div class="card-header text-white">HACS Auto Update</div>
     <div class="card-body">
-      <p class="muted">Automatically refresh the HACS update entity for this integration. When an update is found, review it here before installing. Home Assistant still needs a restart after an integration update is installed.</p>
+      <p class="muted">Check the HACS update entity for this integration at a specific time each day. You can let it install available updates automatically and restart Home Assistant afterwards.</p>
       <div class="form-check form-switch">
         <input class="form-check-input" type="checkbox" id="hacsAutoUpdateToggle">
-        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS update checks</label>
+        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable scheduled HACS update checks</label>
       </div>
       <div class="row g-2 mt-3">
         <div class="col-md-4">
-          <label class="form-label" for="hacsAutoUpdateInterval">Check every (hours)</label>
-          <input id="hacsAutoUpdateInterval" class="form-control" type="number" min="1" max="168" step="1" />
+          <label class="form-label" for="hacsAutoUpdateTime">Check at</label>
+          <input id="hacsAutoUpdateTime" class="form-control" type="time" step="60" />
         </div>
         <div class="col-md-8">
           <label class="form-label" for="hacsAutoUpdateEntity">Update entity</label>
@@ -2848,6 +2883,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       <div class="form-check mt-3">
         <input class="form-check-input" type="checkbox" id="hacsAutoUpdateBackup">
         <label class="form-check-label" for="hacsAutoUpdateBackup">Request a backup before install when supported</label>
+      </div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateAutoInstall">
+        <label class="form-check-label" for="hacsAutoUpdateAutoInstall">Install available updates automatically after the scheduled check</label>
+      </div>
+      <div class="form-check mt-2">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateRestartAfterInstall">
+        <label class="form-check-label" for="hacsAutoUpdateRestartAfterInstall">Restart Home Assistant automatically after a successful scheduled install</label>
       </div>
       <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
         <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -577,7 +577,7 @@ let SETTINGS_DATA = {
   min_access_event_limit: 5,
   max_access_event_limit: 200,
   credential_prompts: { ...DEFAULT_CREDENTIAL_PROMPTS },
-  hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
+  hacs_auto_update: { enabled: false, check_time: '02:00', auto_install: false, restart_after_install: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
   dashboard_access: { can_manage: false, allowed_user_ids: [], users: [] },
 };
 let PHONES = [];
@@ -868,11 +868,25 @@ function coerceHacsBool(value){
   return false;
 }
 
+function normalizeHacsCheckTime(value){
+  const fallback = String(SETTINGS_DATA?.default_hacs_auto_update_check_time || '02:00');
+  const text = String(value || '').trim();
+  const match = text.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return fallback;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return fallback;
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
 function sanitizeHacsAutoUpdate(raw){
   const { min, max } = hacsAutoUpdateRange();
   const base = {
     enabled: false,
     interval_hours: 24,
+    check_time: normalizeHacsCheckTime(),
+    auto_install: false,
+    restart_after_install: false,
     update_entity: '',
     backup: false,
     last_checked: null,
@@ -890,6 +904,9 @@ function sanitizeHacsAutoUpdate(raw){
   if (raw && typeof raw === 'object'){
     base.enabled = coerceHacsBool(raw.enabled);
     base.backup = coerceHacsBool(raw.backup);
+    base.auto_install = coerceHacsBool(raw.auto_install);
+    base.restart_after_install = coerceHacsBool(raw.restart_after_install);
+    base.check_time = normalizeHacsCheckTime(raw.check_time);
     const interval = Number(raw.interval_hours);
     if (Number.isFinite(interval)) base.interval_hours = Math.round(interval);
     base.update_entity = String(raw.update_entity || '').trim();
@@ -948,25 +965,24 @@ function describeHacsResult(config){
 
 function readHacsAutoUpdateForm(){
   const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
-  const { min, max } = hacsAutoUpdateRange();
   const toggle = document.getElementById('hacsAutoUpdateToggle');
-  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const timeInput = document.getElementById('hacsAutoUpdateTime');
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  const autoInstallInput = document.getElementById('hacsAutoUpdateAutoInstall');
+  const restartAfterInstallInput = document.getElementById('hacsAutoUpdateRestartAfterInstall');
   if (toggle) cfg.enabled = !!toggle.checked;
   if (backupInput) cfg.backup = !!backupInput.checked;
+  if (autoInstallInput) cfg.auto_install = !!autoInstallInput.checked;
+  if (restartAfterInstallInput) cfg.restart_after_install = cfg.auto_install && !!restartAfterInstallInput.checked;
   if (entityInput) cfg.update_entity = String(entityInput.value || '').trim();
-  if (intervalInput){
-    const raw = String(intervalInput.value || '').trim();
-    const interval = Number(raw);
-    if (!raw || !Number.isFinite(interval)){
-      throw new Error(`Enter a number between ${min} and ${max}`);
+  if (timeInput){
+    const raw = String(timeInput.value || '').trim();
+    const normalized = normalizeHacsCheckTime(raw);
+    if (!raw || normalized !== raw){
+      throw new Error('Enter a valid check time.');
     }
-    const value = Math.round(interval);
-    if (value < min || value > max){
-      throw new Error(`Enter a number between ${min} and ${max}`);
-    }
-    cfg.interval_hours = value;
+    cfg.check_time = normalized;
   }
   return cfg;
 }
@@ -974,11 +990,12 @@ function readHacsAutoUpdateForm(){
 function renderHacsAutoUpdate(){
   const cfg = sanitizeHacsAutoUpdate(SETTINGS_DATA.hacs_auto_update);
   SETTINGS_DATA.hacs_auto_update = cfg;
-  const { min, max } = hacsAutoUpdateRange();
   const toggle = document.getElementById('hacsAutoUpdateToggle');
-  const intervalInput = document.getElementById('hacsAutoUpdateInterval');
+  const timeInput = document.getElementById('hacsAutoUpdateTime');
   const entityInput = document.getElementById('hacsAutoUpdateEntity');
   const backupInput = document.getElementById('hacsAutoUpdateBackup');
+  const autoInstallInput = document.getElementById('hacsAutoUpdateAutoInstall');
+  const restartAfterInstallInput = document.getElementById('hacsAutoUpdateRestartAfterInstall');
   const checkBtn = document.getElementById('hacsUpdateCheckBtn');
   const installBtn = document.getElementById('hacsUpdateInstallBtn');
   const restartBtn = document.getElementById('hacsRestartNowBtn');
@@ -993,10 +1010,13 @@ function renderHacsAutoUpdate(){
   const canRestart = !!(SETTINGS_DATA.dashboard_access?.can_manage || SETTINGS_DATA.dashboard_access?.current_user_is_admin);
   if (toggle) toggle.checked = !!cfg.enabled;
   if (backupInput) backupInput.checked = !!cfg.backup;
-  if (intervalInput){
-    intervalInput.min = String(min);
-    intervalInput.max = String(max);
-    intervalInput.value = String(cfg.interval_hours);
+  if (autoInstallInput) autoInstallInput.checked = !!cfg.auto_install;
+  if (restartAfterInstallInput) {
+    restartAfterInstallInput.checked = !!cfg.restart_after_install;
+    restartAfterInstallInput.disabled = !cfg.auto_install;
+  }
+  if (timeInput){
+    timeInput.value = cfg.check_time;
   }
   if (entityInput) entityInput.value = cfg.update_entity || '';
   if (checkBtn) checkBtn.disabled = hacsUpdateChecking;
@@ -1024,6 +1044,9 @@ function renderHacsAutoUpdate(){
   }
   if (meta){
     const details = [
+      `Check at: ${cfg.check_time}`,
+      `Auto install: ${cfg.auto_install ? 'on' : 'off'}`,
+      `Auto restart: ${cfg.restart_after_install ? 'on' : 'off'}`,
       `Last checked: ${formatHacsDate(cfg.last_checked)}`,
     ];
     if (cfg.last_installed) details.push(`Last installed: ${formatHacsDate(cfg.last_installed)}`);
@@ -2398,7 +2421,7 @@ async function loadData(){
       auto_sync_delay_minutes: 15,
       health_check_interval_seconds: 30,
       access_event_limit: 30,
-      hacs_auto_update: { enabled: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
+      hacs_auto_update: { enabled: false, check_time: '02:00', auto_install: false, restart_after_install: false, interval_hours: 24, update_entity: '', backup: false, last_result: 'disabled' },
       dashboard_access: { can_manage: false, allowed_user_ids: [], users: [] },
       alerts: { targets: {} },
       registry_users: [],
@@ -2650,13 +2673,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   hacsToggle?.addEventListener('change', async () => {
     await saveHacsAutoUpdate({ enabled: !!hacsToggle.checked });
   });
-  const hacsInterval = document.getElementById('hacsAutoUpdateInterval');
+  const hacsTime = document.getElementById('hacsAutoUpdateTime');
   const commitHacsAutoUpdate = async () => {
     await saveHacsAutoUpdate();
   };
-  hacsInterval?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
-  hacsInterval?.addEventListener('change', commitHacsAutoUpdate);
-  hacsInterval?.addEventListener('blur', commitHacsAutoUpdate);
+  hacsTime?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
+  hacsTime?.addEventListener('change', commitHacsAutoUpdate);
+  hacsTime?.addEventListener('blur', commitHacsAutoUpdate);
   const hacsEntity = document.getElementById('hacsAutoUpdateEntity');
   hacsEntity?.addEventListener('input', () => { setHacsAutoUpdateStatus(''); });
   hacsEntity?.addEventListener('change', commitHacsAutoUpdate);
@@ -2664,6 +2687,18 @@ document.addEventListener('DOMContentLoaded', async () => {
   const hacsBackup = document.getElementById('hacsAutoUpdateBackup');
   hacsBackup?.addEventListener('change', async () => {
     await saveHacsAutoUpdate({ backup: !!hacsBackup.checked });
+  });
+  const hacsAutoInstall = document.getElementById('hacsAutoUpdateAutoInstall');
+  hacsAutoInstall?.addEventListener('change', async () => {
+    const autoInstall = !!hacsAutoInstall.checked;
+    await saveHacsAutoUpdate({
+      auto_install: autoInstall,
+      restart_after_install: autoInstall && !!document.getElementById('hacsAutoUpdateRestartAfterInstall')?.checked,
+    });
+  });
+  const hacsRestartAfterInstall = document.getElementById('hacsAutoUpdateRestartAfterInstall');
+  hacsRestartAfterInstall?.addEventListener('change', async () => {
+    await saveHacsAutoUpdate({ restart_after_install: !!hacsRestartAfterInstall.checked });
   });
   document.getElementById('hacsUpdateCheckBtn')?.addEventListener('click', async (ev) => {
     ev.preventDefault();
@@ -2844,15 +2879,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   <div class="card mt-3">
     <div class="card-header">HACS Auto Update</div>
     <div class="card-body">
-      <p class="muted">Automatically refresh the HACS update entity for this integration. When an update is found, review it here before installing. Home Assistant still needs a restart after an integration update is installed.</p>
+      <p class="muted">Check the HACS update entity for this integration at a specific time each day. You can let it install available updates automatically and restart Home Assistant afterwards.</p>
       <div class="form-check form-switch">
         <input class="form-check-input" type="checkbox" id="hacsAutoUpdateToggle">
-        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable automatic HACS update checks</label>
+        <label class="form-check-label" for="hacsAutoUpdateToggle">Enable scheduled HACS update checks</label>
       </div>
       <div class="row g-2 mt-3">
         <div class="col-md-4">
-          <label class="form-label" for="hacsAutoUpdateInterval">Check every (hours)</label>
-          <input id="hacsAutoUpdateInterval" class="form-control" type="number" min="1" max="168" step="1" />
+          <label class="form-label" for="hacsAutoUpdateTime">Check at</label>
+          <input id="hacsAutoUpdateTime" class="form-control" type="time" step="60" />
         </div>
         <div class="col-md-8">
           <label class="form-label" for="hacsAutoUpdateEntity">Update entity</label>
@@ -2863,6 +2898,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       <div class="form-check mt-3">
         <input class="form-check-input" type="checkbox" id="hacsAutoUpdateBackup">
         <label class="form-check-label" for="hacsAutoUpdateBackup">Request a backup before install when supported</label>
+      </div>
+      <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateAutoInstall">
+        <label class="form-check-label" for="hacsAutoUpdateAutoInstall">Install available updates automatically after the scheduled check</label>
+      </div>
+      <div class="form-check mt-2">
+        <input class="form-check-input" type="checkbox" id="hacsAutoUpdateRestartAfterInstall">
+        <label class="form-check-label" for="hacsAutoUpdateRestartAfterInstall">Restart Home Assistant automatically after a successful scheduled install</label>
       </div>
       <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
         <button id="hacsUpdateCheckBtn" class="btn btn-outline-info btn-sm" type="button"><i class="bi bi-arrow-repeat me-1"></i>Check now</button>


### PR DESCRIPTION
## Summary
- Change HACS auto update scheduling from hourly intervals to a daily time-of-day picker, defaulting to 02:00.
- Add explicit automatic install and automatic restart-after-install switches to the global settings page on desktop and mobile.
- Run scheduled update checks through a new scheduled update path that can install available updates and request a Home Assistant restart when enabled.
- Preserve the existing interval field for backwards compatibility while storing the new daily schedule options.

## Validation
- `python -m py_compile custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_hacs_auto_update.py` using bundled Python
- Manual execution of `custom_components/akuvox_ac/tests/test_hacs_auto_update.py` with local Home Assistant stubs: all 8 tests passed
- `node --check scripts/release-pr-version.cjs`
- `git diff --check`

Note: full `pytest` was not available in the bundled Python environment (`No module named pytest`).