### PR TITLE
[codex] Fix support log download authentication

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -5062,7 +5062,7 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
 class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
     url = "/api/akuvox_ac/ui/support_bundle"
     name = "api:akuvox_ac:ui_support_bundle"
-    requires_auth = True
+    requires_auth = False
 
     _SENSITIVE_KEY_FRAGMENTS = (
         "password",

--- a/custom_components/akuvox_ac/tests/test_dashboard_auth.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_auth.py
@@ -31,6 +31,7 @@ def test_dashboard_post_views_use_dashboard_session_token_instead_of_signed_post
     assert http_module.AkuvoxUIView.requires_auth is False
     assert http_module.AkuvoxUIAction.requires_auth is False
     assert http_module.AkuvoxUISettings.requires_auth is False
+    assert http_module.AkuvoxUISupportBundle.requires_auth is False
     assert "refresh_events" in http_module.ALLOWED_DASHBOARD_SERVICE_PROXY
     assert "delete_user" in http_module.ALLOWED_DASHBOARD_SERVICE_PROXY
 


### PR DESCRIPTION
## Summary
Fixes the Download logs action showing Authentication Required after PR #361 exposed it in Global Settings.

## Root cause
The support bundle view was still declared with `requires_auth = True`, so Home Assistant could reject `/api/akuvox_ac/ui/support_bundle` before the integration's dashboard-session token check could run. Other dashboard UI endpoints allow the request through first and then enforce `_request_can_access_dashboard` inside the view.

## Changes
- Changes `AkuvoxUISupportBundle.requires_auth` to `False` so dashboard session tokens can be accepted.
- Keeps the existing `_request_can_access_dashboard` guard inside the support bundle view.
- Adds auth coverage so the support bundle endpoint remains dashboard-session accessible.

## Validation
- `python -m py_compile custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_dashboard_auth.py`
- `git diff origin/main --check`
- Focused dashboard auth/support test harness passed