### PR TITLE
[codex] Slim face diagnostics and fix face status handling

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -1619,9 +1619,32 @@ class AkuvoxAPI:
 
         await self._ensure_detected()
 
-        async def _attempt(use_https: bool, port: int, verify: bool, rel: str) -> Dict[str, Any]:
+        def _default_face_upload_path() -> str:
+            dest = str(safe_dest or "Face").strip().strip("/") or "Face"
+            return f"/mnt/{dest}/{safe_filename}"
+
+        def _finalize_face_upload_result(result: Dict[str, Any]) -> Dict[str, Any]:
+            path = str(result.get("path") or "").strip()
+            if path:
+                if "/" not in path and "://" not in path:
+                    path = f"/mnt/{str(safe_dest or 'Face').strip().strip('/') or 'Face'}/{path}"
+                result["path"] = path
+                return result
+            result["path"] = _default_face_upload_path()
+            result["path_inferred"] = True
+            return result
+
+        async def _attempt(
+            use_https: bool,
+            port: int,
+            verify: bool,
+            rel: str,
+            field_name: str,
+        ) -> Dict[str, Any]:
             scheme = "https" if use_https else "http"
             url = f"{scheme}://{self.host}:{port}{rel}"
+            attempt_payload = dict(payload_info)
+            attempt_payload["formField"] = field_name
             entry: Dict[str, Any] = {
                 "timestamp": _utc_now_iso(),
                 "method": "POST",
@@ -1630,14 +1653,14 @@ class AkuvoxAPI:
                 "scheme": scheme,
                 "port": port,
                 "verify_ssl": bool(verify if use_https else True),
-                "payload": payload_info,
+                "payload": attempt_payload,
                 "diag_type": "upload:face",
             }
             start = time.perf_counter()
 
             form = FormData()
             form.add_field(
-                "file",
+                field_name,
                 file_bytes,
                 filename=safe_filename,
                 content_type=content_type or "application/octet-stream",
@@ -1713,32 +1736,41 @@ class AkuvoxAPI:
         _add_base(False, configured_port)
         _add_base(False, 80)
 
+        form_field_names = ("file", "importFile")
         for use_https, port, verify in bases:
             for rel in rel_paths:
-                try:
-                    data = await _attempt(use_https, port, verify, rel)
-                    result = self._coerce_face_upload_result(data)
-                    self._validate_face_upload_result(result)
-                    return result
-                except Exception as exc:
-                    _LOGGER.debug(
-                        "Face upload attempt failed for %s://%s:%s%s -> %s",
-                        self.host,
-                        "https" if use_https else "http",
-                        port,
-                        rel,
-                        exc,
-                    )
-                    continue
+                for field_name in form_field_names:
+                    try:
+                        data = await _attempt(use_https, port, verify, rel, field_name)
+                        result = self._coerce_face_upload_result(data)
+                        self._validate_face_upload_result(result)
+                        return _finalize_face_upload_result(result)
+                    except Exception as exc:
+                        _LOGGER.debug(
+                            "Face upload attempt failed for %s://%s:%s%s field=%s -> %s",
+                            "https" if use_https else "http",
+                            self.host,
+                            port,
+                            rel,
+                            field_name,
+                            exc,
+                        )
+                        continue
 
         fallback_rel = rel_paths[0] if rel_paths else "/api/web/filetool/import"
         fallback_use_https = True
         fallback_port = _normalize_port(configured_port, fallback_use_https)
         fallback_verify = bool(self.verify_ssl) if fallback_use_https else True
-        data = await _attempt(fallback_use_https, fallback_port, fallback_verify, fallback_rel)
+        data = await _attempt(
+            fallback_use_https,
+            fallback_port,
+            fallback_verify,
+            fallback_rel,
+            form_field_names[0],
+        )
         result = self._coerce_face_upload_result(data)
         self._validate_face_upload_result(result)
-        return result
+        return _finalize_face_upload_result(result)
 
     @staticmethod
     def _coerce_face_upload_result(data: Any) -> Dict[str, Any]:

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -60,9 +60,10 @@ COMPONENT_ROOT = Path(__file__).parent
 STATIC_ROOT = COMPONENT_ROOT / "www"
 FACE_DATA_PATH = "/api/AK_AC/FaceData"
 FACE_FILE_EXTENSIONS = ("jpg", "jpeg", "png", "webp")
-SUPPORT_BUNDLE_LOG_TAIL_BYTES = 512 * 1024
-SUPPORT_BUNDLE_MAX_LOG_LINES = 1200
-SUPPORT_BUNDLE_REQUEST_LIMIT = MAX_DIAGNOSTICS_HISTORY_LIMIT
+SUPPORT_BUNDLE_LOG_TAIL_BYTES = 192 * 1024
+SUPPORT_BUNDLE_MAX_LOG_LINES = 240
+SUPPORT_BUNDLE_REQUEST_LIMIT = min(80, MAX_DIAGNOSTICS_HISTORY_LIMIT)
+SUPPORT_BUNDLE_VALUE_TEXT_LIMIT = 2500
 
 EXIT_PERMISSION_MATCH = "match"
 EXIT_PERMISSION_WORKING_DAYS = "working_days"
@@ -2143,6 +2144,7 @@ _FACE_FLAG_KEYS = (
     "hasFace",
     "HasFace",
     "FaceRegister",
+    "FaceRegisterStatus",
     "faceRegister",
     "face_register",
 )
@@ -5087,10 +5089,22 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
         "ak_ac",
         "facedata",
         "faceregister",
+        "face upload",
         "face sync",
         "face profile",
-        "http.ban",
-        "login attempt",
+        "filetool",
+        "user.add",
+        "user.set",
+        "retcode",
+    )
+    _LOG_EXCLUDE_NEEDLES = (
+        "access history",
+        "access log",
+        "door event",
+        "caller id",
+        "notification",
+        "notify",
+        "suppressed",
     )
 
     @classmethod
@@ -5324,6 +5338,81 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
         }
 
     @classmethod
+    def _compact_support_value(cls, value: Any, limit: int = SUPPORT_BUNDLE_VALUE_TEXT_LIMIT) -> Any:
+        if value in (None, "", [], {}):
+            return value
+        try:
+            text = json.dumps(value, default=str, sort_keys=True)
+        except Exception:
+            text = str(value)
+        if len(text) <= limit:
+            return value
+        return {
+            "_truncated": True,
+            "chars": len(text),
+            "excerpt": text[: max(0, limit - 3)] + "...",
+        }
+
+    @classmethod
+    def _support_request_is_relevant(cls, request: Any) -> bool:
+        if not isinstance(request, dict):
+            return False
+        diag_type = str(request.get("diag_type") or "").strip().lower()
+        path = str(request.get("path") or request.get("url") or "").strip().lower()
+        method = str(request.get("method") or "").strip().upper()
+
+        if diag_type.startswith("upload:face"):
+            return True
+        if diag_type.startswith(("user:", "contact:", "group:", "schedule:", "relay:")):
+            return True
+        if any(token in path for token in ("/user/", "user/", "filetool", "face")):
+            return True
+        if method == "POST" and not any(
+            token in path for token in ("event", "history", "record", "log")
+        ):
+            return True
+
+        return False
+
+    @classmethod
+    def _slim_support_request(cls, request: Dict[str, Any]) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for key in (
+            "timestamp",
+            "diag_type",
+            "method",
+            "path",
+            "scheme",
+            "port",
+            "status",
+            "ok",
+            "duration_ms",
+            "verify_ssl",
+        ):
+            if key in request:
+                out[key] = request.get(key)
+        if "payload" in request:
+            out["payload"] = cls._compact_support_value(request.get("payload"))
+        if "response_excerpt" in request:
+            out["response_excerpt"] = cls._compact_support_value(
+                request.get("response_excerpt")
+            )
+        if "error" in request:
+            out["error"] = cls._compact_support_value(request.get("error"), 800)
+        return out
+
+    @classmethod
+    def _filter_support_requests(cls, requests: Any) -> List[Dict[str, Any]]:
+        if not isinstance(requests, list):
+            return []
+        filtered = [
+            cls._slim_support_request(request)
+            for request in requests
+            if cls._support_request_is_relevant(request)
+        ]
+        return filtered[:SUPPORT_BUNDLE_REQUEST_LIMIT]
+
+    @classmethod
     def _device_support_snapshot(cls, root: Dict[str, Any]) -> List[Dict[str, Any]]:
         devices: List[Dict[str, Any]] = []
         manager = root.get("sync_manager")
@@ -5340,9 +5429,7 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
             except Exception:
                 requests = []
             health = getattr(coord, "health", {}) or {}
-            events = getattr(coord, "events", []) or []
-            storage = getattr(coord, "storage", None)
-            storage_data = getattr(storage, "data", {}) if storage else {}
+            filtered_requests = cls._filter_support_requests(requests)
             devices.append(
                 {
                     "entry_id": entry_id,
@@ -5357,13 +5444,9 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
                         "verify_ssl": getattr(api, "verify_ssl", None),
                     },
                     "options": cls._copy_json(opts),
-                    "recent_events": cls._copy_json(events[:100]),
-                    "event_state": cls._copy_json(getattr(coord, "event_state", {})),
-                    "caller_state": cls._copy_json(getattr(coord, "caller_state", {})),
-                    "door_event_state": cls._copy_json(
-                        storage_data.get("door_events", {}) if isinstance(storage_data, dict) else {}
-                    ),
-                    "recent_requests": requests,
+                    "request_count": len(requests) if isinstance(requests, list) else 0,
+                    "included_request_count": len(filtered_requests),
+                    "recent_requests": filtered_requests,
                 }
             )
         return devices
@@ -5372,7 +5455,13 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
     def _settings_snapshot(cls, root: Dict[str, Any]) -> Dict[str, Any]:
         settings = root.get("settings_store")
         data = getattr(settings, "data", {}) if settings else {}
-        snapshot = cls._copy_json(data if isinstance(data, dict) else {})
+        raw = data if isinstance(data, dict) else {}
+        snapshot: Dict[str, Any] = {
+            "auto_sync_delay_minutes": raw.get("auto_sync_delay_minutes"),
+            "face_integrity_enabled": raw.get("face_integrity_enabled"),
+            "integrity_interval_minutes": raw.get("integrity_interval_minutes"),
+            "diagnostics_history_limit": raw.get("diagnostics_history_limit"),
+        }
         updater = root.get("hacs_auto_updater")
         if updater and hasattr(updater, "status"):
             try:
@@ -5403,6 +5492,8 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
             lines = []
             for line in text.splitlines():
                 lowered = line.lower()
+                if any(needle in lowered for needle in cls._LOG_EXCLUDE_NEEDLES):
+                    continue
                 if any(needle in lowered for needle in cls._LOG_NEEDLES):
                     lines.append(cls._redact_text(line))
             result["lines"] = lines[-SUPPORT_BUNDLE_MAX_LOG_LINES:]
@@ -5440,8 +5531,9 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
             f"Filtered HA log lines: {len(log_tail.get('lines', [])) if isinstance(log_tail, dict) else 0}",
             "",
             "Contents",
-            "- Redacted structured diagnostics",
-            "- Akuvox/face-related Home Assistant log tail",
+            "- Redacted device request diagnostics",
+            "- Face file and sync status summary",
+            "- Filtered Akuvox/face-related Home Assistant log tail",
         ]
         return "\n".join(lines) + "\n"
 
@@ -5452,7 +5544,7 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
         parts = [
             cls._summary_text(bundle),
             "",
-            "=== Redacted support bundle JSON ===",
+            "=== Redacted device request diagnostics JSON ===",
             json.dumps(bundle, indent=2, sort_keys=True, default=str),
             "",
             "=== Filtered Home Assistant log tail ===",
@@ -5463,10 +5555,6 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
 
     async def _build_support_bundle(self, hass: HomeAssistant) -> Dict[str, Any]:
         root = hass.data.get(DOMAIN, {}) or {}
-        diagnostics = await self._build_payload(
-            root,
-            limit_override=SUPPORT_BUNDLE_REQUEST_LIMIT,
-        )
         bundle = {
             "metadata": {
                 "generated_at": _now_iso(),
@@ -5481,7 +5569,6 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
             "users": self._users_snapshot(root),
             "face_files": self._face_files_snapshot(hass),
             "devices": self._device_support_snapshot(root),
-            "diagnostics": diagnostics,
             "homeassistant_log_tail": await self._homeassistant_log_tail(hass),
         }
         return self._redact_support_data(bundle)

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -1032,6 +1032,7 @@ _FACE_FLAG_KEYS = (
     "hasFace",
     "HasFace",
     "FaceRegister",
+    "FaceRegisterStatus",
     "faceRegister",
     "face_register",
 )
@@ -1885,8 +1886,8 @@ def _integrity_field_differences(
         diffs.append("pin")
 
     if include_face:
-        expected_face = _normalize_boolish(expected.get("FaceRegister"))
-        actual_face = _normalize_boolish(local.get("FaceRegister"))
+        expected_face = _face_flag_from_record(expected)
+        actual_face = _face_flag_from_record(local)
         if expected_face is True and actual_face is not True:
             diffs.append("face status")
 

--- a/custom_components/akuvox_ac/tests/test_api_face_payload.py
+++ b/custom_components/akuvox_ac/tests/test_api_face_payload.py
@@ -68,6 +68,14 @@ class _FaceUploadSessionStub:
         raise RuntimeError("unused in unit test")
 
 
+class _FaceUploadNoPathSessionStub(_FaceUploadSessionStub):
+    def post(self, url, **_kwargs):
+        self.post_urls.append(url)
+        if url.startswith("http://"):
+            return _RequestContextStub(_ResponseStub(200, {"retcode": 0}))
+        return _RequestContextStub(_ResponseStub(503, body="tls unavailable"))
+
+
 class _FormDataStub:
     def __init__(self):
         self.fields = []
@@ -133,3 +141,20 @@ def test_face_upload_tries_http_device_endpoint_when_https_unavailable():
     assert any(url.startswith("https://") for url in session.get_urls)
     assert any(url.startswith("http://") for url in session.get_urls)
     assert session.post_urls[0].startswith("http://")
+
+
+def test_face_upload_infers_device_face_path_when_upload_response_has_no_path():
+    import asyncio
+
+    session = _FaceUploadNoPathSessionStub()
+    api = AkuvoxAPI("127.0.0.1", port=80, username="", password="", session=session)
+    original_form_data = api_module.FormData
+    api_module.FormData = _FormDataStub
+
+    try:
+        result = asyncio.run(api.face_upload(b"jpg", filename="HA001.jpg"))
+    finally:
+        api_module.FormData = original_form_data
+
+    assert result["path"] == "/mnt/Face/HA001.jpg"
+    assert result["path_inferred"] is True

--- a/custom_components/akuvox_ac/tests/test_dashboard_auth.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_auth.py
@@ -74,9 +74,38 @@ def test_support_bundle_text_contains_copyable_sections():
     )
 
     assert "Akuvox Access Control Support Bundle" in text
-    assert "=== Redacted support bundle JSON ===" in text
+    assert "=== Redacted device request diagnostics JSON ===" in text
     assert "=== Filtered Home Assistant log tail ===" in text
     assert "face profile upload failed" in text
+
+
+def test_support_bundle_filters_access_history_from_device_requests():
+    filtered = http_module.AkuvoxUISupportBundle._filter_support_requests(
+        [
+            {
+                "diag_type": "upload:face",
+                "path": "/api/filetool/import?destFile=Face&index=",
+                "method": "POST",
+                "payload": {"filename": "HA001.jpg"},
+            },
+            {
+                "diag_type": "event:history",
+                "path": "/api/access/history",
+                "method": "GET",
+                "response_excerpt": {"events": [1, 2, 3]},
+            },
+            {
+                "diag_type": "user/get",
+                "path": "/api/user/get?NameOrPerID=HA001",
+                "method": "GET",
+            },
+        ]
+    )
+
+    assert [item["path"] for item in filtered] == [
+        "/api/filetool/import?destFile=Face&index=",
+        "/api/user/get?NameOrPerID=HA001",
+    ]
 
 
 def test_dashboard_frontend_does_not_send_bearer_authorization_headers():

--- a/custom_components/akuvox_ac/tests/test_face_status.py
+++ b/custom_components/akuvox_ac/tests/test_face_status.py
@@ -66,3 +66,8 @@ def test_face_status_falls_back_to_pending_when_not_stored_active(monkeypatch):
     result = http._evaluate_face_status(hass, user, devices, stored_status="")
 
     assert result == "pending"
+
+
+def test_face_register_status_is_treated_as_face_flag():
+    assert http._face_flag_from_record({"FaceRegisterStatus": "1"}) is True
+    assert http._face_flag_from_record({"FaceRegisterStatus": "0"}) is False

--- a/custom_components/akuvox_ac/tests/test_paused_user_sync.py
+++ b/custom_components/akuvox_ac/tests/test_paused_user_sync.py
@@ -98,6 +98,16 @@ def test_record_matches_desired_fields_treats_face_register_status_as_registered
     assert integration._record_matches_desired_fields(local, desired) is True
 
 
+def test_face_register_status_satisfies_integrity_face_check():
+    diffs = integration._integrity_field_differences(
+        {"UserID": "HA001", "Name": "User One", "FaceRegisterStatus": "1"},
+        {"UserID": "HA001", "Name": "User One", "FaceRegister": 1},
+        include_face=True,
+    )
+
+    assert "face status" not in diffs
+
+
 def test_record_matches_desired_fields_detects_missing_face_registration():
     local = {
         "UserID": "HA001",


### PR DESCRIPTION
## Summary

- Trim the support-bundle text down to device request diagnostics, face file/status summaries, and a filtered Akuvox/face Home Assistant log tail.
- Exclude access history, door event, caller ID, and notification noise from the copyable diagnostics output.
- Treat `FaceRegisterStatus` as a valid face registration flag during diagnostics and integrity checks.
- Improve face uploads by trying both `file` and `importFile` multipart fields and inferring the device-local `/mnt/Face/<filename>` path when firmware returns success without a path.

## Root cause

The support bundle was including broad diagnostics/access-history data, which made logs too large to share. Separately, some device responses report face state through `FaceRegisterStatus` rather than `FaceRegister`, so registered profiles could be treated as mismatched/error. Some upload responses also returned success without a device path, leaving downstream user payloads without a proper local face path.

## Validation

- `python -m py_compile` on the modified source and focused tests.
- `git diff --check`.
- Focused in-process smoke checks for face upload path inference, diagnostics filtering, and `FaceRegisterStatus` integrity handling.

`pytest` was not run because this local runtime does not have pytest installed (`No module named pytest`).