### PR TITLE
Recreate users when linking uploaded faces

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -5185,8 +5185,61 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
         except Exception:
             return ""
 
+    @staticmethod
+    def _support_face_device_state(
+        user_id: str,
+        raw_profile: Dict[str, Any],
+        devices: Optional[List[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        state = {
+            "device_active": False,
+            "register_mismatch": False,
+            "matched_devices": [],
+        }
+        if not user_id or not isinstance(devices, list):
+            return state
+
+        groups = raw_profile.get("groups") if isinstance(raw_profile, dict) else []
+        for dev in devices:
+            if not isinstance(dev, dict):
+                continue
+            if not dev.get("participate_in_sync", True):
+                continue
+            if not _device_supports_face(dev):
+                continue
+            if not _groups_overlap(groups, dev.get("sync_groups")):
+                continue
+
+            record = None
+            for candidate in dev.get("_users") or dev.get("users") or []:
+                if not isinstance(candidate, dict):
+                    continue
+                candidate_key = (
+                    normalize_user_id(_user_key(candidate)) or _user_key(candidate)
+                )
+                if candidate_key == user_id:
+                    record = candidate
+                    break
+            if record is None:
+                continue
+
+            device_name = str(dev.get("name") or dev.get("entry_id") or "").strip()
+            if device_name:
+                state["matched_devices"].append(device_name)
+            if _device_face_is_active(record):
+                state["device_active"] = True
+            if _device_face_registration_mismatch(record):
+                state["register_mismatch"] = True
+
+        return state
+
     @classmethod
-    def _users_snapshot(cls, root: Dict[str, Any]) -> Dict[str, Any]:
+    def _users_snapshot(
+        cls,
+        root: Dict[str, Any],
+        *,
+        devices: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
         users_store = root.get("users_store")
         raw_users: Dict[str, Any] = {}
         if users_store and hasattr(users_store, "all"):
@@ -5209,12 +5262,24 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
                 continue
             user_id = normalize_user_id(raw_id) or str(raw_id)
             face_url = str(raw_profile.get("face_url") or raw_profile.get("FaceUrl") or "").strip()
-            face_status = str(raw_profile.get("face_status") or "").strip().lower()
+            stored_face_status = str(raw_profile.get("face_status") or "").strip().lower()
             try:
                 error_count = int(raw_profile.get("face_error_count") or 0)
             except Exception:
                 error_count = 0
-            has_face = bool(face_url) or face_status in {"active", "pending", "error"}
+            device_state = cls._support_face_device_state(user_id, raw_profile, devices)
+            face_status = stored_face_status
+            if device_state.get("register_mismatch"):
+                face_status = "error"
+            elif not face_status and device_state.get("device_active"):
+                face_status = "active"
+
+            has_face = (
+                bool(face_url)
+                or face_status in {"active", "pending", "error"}
+                or bool(device_state.get("device_active"))
+                or bool(device_state.get("register_mismatch"))
+            )
             if face_url:
                 counts["with_face_url"] += 1
             if face_status == "pending":
@@ -5223,7 +5288,7 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
                 counts["face_error"] += 1
             if face_status == "active":
                 counts["face_active"] += 1
-            if error_count > 0:
+            if error_count > 0 or face_status == "error" or device_state.get("register_mismatch"):
                 counts["face_sync_errors"] += 1
 
             profile = {
@@ -5245,10 +5310,14 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
                 "face": {
                     "present": has_face,
                     "status": face_status,
+                    "stored_status": stored_face_status,
                     "url_present": bool(face_url),
                     "url_filename": cls._face_filename_from_url(face_url),
                     "synced_at": raw_profile.get("face_synced_at") or "",
                     "error_count": error_count,
+                    "device_active": bool(device_state.get("device_active")),
+                    "register_mismatch": bool(device_state.get("register_mismatch")),
+                    "matched_devices": list(device_state.get("matched_devices") or []),
                 },
             }
             profiles.append(profile)
@@ -5573,6 +5642,10 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
 
     async def _build_support_bundle(self, hass: HomeAssistant) -> Dict[str, Any]:
         root = hass.data.get(DOMAIN, {}) or {}
+        try:
+            state_devices, _ = _serialize_devices(root)
+        except Exception:
+            state_devices = []
         bundle = {
             "metadata": {
                 "generated_at": _now_iso(),
@@ -5584,7 +5657,7 @@ class AkuvoxUISupportBundle(AkuvoxUIDiagnostics):
             },
             "settings": self._settings_snapshot(root),
             "sync_queue": self._sync_queue_snapshot(root),
-            "users": self._users_snapshot(root),
+            "users": self._users_snapshot(root, devices=state_devices),
             "face_files": self._face_files_snapshot(hass),
             "devices": self._device_support_snapshot(root),
             "homeassistant_log_tail": await self._homeassistant_log_tail(hass),

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -5165,6 +5165,41 @@ class SyncManager:
         if not filename:
             filename = face_path.name or f"{ha_key}.jpg"
 
+        device_record = existing if isinstance(existing, dict) else None
+        if not device_record or not str(device_record.get("ID") or "").strip():
+            try:
+                matches = await _lookup_device_user_ids_by_ha_key(api, ha_key)
+            except Exception:
+                matches = []
+            if matches:
+                device_record = matches[0]
+
+        delete_records: List[Dict[str, Any]] = []
+        if isinstance(device_record, dict):
+            delete_records.append(device_record)
+        else:
+            try:
+                delete_records = await _lookup_device_user_ids_by_ha_key(api, ha_key)
+            except Exception:
+                delete_records = []
+
+        seen_delete: Set[Tuple[str, str, str]] = set()
+        for rec in delete_records:
+            if not isinstance(rec, dict):
+                continue
+            marker = (
+                str(rec.get("ID") or ""),
+                str(rec.get("UserID") or rec.get("UserId") or ""),
+                str(rec.get("Name") or ""),
+            )
+            if marker in seen_delete:
+                continue
+            seen_delete.add(marker)
+            try:
+                await _delete_user_every_way(api, rec)  # type: ignore[arg-type]
+            except Exception:
+                pass
+
         try:
             upload_result = await api.face_upload(face_bytes, filename=filename)
         except Exception as err:
@@ -5190,23 +5225,17 @@ class SyncManager:
         if not face_device_reference:
             face_device_reference = face_reference
 
-        device_record = existing if isinstance(existing, dict) else None
-        if not device_record or not str(device_record.get("ID") or "").strip():
-            try:
-                matches = await _lookup_device_user_ids_by_ha_key(api, ha_key)
-            except Exception:
-                matches = []
-            if matches:
-                device_record = matches[0]
-
         payload = dict(desired or {})
         payload["FaceUrl"] = face_device_reference
         payload["FaceRegister"] = 1
-        set_payload = _prepare_user_set_payload(ha_key, payload, device_record)
-        set_payload["FaceRegisterStatus"] = "1"
+        add_payload = _prepare_user_add_payload(
+            ha_key,
+            payload,
+            sources=(payload, device_record),
+        )
 
         try:
-            await api.user_set([set_payload])
+            await api.user_add([add_payload])
         except Exception as err:
             _LOGGER.debug("Failed to link uploaded face for %s: %s", ha_key, err)
             try:

--- a/custom_components/akuvox_ac/tests/test_contact_sync.py
+++ b/custom_components/akuvox_ac/tests/test_contact_sync.py
@@ -49,14 +49,18 @@ class _ReplaceApiStub:
 class _FaceApiStub:
     def __init__(self):
         self.upload_calls = []
-        self.set_calls = []
+        self.add_calls = []
+        self.delete_calls = []
 
     async def face_upload(self, face_bytes, *, filename):
         self.upload_calls.append({"bytes": face_bytes, "filename": filename})
         return {"path": "/mnt/Face/HA001.jpg"}
 
-    async def user_set(self, items):
-        self.set_calls.append(items)
+    async def user_delete(self, value):
+        self.delete_calls.append(value)
+
+    async def user_add(self, items):
+        self.add_calls.append(items)
 
 
 class _FaceHassStub:
@@ -264,8 +268,8 @@ def test_upload_face_asset_links_device_import_path(tmp_path):
 
     assert uploaded is True
     assert api.upload_calls == [{"bytes": b"face-bytes", "filename": "HA001.jpg"}]
-    assert api.set_calls[0][0]["ID"] == "42"
-    assert "FaceUrl" not in api.set_calls[0][0]
-    assert api.set_calls[0][0]["FaceFileName"] == "HA001.jpg"
-    assert api.set_calls[0][0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
-    assert api.set_calls[0][0]["FaceRegisterStatus"] == "1"
+    assert api.delete_calls == ["42", "HA001", "Lee Fletcher"]
+    assert "FaceUrl" not in api.add_calls[0][0]
+    assert api.add_calls[0][0]["FaceFileName"] == "HA001.jpg"
+    assert api.add_calls[0][0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
+    assert api.add_calls[0][0]["FaceRegister"] == 1

--- a/custom_components/akuvox_ac/tests/test_dashboard_auth.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_auth.py
@@ -108,6 +108,47 @@ def test_support_bundle_filters_access_history_from_device_requests():
     ]
 
 
+def test_support_bundle_counts_device_face_registration_mismatches():
+    class _UsersStore:
+        def all(self):
+            return {
+                "HA001": {
+                    "name": "Lee Fletcher",
+                    "groups": ["Default"],
+                    "face_status": "active",
+                    "face_url": "/api/AK_AC/FaceData/HA001.jpg",
+                }
+            }
+
+    snapshot = http_module.AkuvoxUISupportBundle._users_snapshot(
+        {"users_store": _UsersStore()},
+        devices=[
+            {
+                "name": "Gate",
+                "type": "Intercom",
+                "participate_in_sync": True,
+                "sync_groups": ["Default"],
+                "users": [
+                    {
+                        "UserID": "HA001",
+                        "Name": "Lee Fletcher",
+                        "FaceUrl": "/mnt/Face/HA001.jpg",
+                        "FaceRegister": "0",
+                    }
+                ],
+            }
+        ],
+    )
+
+    assert snapshot["counts"]["face_active"] == 0
+    assert snapshot["counts"]["face_error"] == 1
+    assert snapshot["counts"]["face_sync_errors"] == 1
+    assert snapshot["profiles"][0]["face"]["status"] == "error"
+    assert snapshot["profiles"][0]["face"]["stored_status"] == "active"
+    assert snapshot["profiles"][0]["face"]["register_mismatch"] is True
+    assert snapshot["profiles"][0]["face"]["matched_devices"] == ["Gate"]
+
+
 def test_dashboard_frontend_does_not_send_bearer_authorization_headers():
     www = Path(http_module.STATIC_ROOT)
 


### PR DESCRIPTION
## Summary
- Recreate the device user around direct face uploads, then link the freshly imported face with the web UI-style `user.add` payload instead of `user.set`.
- Feed live device records into support bundle face counts so device face registration mismatches are counted like the dashboard.
- Keep support diagnostics focused on relevant device/user/face requests while excluding access history noise.

## Why
The 3.6.7 bundle showed dashboard face errors while the support summary still reported `Face error: 0`. The device request diagnostics also showed `user:set` returning `retcode: 28` when trying to link an uploaded `FaceFileName`/`importFile`. The Akuvox web UI flow uploads the face and then creates the user with `user.add`, so this change follows that path for repair/relink attempts.

## Validation
- `python -m py_compile custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_contact_sync.py custom_components/akuvox_ac/tests/test_dashboard_auth.py`
- Focused test functions executed directly with HA stubs: face upload relink flow and support-bundle mismatch count both passed.
- `git diff --check`

Note: local `pytest` is not installed in this runtime (`No module named pytest`), so the focused checks were run directly.