### PR TITLE
Repair active face registration mismatches

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -12,7 +12,7 @@ from functools import partial
 from datetime import timedelta
 from pathlib import Path
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, Optional, Mapping, Set
+from typing import Any, Dict, Iterable, List, Optional, Mapping, Set, Tuple
 from urllib.parse import urlencode, urlsplit, unquote
 
 from aiohttp import web
@@ -2280,9 +2280,6 @@ def _evaluate_face_status(
     if not wants_face:
         return "none"
 
-    if stored_status == "active":
-        return "active"
-
     user_groups = user.get("groups") or []
     relevant_devices = [
         dev
@@ -2295,19 +2292,27 @@ def _evaluate_face_status(
     if not relevant_devices:
         return "active"
 
+    observed: List[Tuple[Dict[str, Any], Optional[Dict[str, Any]]]] = []
     for dev in relevant_devices:
+        record = None
+        for candidate in dev.get("_users") or dev.get("users") or []:
+            candidate_key = normalize_user_id(_user_key(candidate)) or _user_key(candidate)
+            if candidate_key == user_id:
+                record = candidate
+                break
+        if record is not None and _device_face_registration_mismatch(record):
+            return "error"
+        observed.append((dev, record))
+
+    if stored_status == "active":
+        return "active"
+
+    for dev, record in observed:
         if not dev.get("online", True):
             return "pending"
         sync_state = str(dev.get("sync_status") or "").strip().lower()
-        record = None
-        for candidate in dev.get("_users") or dev.get("users") or []:
-            if _user_key(candidate) == user_id:
-                record = candidate
-                break
         if record is None:
             return "pending"
-        if _device_face_registration_mismatch(record):
-            return "error"
         face_active = _device_face_is_active(record)
         if not face_active:
             return "pending"

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -4408,7 +4408,7 @@ class SyncQueue:
                         continue
                     status = str((profile or {}).get("status") or "").strip().lower()
                     face_status = str((profile or {}).get("face_status") or "").strip().lower()
-                    if status == "pending" or face_status == "pending":
+                    if status == "pending" or face_status in {"pending", "error"}:
                         pending_detected = True
                         break
 
@@ -5252,7 +5252,12 @@ class SyncManager:
         try:
             users_store = self._users_store()
             if users_store:
-                await users_store.upsert_profile(ha_key, face_error_count=0)
+                await users_store.upsert_profile(
+                    ha_key,
+                    face_status="pending",
+                    face_synced_at="",
+                    face_error_count=0,
+                )
         except Exception:
             pass
 
@@ -6209,31 +6214,35 @@ class SyncManager:
                             if expected_url or expected_face:
                                 if force_recreate_on_error:
                                     try:
-                                        await self._recreate_user_for_face_mismatch(
+                                        repaired = await self._upload_face_asset_to_device(
                                             api,
+                                            coord,
                                             ha_key,
                                             desired,
-                                            local,
+                                            registry.get(ha_key) or {},
+                                            existing=local,
+                                            force=True,
                                         )
+                                        if not repaired:
+                                            raise RuntimeError("face upload repair did not complete")
                                         try:
-                                            if users_store:
-                                                await users_store.upsert_profile(
-                                                    ha_key,
-                                                    face_status="pending",
-                                                    face_error_count=0,
-                                                )
+                                            coord.users = await api.user_list()
+                                            await _store_device_user_ids(
+                                                getattr(coord, "storage", None),
+                                                coord.users,
+                                            )
                                         except Exception:
                                             pass
                                         try:
                                             coord._append_event(
-                                                f"Recreated {ha_key} due to face sync error state"
+                                                f"Uploaded face for {ha_key} due to face sync error state"
                                             )  # type: ignore[attr-defined]
                                         except Exception:
                                             pass
                                         continue
                                     except Exception as err:
                                         _LOGGER.warning(
-                                            "Failed to recreate user %s after face error state: %s",
+                                            "Failed to repair face upload for %s after face error state: %s",
                                             ha_key,
                                             err,
                                         )
@@ -6241,22 +6250,34 @@ class SyncManager:
                                     error_count = await self._bump_face_error_count(ha_key)
                                     if error_count >= FACE_SYNC_ERROR_THRESHOLD:
                                         try:
-                                            await self._recreate_user_for_face_mismatch(
+                                            repaired = await self._upload_face_asset_to_device(
                                                 api,
+                                                coord,
                                                 ha_key,
                                                 desired,
-                                                local,
+                                                registry.get(ha_key) or {},
+                                                existing=local,
+                                                force=True,
                                             )
-                                            await self._reset_face_error_count(ha_key)
+                                            if not repaired:
+                                                raise RuntimeError("face upload repair did not complete")
+                                            try:
+                                                coord.users = await api.user_list()
+                                                await _store_device_user_ids(
+                                                    getattr(coord, "storage", None),
+                                                    coord.users,
+                                                )
+                                            except Exception:
+                                                pass
                                             try:
                                                 coord._append_event(
-                                                    f"Recreated {ha_key} after {error_count} face sync errors"
+                                                    f"Uploaded face for {ha_key} after {error_count} face sync errors"
                                                 )  # type: ignore[attr-defined]
                                             except Exception:
                                                 pass
                                         except Exception as err:
                                             _LOGGER.warning(
-                                                "Failed to recreate user %s after face sync errors: %s",
+                                                "Failed to repair face upload for %s after face sync errors: %s",
                                                 ha_key,
                                                 err,
                                             )

--- a/custom_components/akuvox_ac/tests/test_contact_sync.py
+++ b/custom_components/akuvox_ac/tests/test_contact_sync.py
@@ -82,6 +82,14 @@ class _FaceHassStub:
         return func(*args)
 
 
+class _UsersStoreStub:
+    def __init__(self):
+        self.upserts = []
+
+    async def upsert_profile(self, key, **kwargs):
+        self.upserts.append((key, kwargs))
+
+
 def _make_manager():
     hass = SimpleNamespace(data={integration.DOMAIN: {}}, config=SimpleNamespace(path=lambda *parts: "/tmp"))
     return integration.SyncManager(hass)
@@ -238,6 +246,8 @@ def test_replace_user_on_device_deletes_existing_before_add():
 
 def test_upload_face_asset_links_device_import_path(tmp_path):
     hass = _FaceHassStub(tmp_path)
+    users_store = _UsersStoreStub()
+    hass.data[integration.DOMAIN]["users_store"] = users_store
     manager = integration.SyncManager(hass)
     api = _FaceApiStub()
     coord = SimpleNamespace(health={"device_type": "intercom"}, events=[], _append_event=lambda item: None)
@@ -273,3 +283,7 @@ def test_upload_face_asset_links_device_import_path(tmp_path):
     assert api.add_calls[0][0]["FaceFileName"] == "HA001.jpg"
     assert api.add_calls[0][0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
     assert api.add_calls[0][0]["FaceRegister"] == 1
+    assert users_store.upserts[-1] == (
+        "HA001",
+        {"face_status": "pending", "face_synced_at": "", "face_error_count": 0},
+    )

--- a/custom_components/akuvox_ac/tests/test_face_status.py
+++ b/custom_components/akuvox_ac/tests/test_face_status.py
@@ -47,6 +47,29 @@ def test_face_status_stays_active_when_stored_active(monkeypatch):
     assert result == "active"
 
 
+def test_face_status_errors_when_stored_active_but_device_register_mismatch():
+    hass = _make_hass()
+    user = {"id": "user1", "face_url": "http://example.invalid/face.jpg"}
+    devices = [
+        {
+            "participate_in_sync": True,
+            "sync_status": "in_sync",
+            "online": True,
+            "users": [
+                {
+                    "UserID": "user1",
+                    "FaceUrl": "/mnt/Face/user1.jpg",
+                    "FaceRegister": "0",
+                }
+            ],
+        }
+    ]
+
+    result = http._evaluate_face_status(hass, user, devices, stored_status="active")
+
+    assert result == "error"
+
+
 def test_face_status_falls_back_to_pending_when_not_stored_active(monkeypatch):
     """When the store is not active we still surface pending state."""
 


### PR DESCRIPTION
## Summary
- Treat device face registration mismatches as `error` even when the stored profile still says the face is `active`.
- Let background sync wake up for face `error` states, not only `pending` states.
- Use the direct face upload/import repair flow from integrity checks instead of a plain user recreate when a face mismatch is detected.
- Mark a successfully re-uploaded face as `pending` until the device confirms it active again.

## Why
The 3.6.8 diagnostics now correctly reported `Face error: 8`, but every affected profile still had `stored_status: active`. The status evaluator returned early for stored-active faces, so the profile never moved into a repairable error/pending state and no new `upload:face` request appeared in diagnostics. The integrity repair path also recreated users without necessarily running the face file import flow.

## Validation
- `python -m py_compile custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_contact_sync.py custom_components/akuvox_ac/tests/test_face_status.py`
- Focused test functions executed directly with HA stubs: face upload relink flow and stored-active registration mismatch handling both passed.
- `git diff --check`

Note: local `pytest` is not installed in this runtime (`No module named pytest`), so the focused checks were run directly.