### PR TITLE
[codex] Mirror Akuvox web face upload flow

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -705,6 +705,63 @@ class AkuvoxAPI:
         cleaned = str(name or "").strip()
         return cleaned or candidate
 
+    @staticmethod
+    def _is_device_face_import_reference(reference: Any) -> bool:
+        """Return True when a face reference points at the device import store."""
+
+        if reference in (None, ""):
+            return False
+        text = str(reference or "").strip().replace("\\", "/").lower()
+        return text.startswith("/mnt/face/") or text.startswith("mnt/face/")
+
+    @classmethod
+    def _face_import_filename_from_item(cls, item: Dict[str, Any]) -> str:
+        """Extract the filename used by Akuvox web UI face import payloads."""
+
+        if not isinstance(item, dict):
+            return ""
+
+        import_file = item.get("importFile") or item.get("ImportFile")
+        if isinstance(import_file, dict):
+            for key in ("fileName", "filename", "name", "FileName"):
+                value = import_file.get(key)
+                if value not in (None, ""):
+                    filename = Path(str(value)).name
+                    if filename:
+                        return filename
+
+        for key in ("FaceFileName", "faceFileName", "face_filename", "face_file_name"):
+            value = item.get(key)
+            if value not in (None, ""):
+                filename = Path(str(value)).name
+                if filename:
+                    return filename
+
+        for key in ("FaceUrl", "FaceURL", "face_url", "faceUrl"):
+            value = item.get(key)
+            if value not in (None, "") and cls._is_device_face_import_reference(value):
+                filename = cls._face_reference_to_filename(value)
+                if filename:
+                    return Path(filename).name
+
+        return ""
+
+    @classmethod
+    def _apply_face_import_fields(cls, item: Dict[str, Any]) -> None:
+        """Mirror the Akuvox web UI face-link fields when a file was imported."""
+
+        filename = cls._face_import_filename_from_item(item)
+        if not filename:
+            return
+
+        item["FaceFileName"] = filename
+        item["importFile"] = {"fileName": filename, "fileData": {}}
+
+        face_url = item.get("FaceUrl") or item.get("FaceURL")
+        if cls._is_device_face_import_reference(face_url):
+            item.pop("FaceUrl", None)
+            item.pop("FaceURL", None)
+
     def _normalize_user_items_for_add_or_set(
         self,
         items: List[Dict[str, Any]],
@@ -953,7 +1010,7 @@ class AkuvoxAPI:
                 if not had_user_id_alias:
                     d.pop("UserId", None)
             if for_set:
-                face_source = d.pop("FaceFileName", None)
+                face_source = d.get("FaceFileName")
             else:
                 face_source = d.get("FaceFileName")
             if not face_source and isinstance(d.get("FaceUrl"), str):
@@ -973,6 +1030,7 @@ class AkuvoxAPI:
                     current = d.get("FaceRegister")
                     if self._coerce_int(current) != 1:
                         d["FaceRegister"] = 1
+            self._apply_face_import_fields(d)
             if for_set:
                 d.setdefault("PrivatePIN", "")
                 d.setdefault("AnalogNumber", "")
@@ -1016,7 +1074,10 @@ class AkuvoxAPI:
             "CardCode": "",
             "ContactID": "-1",
             "DialAccount": "0",
+            "FaceFileName": "",
             "FaceRegisterStatus": "0",
+            "FaceUrl": "",
+            "importFile": {"fileName": "", "fileData": {}},
             "LiftFloorNum": "0",
             "PhoneNum": "",
             "PriorityCall": "0",
@@ -1033,7 +1094,7 @@ class AkuvoxAPI:
             return {"ok": False, "errors": ["Payload item is not an object"]}
 
         template = cls._user_set_working_template()
-        optional_keys = {"ID"}
+        optional_keys = {"ID", "FaceFileName", "FaceUrl", "importFile"}
         required_keys = set(template.keys()) - optional_keys
         forbidden_keys = {"ScheduleRelay", "BLE_AuthCode", "FaceRegister", "Priority"}
         string_fields = {
@@ -1052,6 +1113,8 @@ class AkuvoxAPI:
             "BLEAuthCode",
             "BLE_Expired",
             "BLE_Status",
+            "FaceFileName",
+            "FaceUrl",
             "PrivatePIN",
             "AnalogNumber",
             "AnalogReplace",
@@ -1101,7 +1164,7 @@ class AkuvoxAPI:
             return {"missing": [], "unexpected": [], "type_mismatches": []}
 
         template = cls._user_set_working_template()
-        optional_keys = {"ID"}
+        optional_keys = {"ID", "FaceFileName", "FaceUrl", "importFile"}
         missing = [key for key in template if key not in record and key not in optional_keys]
         unexpected = [key for key in record if key not in template]
         type_mismatches: List[Dict[str, str]] = []
@@ -1598,10 +1661,10 @@ class AkuvoxAPI:
         query = urlencode(params)
 
         base_paths = (
-            "/api/filetool/import",
-            "/filetool/import",
             "/api/web/filetool/import",
             "/web/filetool/import",
+            "/api/filetool/import",
+            "/filetool/import",
         )
         rel_paths = tuple(f"{path}?{query}" if query else path for path in base_paths)
 
@@ -1670,10 +1733,15 @@ class AkuvoxAPI:
                 _LOGGER.debug(
                     "POST %s (face upload) filename=%s size=%s", url, safe_filename, len(file_bytes)
                 )
+                origin = f"{scheme}://{self.host}:{port}"
                 async with self._session.post(
                     url,
                     data=form,
-                    headers={"Accept": "application/json, text/plain, */*"},
+                    headers={
+                        "Accept": "application/json, text/plain, */*",
+                        "Origin": origin,
+                        "Referer": f"{origin}/",
+                    },
                     ssl=(verify if use_https else None),
                     timeout=30,
                     auth=self._auth,
@@ -1997,6 +2065,7 @@ class AkuvoxAPI:
             "Room": tuple(),
             "PhoneNum": ("phone", "phone_num"),
             "FaceUrl": ("face_url", "FaceURL"),
+            "FaceFileName": ("faceFileName", "face_filename", "face_file_name"),
         }
 
         for target, aliases in optional_string.items():
@@ -2017,6 +2086,14 @@ class AkuvoxAPI:
                 pin_text = str(pin_value).strip()
                 if pin_text:
                     base["PrivatePIN"] = pin_text
+
+        import_file = item.get("importFile") or item.get("ImportFile")
+        if isinstance(import_file, dict):
+            filename = self._face_import_filename_from_item({"importFile": import_file})
+            if filename:
+                base["importFile"] = {"fileName": filename, "fileData": {}}
+
+        self._apply_face_import_fields(base)
 
         return base
 

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -62,8 +62,8 @@ FACE_DATA_PATH = "/api/AK_AC/FaceData"
 FACE_FILE_EXTENSIONS = ("jpg", "jpeg", "png", "webp")
 SUPPORT_BUNDLE_LOG_TAIL_BYTES = 192 * 1024
 SUPPORT_BUNDLE_MAX_LOG_LINES = 240
-SUPPORT_BUNDLE_REQUEST_LIMIT = min(80, MAX_DIAGNOSTICS_HISTORY_LIMIT)
-SUPPORT_BUNDLE_VALUE_TEXT_LIMIT = 2500
+SUPPORT_BUNDLE_REQUEST_LIMIT = min(40, MAX_DIAGNOSTICS_HISTORY_LIMIT)
+SUPPORT_BUNDLE_VALUE_TEXT_LIMIT = 1200
 
 EXIT_PERMISSION_MATCH = "match"
 EXIT_PERMISSION_WORKING_DAYS = "working_days"
@@ -5363,13 +5363,22 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
 
         if diag_type.startswith("upload:face"):
             return True
-        if diag_type.startswith(("user:", "contact:", "group:", "schedule:", "relay:")):
+        if diag_type in {"user:add", "user:set", "user:del", "user:delete", "user:get"}:
             return True
-        if any(token in path for token in ("/user/", "user/", "filetool", "face")):
-            return True
-        if method == "POST" and not any(
-            token in path for token in ("event", "history", "record", "log")
+        if any(
+            token in path
+            for token in (
+                "filetool/import",
+                "/face/",
+                "/api/user/add",
+                "/api/user/set",
+                "/api/user/del",
+                "/api/user/delete",
+                "/api/user/get",
+            )
         ):
+            return True
+        if method == "POST" and "face" in path:
             return True
 
         return False
@@ -5405,12 +5414,21 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
     def _filter_support_requests(cls, requests: Any) -> List[Dict[str, Any]]:
         if not isinstance(requests, list):
             return []
-        filtered = [
-            cls._slim_support_request(request)
-            for request in requests
-            if cls._support_request_is_relevant(request)
-        ]
-        return filtered[:SUPPORT_BUNDLE_REQUEST_LIMIT]
+        primary: List[Dict[str, Any]] = []
+        user_get: List[Dict[str, Any]] = []
+        for request in requests:
+            if not cls._support_request_is_relevant(request):
+                continue
+            slim = cls._slim_support_request(request)
+            diag_type = str(request.get("diag_type") or "").strip().lower()
+            path = str(request.get("path") or request.get("url") or "").strip().lower()
+            if diag_type == "user:get" or "/api/user/get" in path:
+                user_get.append(slim)
+            else:
+                primary.append(slim)
+
+        remaining = max(0, SUPPORT_BUNDLE_REQUEST_LIMIT - len(primary))
+        return (primary + user_get[: min(6, remaining)])[:SUPPORT_BUNDLE_REQUEST_LIMIT]
 
     @classmethod
     def _device_support_snapshot(cls, root: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -1199,6 +1199,66 @@ _FACE_REGISTER_KEYS = (
 )
 
 
+def _face_reference_is_device_import(reference: Any) -> bool:
+    if reference in (None, ""):
+        return False
+    text = str(reference or "").strip().replace("\\", "/").lower()
+    return text.startswith("/mnt/face/") or text.startswith("mnt/face/")
+
+
+def _face_import_filename_from_sources(
+    ha_key: str,
+    *sources: Optional[Dict[str, Any]],
+) -> str:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        import_file = source.get("importFile") or source.get("ImportFile")
+        if isinstance(import_file, dict):
+            for key in ("fileName", "filename", "name", "FileName"):
+                value = import_file.get(key)
+                if value not in (None, ""):
+                    name = Path(str(value)).name
+                    if name:
+                        return name
+        for key in _FACE_FILENAME_KEYS:
+            value = source.get(key)
+            if value not in (None, ""):
+                name = Path(str(value)).name
+                if name:
+                    return name
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in _FACE_URL_KEYS:
+            value = source.get(key)
+            if value not in (None, "") and _face_reference_is_device_import(value):
+                try:
+                    name = face_filename_from_reference(str(value), ha_key)
+                except Exception:
+                    name = Path(str(value)).name
+                if name:
+                    return Path(str(name)).name
+
+    return ""
+
+
+def _apply_face_import_fields(
+    payload: Dict[str, Any],
+    *,
+    ha_key: str,
+    sources: Tuple[Optional[Dict[str, Any]], ...],
+) -> bool:
+    filename = _face_import_filename_from_sources(ha_key, payload, *sources)
+    if not filename:
+        return False
+
+    payload["FaceFileName"] = filename
+    payload["importFile"] = {"fileName": filename, "fileData": {}}
+    return True
+
+
 def _ensure_face_payload_fields(
     payload: Dict[str, Any],
     *,
@@ -1220,15 +1280,25 @@ def _ensure_face_payload_fields(
                     return text
         return None
 
-    face_url = _extract_first(_FACE_URL_KEYS)
+    raw_face_url = _extract_first(_FACE_URL_KEYS)
+    face_url = raw_face_url
     if not face_url:
         face_url = _extract_first(_FACE_FILENAME_KEYS)
 
-    if face_url:
+    import_linked = _apply_face_import_fields(
+        payload,
+        ha_key=ha_key,
+        sources=sources,
+    )
+
+    if face_url and not (import_linked and (not raw_face_url or _face_reference_is_device_import(raw_face_url))):
         payload["FaceUrl"] = str(face_url)
+    elif import_linked:
+        payload.pop("FaceUrl", None)
 
     for key in _FACE_FILENAME_KEYS:
-        payload.pop(key, None)
+        if key != "FaceFileName":
+            payload.pop(key, None)
     for key in _FACE_URL_KEYS:
         if key != "FaceUrl":
             payload.pop(key, None)
@@ -1366,7 +1436,7 @@ def _prepare_user_set_payload(
         "LicensePlate": [{}, {}, {}, {}, {}],
         "LicensePlateTime": [{}, {}, {}, {}, {}],
     }
-    base_keys = set(payload.keys()) | {"ID"}
+    base_keys = set(payload.keys()) | {"ID", "FaceUrl", "FaceFileName", "importFile"}
 
     if isinstance(existing, dict):
         payload.update({k: v for k, v in _remap_user_set_keys(existing).items() if v is not None})
@@ -1385,11 +1455,13 @@ def _prepare_user_set_payload(
         payload["UserID"] = str(ha_key)
 
     face_url_value: Optional[str] = None
+    raw_face_url_value: Optional[str] = None
     face_url_present = False
+    face_filename_value = _face_import_filename_from_sources(ha_key, desired, existing, payload)
     for source in (desired, existing, payload):
         if not isinstance(source, dict):
             continue
-        for key in (*_FACE_URL_KEYS, *_FACE_FILENAME_KEYS):
+        for key in _FACE_URL_KEYS:
             if key not in source:
                 continue
             face_url_present = True
@@ -1399,17 +1471,26 @@ def _prepare_user_set_payload(
             text = str(raw_value).strip()
             if text:
                 face_url_value = text
+                raw_face_url_value = text
                 break
         if face_url_value is not None:
             break
 
-    if face_url_value is not None:
+    if face_filename_value:
+        payload["FaceFileName"] = face_filename_value
+        payload["importFile"] = {"fileName": face_filename_value, "fileData": {}}
+
+    if face_url_value is not None and not (
+        face_filename_value and _face_reference_is_device_import(raw_face_url_value)
+    ):
         payload["FaceUrl"] = face_url_value
+    elif face_filename_value and _face_reference_is_device_import(raw_face_url_value):
+        payload.pop("FaceUrl", None)
     elif face_url_present:
         payload["FaceUrl"] = ""
 
     for key in (*_FACE_URL_KEYS, *_FACE_FILENAME_KEYS):
-        if key != "FaceUrl":
+        if key not in {"FaceUrl", "FaceFileName"}:
             payload.pop(key, None)
 
     for key in ("ScheduleID", "Type", "Id", "id"):
@@ -1424,6 +1505,13 @@ def _prepare_user_set_payload(
 
     if str(payload.get("FaceUrl") or "").strip() and str(payload.get("FaceRegisterStatus") or "").strip() != "1":
         payload["FaceRegisterStatus"] = "1"
+
+    if "FaceRegisterStatus" in payload:
+        face_status_flag = _normalize_boolish(payload.get("FaceRegisterStatus"))
+        if face_status_flag is None:
+            payload["FaceRegisterStatus"] = str(payload.get("FaceRegisterStatus") or "")
+        else:
+            payload["FaceRegisterStatus"] = "1" if face_status_flag else "0"
 
     payload["LicensePlate"] = _normalize_fixed_plate(payload.get("LicensePlate"))
     payload["LicensePlateTime"] = _normalize_fixed_plate(payload.get("LicensePlateTime"))
@@ -1918,6 +2006,12 @@ def _record_matches_desired_fields(local: Dict[str, Any], desired: Dict[str, Any
             if expected_face is False and actual_face is True:
                 return False
             continue
+
+        if key in (*_FACE_URL_KEYS, *_FACE_FILENAME_KEYS, "importFile"):
+            expected_face = _face_flag_from_record(desired)
+            actual_face = _face_flag(local)
+            if expected_face is True and actual_face is True:
+                continue
 
         local_value = local.get(key)
         if _text(local_value) != _text(desired_value):

--- a/custom_components/akuvox_ac/tests/test_api_face_payload.py
+++ b/custom_components/akuvox_ac/tests/test_api_face_payload.py
@@ -107,7 +107,31 @@ def test_normalize_user_add_keeps_face_filename_for_modern_firmware():
     )
 
     assert normalized[0]["FaceFileName"] == "HA001.jpg"
+    assert normalized[0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
     assert normalized[0]["FaceRegister"] == 1
+
+
+def test_normalize_user_set_uses_web_face_import_fields_for_device_file():
+    api = AkuvoxAPI("127.0.0.1", port=80, username="", password="", session=_SessionStub())
+
+    normalized = api._normalize_user_items_for_add_or_set(
+        [
+            {
+                "UserID": "HA001",
+                "ID": "7",
+                "Name": "Test",
+                "FaceUrl": "/mnt/Face/HA001.jpg",
+                "FaceRegisterStatus": "1",
+            }
+        ],
+        allow_face_url=True,
+        for_set=True,
+    )
+
+    assert normalized[0]["FaceFileName"] == "HA001.jpg"
+    assert normalized[0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
+    assert "FaceUrl" not in normalized[0]
+    assert normalized[0]["FaceRegisterStatus"] == "1"
 
 
 def test_normalize_user_set_preserves_face_url_field():
@@ -141,6 +165,7 @@ def test_face_upload_tries_http_device_endpoint_when_https_unavailable():
     assert any(url.startswith("https://") for url in session.get_urls)
     assert any(url.startswith("http://") for url in session.get_urls)
     assert session.post_urls[0].startswith("http://")
+    assert "/api/web/filetool/import" in session.post_urls[0]
 
 
 def test_face_upload_infers_device_face_path_when_upload_response_has_no_path():

--- a/custom_components/akuvox_ac/tests/test_contact_sync.py
+++ b/custom_components/akuvox_ac/tests/test_contact_sync.py
@@ -265,5 +265,7 @@ def test_upload_face_asset_links_device_import_path(tmp_path):
     assert uploaded is True
     assert api.upload_calls == [{"bytes": b"face-bytes", "filename": "HA001.jpg"}]
     assert api.set_calls[0][0]["ID"] == "42"
-    assert api.set_calls[0][0]["FaceUrl"] == "/mnt/Face/HA001.jpg"
+    assert "FaceUrl" not in api.set_calls[0][0]
+    assert api.set_calls[0][0]["FaceFileName"] == "HA001.jpg"
+    assert api.set_calls[0][0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
     assert api.set_calls[0][0]["FaceRegisterStatus"] == "1"

--- a/custom_components/akuvox_ac/tests/test_paused_user_sync.py
+++ b/custom_components/akuvox_ac/tests/test_paused_user_sync.py
@@ -81,6 +81,41 @@ def test_prepare_user_set_payload_keeps_existing_face_url_and_status():
     assert payload.get("ContactID") == "16"
 
 
+def test_prepare_user_set_payload_links_uploaded_face_like_web_ui():
+    payload = integration._prepare_user_set_payload(
+        "HA001",
+        {
+            "UserID": "HA001",
+            "Name": "User One",
+            "FaceUrl": "/mnt/Face/HA001.jpg",
+            "FaceRegister": 1,
+        },
+        {"ID": "368", "UserID": "HA001", "Name": "User One"},
+    )
+
+    assert "FaceUrl" not in payload
+    assert payload["FaceFileName"] == "HA001.jpg"
+    assert payload["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
+    assert payload["FaceRegisterStatus"] == "1"
+
+
+def test_prepare_user_add_payload_links_uploaded_face_like_web_ui():
+    payload = integration._prepare_user_add_payload(
+        "HA001",
+        {
+            "UserID": "HA001",
+            "Name": "User One",
+            "FaceUrl": "/mnt/Face/HA001.jpg",
+            "FaceRegister": 1,
+        },
+    )
+
+    assert "FaceUrl" not in payload
+    assert payload["FaceFileName"] == "HA001.jpg"
+    assert payload["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
+    assert payload["FaceRegister"] == 1
+
+
 def test_record_matches_desired_fields_treats_face_register_status_as_registered():
     local = {
         "UserID": "HA001",


### PR DESCRIPTION
## Summary

- Prefer the same face upload endpoint used by the Akuvox web UI: `/api/web/filetool/import?destFile=Face&index=`.
- Add browser-like `Origin` and `Referer` headers to face upload requests.
- Link uploaded face files using the Akuvox web UI payload fields: `FaceFileName` and `importFile: {fileName, fileData: {}}`.
- Stop sending `FaceUrl` for device-local `/mnt/Face/...` references so the user add/set payload mirrors the web interface more closely.
- Keep legacy/public `FaceUrl` behavior for non-device-local references.
- Further trim support diagnostics so face bundles focus on face upload and user add/set/get requests, not repeated schedule/contact data.

## Root cause

The device web UI does a two-step flow: upload the image to the device, then reference the uploaded filename using `FaceFileName` and `importFile` during `user.add`. The integration was uploading successfully, but then mostly linking the face with `FaceUrl`/`FaceRegisterStatus`. The device accepted those calls but could leave the face profile in an error/not-linked state.

## Validation

- `python -m py_compile` on modified source and focused tests.
- `git diff --check`.
- Focused in-process checks for:
  - web-style face upload endpoint ordering,
  - user.add/user.set face import payload shaping,
  - direct face upload linking through `FaceFileName`/`importFile`,
  - slim support diagnostics filtering.

`pytest` was not run because this local runtime does not have pytest installed (`No module named pytest`).