### PR TITLE
[codex] Fix log viewer auth and HTTP face upload

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -139,6 +139,8 @@ class AkuvoxAPI:
         configured_port: Optional[int] = self.port
         _add_combo(True, configured_port, False)
         _add_combo(True, 443, False)
+        _add_combo(False, configured_port)
+        _add_combo(False, 80)
 
         # Deduplicate preserving order
         seen = set()
@@ -1708,6 +1710,8 @@ class AkuvoxAPI:
             _add_base(True, configured_port, verify)
         _add_base(True, 443, False)
         _add_base(True, 443, True)
+        _add_base(False, configured_port)
+        _add_base(False, 80)
 
         for use_https, port, verify in bases:
             for rel in rel_paths:

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import io
 import json
 import logging
 import json
@@ -9,7 +8,6 @@ import platform
 import re
 import secrets
 import time
-import zipfile
 from functools import partial
 from datetime import timedelta
 from pathlib import Path
@@ -5062,7 +5060,7 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
 class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
     url = "/api/akuvox_ac/ui/support_bundle"
     name = "api:akuvox_ac:ui_support_bundle"
-    requires_auth = True
+    requires_auth = False
 
     _SENSITIVE_KEY_FRAGMENTS = (
         "password",
@@ -5441,12 +5439,27 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
             f"Profiles with face sync errors: {counts.get('face_sync_errors', 0)}",
             f"Filtered HA log lines: {len(log_tail.get('lines', [])) if isinstance(log_tail, dict) else 0}",
             "",
-            "Files",
-            "- support_bundle.json: redacted structured diagnostics",
-            "- summary.txt: this overview",
-            "- home-assistant.log.filtered.txt: Akuvox/face-related Home Assistant log tail",
+            "Contents",
+            "- Redacted structured diagnostics",
+            "- Akuvox/face-related Home Assistant log tail",
         ]
         return "\n".join(lines) + "\n"
+
+    @classmethod
+    def _support_bundle_text(cls, bundle: Dict[str, Any]) -> str:
+        log_tail = bundle.get("homeassistant_log_tail", {}) if isinstance(bundle, dict) else {}
+        log_lines = log_tail.get("lines", []) if isinstance(log_tail, dict) else []
+        parts = [
+            cls._summary_text(bundle),
+            "",
+            "=== Redacted support bundle JSON ===",
+            json.dumps(bundle, indent=2, sort_keys=True, default=str),
+            "",
+            "=== Filtered Home Assistant log tail ===",
+            "\n".join(str(line) for line in log_lines) if log_lines else "(no matching log lines found)",
+            "",
+        ]
+        return "\n".join(parts)
 
     async def _build_support_bundle(self, hass: HomeAssistant) -> Dict[str, Any]:
         root = hass.data.get(DOMAIN, {}) or {}
@@ -5480,26 +5493,13 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
 
         bundle = await self._build_support_bundle(hass)
         stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
-        filename = f"akuvox-support-{stamp}.zip"
-        buffer = io.BytesIO()
-        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
-            archive.writestr("summary.txt", self._summary_text(bundle))
-            archive.writestr(
-                "support_bundle.json",
-                json.dumps(bundle, indent=2, sort_keys=True, default=str),
-            )
-            log_tail = bundle.get("homeassistant_log_tail", {})
-            lines = log_tail.get("lines", []) if isinstance(log_tail, dict) else []
-            archive.writestr(
-                "home-assistant.log.filtered.txt",
-                "\n".join(str(line) for line in lines) + ("\n" if lines else ""),
-            )
+        filename = f"akuvox-support-{stamp}.txt"
 
         return web.Response(
-            body=buffer.getvalue(),
-            content_type="application/zip",
+            text=self._support_bundle_text(bundle),
+            content_type="text/plain",
             headers={
-                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Disposition": f'inline; filename="{filename}"',
                 "Cache-Control": "no-store",
             },
         )

--- a/custom_components/akuvox_ac/tests/test_api_face_payload.py
+++ b/custom_components/akuvox_ac/tests/test_api_face_payload.py
@@ -1,4 +1,5 @@
 from custom_components.akuvox_ac.api import AkuvoxAPI
+from custom_components.akuvox_ac import api as api_module
 from custom_components.akuvox_ac.http import _build_face_upload_payload
 
 
@@ -11,6 +12,68 @@ class _SessionStub:
 
     def head(self, *_args, **_kwargs):
         raise RuntimeError("unused in unit test")
+
+
+class _ResponseStub:
+    def __init__(self, status=200, data=None, body=""):
+        self.status = status
+        self.reason = "stub"
+        self._data = data
+        self._body = body
+
+    async def json(self, content_type=None):
+        if self._data is None:
+            raise ValueError("not json")
+        return self._data
+
+    async def text(self):
+        return self._body
+
+    def raise_for_status(self):
+        if not (200 <= self.status < 400):
+            raise RuntimeError(f"{self.status}: {self.reason}")
+
+
+class _RequestContextStub:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FaceUploadSessionStub:
+    def __init__(self):
+        self.get_urls = []
+        self.post_urls = []
+
+    def get(self, url, **_kwargs):
+        self.get_urls.append(url)
+        if url.startswith("http://"):
+            return _RequestContextStub(_ResponseStub(200, {"retcode": 0}))
+        return _RequestContextStub(_ResponseStub(503, body="tls unavailable"))
+
+    def post(self, url, **_kwargs):
+        self.post_urls.append(url)
+        if url.startswith("http://"):
+            return _RequestContextStub(
+                _ResponseStub(200, {"retcode": 0, "path": "/mnt/Face/HA001.jpg"})
+            )
+        return _RequestContextStub(_ResponseStub(503, body="tls unavailable"))
+
+    def head(self, *_args, **_kwargs):
+        raise RuntimeError("unused in unit test")
+
+
+class _FormDataStub:
+    def __init__(self):
+        self.fields = []
+
+    def add_field(self, *args, **kwargs):
+        self.fields.append((args, kwargs))
 
 
 def test_build_face_upload_payload_includes_legacy_import_fields():
@@ -50,3 +113,23 @@ def test_normalize_user_set_preserves_face_url_field():
 
     assert normalized[0]["FaceUrl"] == ""
     assert normalized[0]["FaceRegisterStatus"] == "1"
+
+
+def test_face_upload_tries_http_device_endpoint_when_https_unavailable():
+    import asyncio
+
+    session = _FaceUploadSessionStub()
+    api = AkuvoxAPI("127.0.0.1", port=80, username="", password="", session=session)
+    original_form_data = api_module.FormData
+    api_module.FormData = _FormDataStub
+
+    try:
+        result = asyncio.run(api.face_upload(b"jpg", filename="HA001.jpg"))
+    finally:
+        api_module.FormData = original_form_data
+
+    assert result["path"] == "/mnt/Face/HA001.jpg"
+    assert api._detected == (False, 80, True)
+    assert any(url.startswith("https://") for url in session.get_urls)
+    assert any(url.startswith("http://") for url in session.get_urls)
+    assert session.post_urls[0].startswith("http://")

--- a/custom_components/akuvox_ac/tests/test_dashboard_auth.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_auth.py
@@ -31,6 +31,7 @@ def test_dashboard_post_views_use_dashboard_session_token_instead_of_signed_post
     assert http_module.AkuvoxUIView.requires_auth is False
     assert http_module.AkuvoxUIAction.requires_auth is False
     assert http_module.AkuvoxUISettings.requires_auth is False
+    assert http_module.AkuvoxUISupportBundle.requires_auth is False
     assert "refresh_events" in http_module.ALLOWED_DASHBOARD_SERVICE_PROXY
     assert "delete_user" in http_module.ALLOWED_DASHBOARD_SERVICE_PROXY
 
@@ -57,6 +58,25 @@ def test_support_bundle_is_signed_and_redacts_sensitive_values():
     assert redacted["has_pin"] is True
     assert redacted["has_phone"] is True
     assert redacted["face_url"] == "/api/AK_AC/FaceData/HA001.jpg"
+
+
+def test_support_bundle_text_contains_copyable_sections():
+    text = http_module.AkuvoxUISupportBundle._support_bundle_text(
+        {
+            "metadata": {
+                "generated_at": "2026-05-27T10:00:00+00:00",
+                "integration_version_label": "3.5.7",
+            },
+            "users": {"counts": {"total": 1, "face_active": 0, "face_pending": 0, "face_error": 1}},
+            "devices": [{"name": "Gate"}],
+            "homeassistant_log_tail": {"lines": ["face profile upload failed"]},
+        }
+    )
+
+    assert "Akuvox Access Control Support Bundle" in text
+    assert "=== Redacted support bundle JSON ===" in text
+    assert "=== Filtered Home Assistant log tail ===" in text
+    assert "face profile upload failed" in text
 
 
 def test_dashboard_frontend_does_not_send_bearer_authorization_headers():

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -77,6 +77,17 @@
       max-height:320px;
       overflow:auto;
     }
+    .support-log-panel textarea{
+      min-height:360px;
+      background:#07101f;
+      border:1px solid var(--border);
+      color:var(--text);
+      font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size:0.82rem;
+      line-height:1.35;
+      white-space:pre;
+    }
+    .support-log-panel textarea:focus{ background:#07101f; color:var(--text); border-color:var(--accent); box-shadow:0 0 0 0.2rem rgba(47,240,196,0.2); }
     code{ font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
     .badge.method{
       background:rgba(47,240,196,0.12);
@@ -585,12 +596,21 @@ function openInApp(view, params = {}, options = {}) {
   <div class="d-flex align-items-center gap-2 flex-wrap">
     <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
     <h2 class="m-0 flex-grow-1 text-white">Device Diagnostics</h2>
-    <button class="btn btn-outline-info" id="btnDownloadSupportBundle" type="button"><i class="bi bi-download"></i> Download logs</button>
+    <button class="btn btn-outline-info" id="btnDownloadSupportBundle" type="button"><i class="bi bi-file-earmark-text"></i> View logs</button>
     <button class="btn btn-outline-info" id="btnRefresh"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
     <span id="busy" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display:none;"></span>
   </div>
   <p class="muted mt-2">Review the most recent HTTP requests sent from Home Assistant to each Akuvox device. Entries include the request payload, status and timing so you can validate what was delivered.</p>
   <div id="statusMessage" class="alert alert-danger d-none" role="alert"></div>
+  <div class="support-log-panel card mt-3" id="supportLogPanel" hidden>
+    <div class="card-body">
+      <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+        <h5 class="mb-0">Support logs</h5>
+        <button class="btn btn-sm btn-outline-info" id="copySupportLogBtn" type="button"><i class="bi bi-clipboard me-1"></i>Copy to clipboard</button>
+      </div>
+      <textarea class="form-control mt-3" id="supportLogText" readonly spellcheck="false"></textarea>
+    </div>
+  </div>
   <div class="nav nav-tabs diag-tabs" id="diagTabNav" role="tablist">
     <button class="nav-link active" type="button" data-tab-target="requests">Request history</button>
     <button class="nav-link" type="button" data-tab-target="events">Event storage</button>
@@ -2206,46 +2226,72 @@ async function loadDiagnostics(){
   }
 }
 
-function supportBundleFilename(response){
-  const fallback = 'akuvox-support-bundle.zip';
-  try {
-    const disposition = response.headers.get('Content-Disposition') || '';
-    const utfMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-    if (utfMatch && utfMatch[1]) return decodeURIComponent(utfMatch[1].trim());
-    const match = disposition.match(/filename="?([^";]+)"?/i);
-    if (match && match[1]) return match[1].trim();
-  } catch (err) {}
-  return fallback;
+async function fetchSupportBundleResponse(){
+  if (window.AK_AC_DASHBOARD_FETCH) {
+    try {
+      const response = await window.AK_AC_DASHBOARD_FETCH('/api/akuvox_ac/ui/support_bundle', { method: 'GET' });
+      if (response && (response.ok || (response.status !== 401 && response.status !== 403))) {
+        return response;
+      }
+    } catch (err) {}
+  }
+  return fetchWithAuth(API_SUPPORT_BUNDLE);
 }
 
-async function downloadSupportBundle(){
+function showSupportLogText(text){
+  const panel = document.getElementById('supportLogPanel');
+  const textarea = document.getElementById('supportLogText');
+  if (!panel || !textarea) return;
+  textarea.value = text || '';
+  panel.hidden = false;
+  textarea.focus();
+}
+
+async function copySupportLogText(){
+  const textarea = document.getElementById('supportLogText');
+  if (!textarea || !textarea.value) {
+    showStatus('No logs to copy yet.', 'warning');
+    return;
+  }
+  try {
+    if (!navigator.clipboard || !window.isSecureContext) throw new Error('clipboard unavailable');
+    await navigator.clipboard.writeText(textarea.value);
+    showStatus('Logs copied to clipboard.', 'success');
+  } catch (err) {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      if (document.execCommand('copy')) {
+        showStatus('Logs copied to clipboard.', 'success');
+        return;
+      }
+    } catch (copyErr) {}
+    showStatus('Logs selected. Press Ctrl+C to copy.', 'warning');
+  }
+}
+
+async function viewSupportLogs(){
   if (!btnDownloadSupportBundle) return;
   const original = btnDownloadSupportBundle.innerHTML;
   btnDownloadSupportBundle.disabled = true;
   btnDownloadSupportBundle.innerHTML = '<span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>Preparing';
   showStatus('');
   try {
-    const response = await fetchWithAuth(API_SUPPORT_BUNDLE);
+    const response = await fetchSupportBundleResponse();
+    const text = await response.text();
     if (!response.ok){
-      const text = await response.text();
       const err = buildError(response, text);
-      if (!handleAuthError(err)) throw err;
-      return;
+      throw err;
     }
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = supportBundleFilename(response);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
-    showStatus('Support bundle downloaded.');
+    showSupportLogText(text);
+    showStatus('Logs ready to copy.', 'success');
   } catch (err) {
-    if (handleAuthError(err)) return;
-    console.error('Failed to download support bundle', err);
-    showStatus('Failed to download logs: ' + (err && err.message ? err.message : err));
+    console.error('Failed to load support logs', err);
+    const message = isAuthError(err)
+      ? 'Home Assistant rejected the log request. Refresh this page and try again.'
+      : 'Failed to load logs: ' + (err && err.message ? err.message : err);
+    showStatus(message);
   } finally {
     btnDownloadSupportBundle.disabled = false;
     btnDownloadSupportBundle.innerHTML = original;
@@ -2263,7 +2309,11 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   btnDownloadSupportBundle?.addEventListener('click', (ev) => {
     ev.preventDefault();
-    downloadSupportBundle();
+    viewSupportLogs();
+  });
+  document.getElementById('copySupportLogBtn')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    copySupportLogText();
   });
   document.querySelectorAll('[data-tab-target]')?.forEach((btn) => {
     btn.addEventListener('click', (ev) => {

--- a/custom_components/akuvox_ac/www/diagnostics.html
+++ b/custom_components/akuvox_ac/www/diagnostics.html
@@ -77,6 +77,17 @@
       max-height:320px;
       overflow:auto;
     }
+    .support-log-panel textarea{
+      min-height:360px;
+      background:#07101f;
+      border:1px solid var(--border);
+      color:var(--text);
+      font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size:0.82rem;
+      line-height:1.35;
+      white-space:pre;
+    }
+    .support-log-panel textarea:focus{ background:#07101f; color:var(--text); border-color:var(--accent); box-shadow:0 0 0 0.2rem rgba(47,240,196,0.2); }
     code{ font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
     .badge.method{
       background:rgba(47,240,196,0.12);
@@ -585,12 +596,21 @@ function openInApp(view, params = {}, options = {}) {
   <div class="d-flex align-items-center gap-2 flex-wrap">
     <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
     <h2 class="m-0 flex-grow-1">Device Diagnostics</h2>
-    <button class="btn btn-outline-info" id="btnDownloadSupportBundle" type="button"><i class="bi bi-download"></i> Download logs</button>
+    <button class="btn btn-outline-info" id="btnDownloadSupportBundle" type="button"><i class="bi bi-file-earmark-text"></i> View logs</button>
     <button class="btn btn-outline-info" id="btnRefresh"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
     <span id="busy" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display:none;"></span>
   </div>
   <p class="muted mt-2">Review the most recent HTTP requests sent from Home Assistant to each Akuvox device. Entries include the request payload, status and timing so you can validate what was delivered.</p>
   <div id="statusMessage" class="alert alert-danger d-none" role="alert"></div>
+  <div class="support-log-panel card mt-3" id="supportLogPanel" hidden>
+    <div class="card-body">
+      <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+        <h5 class="mb-0">Support logs</h5>
+        <button class="btn btn-sm btn-outline-info" id="copySupportLogBtn" type="button"><i class="bi bi-clipboard me-1"></i>Copy to clipboard</button>
+      </div>
+      <textarea class="form-control mt-3" id="supportLogText" readonly spellcheck="false"></textarea>
+    </div>
+  </div>
   <div class="nav nav-tabs diag-tabs" id="diagTabNav" role="tablist">
     <button class="nav-link active" type="button" data-tab-target="requests">Request history</button>
     <button class="nav-link" type="button" data-tab-target="events">Event storage</button>
@@ -2206,46 +2226,72 @@ async function loadDiagnostics(){
   }
 }
 
-function supportBundleFilename(response){
-  const fallback = 'akuvox-support-bundle.zip';
-  try {
-    const disposition = response.headers.get('Content-Disposition') || '';
-    const utfMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-    if (utfMatch && utfMatch[1]) return decodeURIComponent(utfMatch[1].trim());
-    const match = disposition.match(/filename="?([^";]+)"?/i);
-    if (match && match[1]) return match[1].trim();
-  } catch (err) {}
-  return fallback;
+async function fetchSupportBundleResponse(){
+  if (window.AK_AC_DASHBOARD_FETCH) {
+    try {
+      const response = await window.AK_AC_DASHBOARD_FETCH('/api/akuvox_ac/ui/support_bundle', { method: 'GET' });
+      if (response && (response.ok || (response.status !== 401 && response.status !== 403))) {
+        return response;
+      }
+    } catch (err) {}
+  }
+  return fetchWithAuth(API_SUPPORT_BUNDLE);
 }
 
-async function downloadSupportBundle(){
+function showSupportLogText(text){
+  const panel = document.getElementById('supportLogPanel');
+  const textarea = document.getElementById('supportLogText');
+  if (!panel || !textarea) return;
+  textarea.value = text || '';
+  panel.hidden = false;
+  textarea.focus();
+}
+
+async function copySupportLogText(){
+  const textarea = document.getElementById('supportLogText');
+  if (!textarea || !textarea.value) {
+    showStatus('No logs to copy yet.', 'warning');
+    return;
+  }
+  try {
+    if (!navigator.clipboard || !window.isSecureContext) throw new Error('clipboard unavailable');
+    await navigator.clipboard.writeText(textarea.value);
+    showStatus('Logs copied to clipboard.', 'success');
+  } catch (err) {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      if (document.execCommand('copy')) {
+        showStatus('Logs copied to clipboard.', 'success');
+        return;
+      }
+    } catch (copyErr) {}
+    showStatus('Logs selected. Press Ctrl+C to copy.', 'warning');
+  }
+}
+
+async function viewSupportLogs(){
   if (!btnDownloadSupportBundle) return;
   const original = btnDownloadSupportBundle.innerHTML;
   btnDownloadSupportBundle.disabled = true;
   btnDownloadSupportBundle.innerHTML = '<span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>Preparing';
   showStatus('');
   try {
-    const response = await fetchWithAuth(API_SUPPORT_BUNDLE);
+    const response = await fetchSupportBundleResponse();
+    const text = await response.text();
     if (!response.ok){
-      const text = await response.text();
       const err = buildError(response, text);
-      if (!handleAuthError(err)) throw err;
-      return;
+      throw err;
     }
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = supportBundleFilename(response);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
-    showStatus('Support bundle downloaded.');
+    showSupportLogText(text);
+    showStatus('Logs ready to copy.', 'success');
   } catch (err) {
-    if (handleAuthError(err)) return;
-    console.error('Failed to download support bundle', err);
-    showStatus('Failed to download logs: ' + (err && err.message ? err.message : err));
+    console.error('Failed to load support logs', err);
+    const message = isAuthError(err)
+      ? 'Home Assistant rejected the log request. Refresh this page and try again.'
+      : 'Failed to load logs: ' + (err && err.message ? err.message : err);
+    showStatus(message);
   } finally {
     btnDownloadSupportBundle.disabled = false;
     btnDownloadSupportBundle.innerHTML = original;
@@ -2263,7 +2309,11 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   btnDownloadSupportBundle?.addEventListener('click', (ev) => {
     ev.preventDefault();
-    downloadSupportBundle();
+    viewSupportLogs();
+  });
+  document.getElementById('copySupportLogBtn')?.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    copySupportLogText();
   });
   document.querySelectorAll('[data-tab-target]')?.forEach((btn) => {
     btn.addEventListener('click', (ev) => {

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -14,6 +14,17 @@
     label{ color:#fff; }
     .muted{ color:var(--muted); }
     .small-mono{ font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .support-log-text{
+      min-height:320px;
+      background:#07101f;
+      border:1px solid var(--border);
+      color:var(--text);
+      font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size:0.82rem;
+      line-height:1.35;
+      white-space:pre;
+    }
+    .support-log-text:focus{ background:#07101f; color:var(--text); border-color:#0dcaf0; box-shadow:0 0 0 0.2rem rgba(13,202,240,0.2); }
     .saved-input-wrap{ position:relative; max-width:220px; width:100%; }
     .saved-input-wrap input{ width:100%; }
     .saved-overlay{
@@ -624,16 +635,6 @@ const DEVICE_SAVE_STATE = new Map();
 
 function setBusy(yes){ document.getElementById('busy').style.display = yes ? 'inline-block':'none'; }
 
-function supportBundleFilename(response){
-  const fallback = 'akuvox-support-bundle.zip';
-  const header = response && response.headers ? response.headers.get('Content-Disposition') : '';
-  if (!header) return fallback;
-  const match = header.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
-  if (!match) return fallback;
-  const raw = match[1] || match[2] || fallback;
-  try { return decodeURIComponent(raw); } catch (err) { return raw || fallback; }
-}
-
 function setSupportBundleStatus(message = '', kind = ''){
   const el = document.getElementById('supportBundleStatus');
   if (!el) return;
@@ -641,35 +642,73 @@ function setSupportBundleStatus(message = '', kind = ''){
   el.className = `small mt-2 ${kind === 'error' ? 'text-danger' : kind === 'success' ? 'text-success' : 'muted'}`;
 }
 
-async function downloadSupportBundle(){
+function showSupportLogText(text){
+  const panel = document.getElementById('supportLogPanel');
+  const textarea = document.getElementById('supportLogText');
+  if (!panel || !textarea) return;
+  textarea.value = text || '';
+  panel.hidden = false;
+  textarea.focus();
+}
+
+async function copySupportLogText(){
+  const textarea = document.getElementById('supportLogText');
+  if (!textarea || !textarea.value) {
+    setSupportBundleStatus('No logs to copy yet.', 'error');
+    return;
+  }
+  try {
+    if (!navigator.clipboard || !window.isSecureContext) throw new Error('clipboard unavailable');
+    await navigator.clipboard.writeText(textarea.value);
+    setSupportBundleStatus('Logs copied to clipboard.', 'success');
+  } catch (err) {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      if (document.execCommand('copy')) {
+        setSupportBundleStatus('Logs copied to clipboard.', 'success');
+        return;
+      }
+    } catch (copyErr) {}
+    setSupportBundleStatus('Logs selected. Press Ctrl+C to copy.', 'error');
+  }
+}
+
+async function fetchSupportBundleResponse(){
+  if (window.AK_AC_DASHBOARD_FETCH) {
+    try {
+      const response = await window.AK_AC_DASHBOARD_FETCH('/api/akuvox_ac/ui/support_bundle', { method: 'GET' });
+      if (response && (response.ok || (response.status !== 401 && response.status !== 403))) {
+        return response;
+      }
+    } catch (err) {}
+  }
+  return fetchWithAuth(API_SUPPORT_BUNDLE);
+}
+
+async function viewSupportLogs(){
   const btn = document.getElementById('downloadSupportBundleBtn');
   const original = btn ? btn.innerHTML : '';
   if (btn) {
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>Preparing';
   }
-  setSupportBundleStatus('Preparing support bundle...');
+  setSupportBundleStatus('Preparing logs...');
   try {
-    const response = await fetchWithAuth(API_SUPPORT_BUNDLE);
+    const response = await fetchSupportBundleResponse();
+    const text = await response.text();
     if (!response.ok) {
-      const text = await response.text();
-      const err = buildError(response, text);
-      if (handleAuthError(err)) return;
-      throw err;
+      throw buildError(response, text);
     }
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = supportBundleFilename(response);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(url);
-    setSupportBundleStatus('Support bundle downloaded.', 'success');
+    showSupportLogText(text);
+    setSupportBundleStatus('Logs ready to copy.', 'success');
   } catch (err) {
-    console.error('Failed to download support bundle', err);
-    setSupportBundleStatus('Failed to download logs: ' + (err && err.message ? err.message : err), 'error');
+    console.error('Failed to load support logs', err);
+    const message = isAuthError(err)
+      ? 'Home Assistant rejected the log request. Refresh this page and try again.'
+      : 'Failed to load logs: ' + (err && err.message ? err.message : err);
+    setSupportBundleStatus(message, 'error');
   } finally {
     if (btn) {
       btn.disabled = false;
@@ -2610,7 +2649,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.getElementById('downloadSupportBundleBtn')?.addEventListener('click', (e) => {
     e.preventDefault();
-    downloadSupportBundle();
+    viewSupportLogs();
+  });
+  document.getElementById('copySupportLogBtn')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    copySupportLogText();
   });
 
   const autoSyncInput = document.getElementById('autoSyncDelayInput');
@@ -2870,12 +2913,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
       <div>
         <div class="fw-semibold">Device diagnostics</div>
-        <div class="muted small">Download troubleshooting logs or inspect the diagnostics dashboard for the last HTTP requests sent to each Akuvox device.</div>
+        <div class="muted small">View troubleshooting logs or inspect the diagnostics dashboard for the last HTTP requests sent to each Akuvox device.</div>
         <div id="supportBundleStatus" class="small mt-2 muted"></div>
       </div>
       <div class="d-flex flex-wrap gap-2">
-        <button class="btn btn-outline-light" id="downloadSupportBundleBtn" type="button"><i class="bi bi-download me-1"></i>Download logs</button>
+        <button class="btn btn-outline-light" id="downloadSupportBundleBtn" type="button"><i class="bi bi-file-earmark-text me-1"></i>View logs</button>
         <a class="btn btn-outline-info" id="openDiagnosticsBtn" href="/akuvox-ac/diagnostics"><i class="bi bi-activity me-1"></i>Open diagnostics</a>
+      </div>
+      <div class="w-100" id="supportLogPanel" hidden>
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mt-3">
+          <div class="fw-semibold text-white">Support logs</div>
+          <button class="btn btn-sm btn-outline-info" id="copySupportLogBtn" type="button"><i class="bi bi-clipboard me-1"></i>Copy to clipboard</button>
+        </div>
+        <textarea class="form-control support-log-text mt-2" id="supportLogText" readonly spellcheck="false"></textarea>
       </div>
     </div>
   </div>

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -15,6 +15,17 @@
     label{ color:#fff; }
     .muted{ color:var(--muted); }
     .small-mono{ font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .support-log-text{
+      min-height:320px;
+      background:#07101f;
+      border:1px solid var(--border);
+      color:var(--text);
+      font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size:0.82rem;
+      line-height:1.35;
+      white-space:pre;
+    }
+    .support-log-text:focus{ background:#07101f; color:var(--text); border-color:#0dcaf0; box-shadow:0 0 0 0.2rem rgba(13,202,240,0.2); }
     .saved-input-wrap{ position:relative; max-width:220px; width:100%; }
     .saved-input-wrap input{ width:100%; }
     .saved-overlay{
@@ -626,16 +637,6 @@ const DEVICE_SAVE_STATE = new Map();
 
 function setBusy(yes){ document.getElementById('busy').style.display = yes ? 'inline-block':'none'; }
 
-function supportBundleFilename(response){
-  const fallback = 'akuvox-support-bundle.zip';
-  const header = response && response.headers ? response.headers.get('Content-Disposition') : '';
-  if (!header) return fallback;
-  const match = header.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
-  if (!match) return fallback;
-  const raw = match[1] || match[2] || fallback;
-  try { return decodeURIComponent(raw); } catch (err) { return raw || fallback; }
-}
-
 function setSupportBundleStatus(message = '', kind = ''){
   const el = document.getElementById('supportBundleStatus');
   if (!el) return;
@@ -643,35 +644,73 @@ function setSupportBundleStatus(message = '', kind = ''){
   el.className = `small mt-2 ${kind === 'error' ? 'text-danger' : kind === 'success' ? 'text-success' : 'muted'}`;
 }
 
-async function downloadSupportBundle(){
+function showSupportLogText(text){
+  const panel = document.getElementById('supportLogPanel');
+  const textarea = document.getElementById('supportLogText');
+  if (!panel || !textarea) return;
+  textarea.value = text || '';
+  panel.hidden = false;
+  textarea.focus();
+}
+
+async function copySupportLogText(){
+  const textarea = document.getElementById('supportLogText');
+  if (!textarea || !textarea.value) {
+    setSupportBundleStatus('No logs to copy yet.', 'error');
+    return;
+  }
+  try {
+    if (!navigator.clipboard || !window.isSecureContext) throw new Error('clipboard unavailable');
+    await navigator.clipboard.writeText(textarea.value);
+    setSupportBundleStatus('Logs copied to clipboard.', 'success');
+  } catch (err) {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      if (document.execCommand('copy')) {
+        setSupportBundleStatus('Logs copied to clipboard.', 'success');
+        return;
+      }
+    } catch (copyErr) {}
+    setSupportBundleStatus('Logs selected. Press Ctrl+C to copy.', 'error');
+  }
+}
+
+async function fetchSupportBundleResponse(){
+  if (window.AK_AC_DASHBOARD_FETCH) {
+    try {
+      const response = await window.AK_AC_DASHBOARD_FETCH('/api/akuvox_ac/ui/support_bundle', { method: 'GET' });
+      if (response && (response.ok || (response.status !== 401 && response.status !== 403))) {
+        return response;
+      }
+    } catch (err) {}
+  }
+  return fetchWithAuth(API_SUPPORT_BUNDLE);
+}
+
+async function viewSupportLogs(){
   const btn = document.getElementById('downloadSupportBundleBtn');
   const original = btn ? btn.innerHTML : '';
   if (btn) {
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>Preparing';
   }
-  setSupportBundleStatus('Preparing support bundle...');
+  setSupportBundleStatus('Preparing logs...');
   try {
-    const response = await fetchWithAuth(API_SUPPORT_BUNDLE);
+    const response = await fetchSupportBundleResponse();
+    const text = await response.text();
     if (!response.ok) {
-      const text = await response.text();
-      const err = buildError(response, text);
-      if (handleAuthError(err)) return;
-      throw err;
+      throw buildError(response, text);
     }
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = supportBundleFilename(response);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(url);
-    setSupportBundleStatus('Support bundle downloaded.', 'success');
+    showSupportLogText(text);
+    setSupportBundleStatus('Logs ready to copy.', 'success');
   } catch (err) {
-    console.error('Failed to download support bundle', err);
-    setSupportBundleStatus('Failed to download logs: ' + (err && err.message ? err.message : err), 'error');
+    console.error('Failed to load support logs', err);
+    const message = isAuthError(err)
+      ? 'Home Assistant rejected the log request. Refresh this page and try again.'
+      : 'Failed to load logs: ' + (err && err.message ? err.message : err);
+    setSupportBundleStatus(message, 'error');
   } finally {
     if (btn) {
       btn.disabled = false;
@@ -2624,7 +2663,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.getElementById('downloadSupportBundleBtn')?.addEventListener('click', (e) => {
     e.preventDefault();
-    downloadSupportBundle();
+    viewSupportLogs();
+  });
+  document.getElementById('copySupportLogBtn')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    copySupportLogText();
   });
 
   const autoSyncInput = document.getElementById('autoSyncDelayInput');
@@ -2885,12 +2928,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
       <div>
         <div class="fw-semibold text-white">Device diagnostics</div>
-        <div class="muted small">Download troubleshooting logs or inspect the diagnostics dashboard for the last HTTP requests sent to each Akuvox device.</div>
+        <div class="muted small">View troubleshooting logs or inspect the diagnostics dashboard for the last HTTP requests sent to each Akuvox device.</div>
         <div id="supportBundleStatus" class="small mt-2 muted"></div>
       </div>
       <div class="d-flex flex-wrap gap-2">
-        <button class="btn btn-outline-light" id="downloadSupportBundleBtn" type="button"><i class="bi bi-download me-1"></i>Download logs</button>
+        <button class="btn btn-outline-light" id="downloadSupportBundleBtn" type="button"><i class="bi bi-file-earmark-text me-1"></i>View logs</button>
         <a class="btn btn-outline-info" id="openDiagnosticsBtn" href="/akuvox-ac/diagnostics"><i class="bi bi-activity me-1"></i>Open diagnostics</a>
+      </div>
+      <div class="w-100" id="supportLogPanel" hidden>
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mt-3">
+          <div class="fw-semibold text-white">Support logs</div>
+          <button class="btn btn-sm btn-outline-info" id="copySupportLogBtn" type="button"><i class="bi bi-clipboard me-1"></i>Copy to clipboard</button>
+        </div>
+        <textarea class="form-control support-log-text mt-2" id="supportLogText" readonly spellcheck="false"></textarea>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Fixes two follow-up issues: support logs still showing Authentication Required, and direct face uploads still failing on HTTP-only Akuvox devices.

## Root Cause
- The support bundle endpoint still required Home Assistant auth before the dashboard session token guard could run.
- The dashboard log action still depended on a file download flow, which is brittle inside Home Assistant iframes.
- The direct face upload path only tried HTTPS upload endpoints unless the API client had already detected HTTP. Many Akuvox devices expose the web API over HTTP/80.

## Changes
- Allows `/api/akuvox_ac/ui/support_bundle` through to the view and keeps dashboard access checks inside the view.
- Changes support logs from a ZIP download into redacted plain text that is displayed in the settings and diagnostics pages with a copy-to-clipboard button.
- Makes desktop/mobile settings and diagnostics use the dashboard-session fetch path first, with signed fetch as fallback.
- Adds HTTP configured-port and HTTP/80 endpoints to face upload probing.
- Adds focused tests for support log text output, dashboard auth, and HTTP face upload fallback.

## Validation
- `python -m py_compile custom_components/akuvox_ac/api.py custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_api_face_payload.py custom_components/akuvox_ac/tests/test_dashboard_auth.py`
- `git diff --check`
- Manual focused test invocation for dashboard auth/log text/frontend auth header scan and face payload/upload fallback tests
- `python -m pytest ...` was not run because `pytest` is not installed in the bundled runtime.