### PR TITLE
Fix Akuvox face registration payload linking

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -370,6 +370,9 @@ class AkuvoxAPI:
                         _LOGGER.debug("POST %s -> %s / body=%s", url, r.status, txt or data)
                         entry["status"] = r.status
                         entry["ok"] = 200 <= r.status < 400
+                        retcode, _message = self._parse_result_status(data)
+                        if retcode is not None and not _retcode_is_success(retcode):
+                            entry["ok"] = False
                         if txt:
                             entry["response_excerpt"] = _truncate_string(txt)
                         else:
@@ -395,6 +398,9 @@ class AkuvoxAPI:
                         _LOGGER.debug("GET %s -> %s / body=%s", url, r.status, txt or data)
                         entry["status"] = r.status
                         entry["ok"] = 200 <= r.status < 400
+                        retcode, _message = self._parse_result_status(data)
+                        if retcode is not None and not _retcode_is_success(retcode):
+                            entry["ok"] = False
                         if txt:
                             entry["response_excerpt"] = _truncate_string(txt)
                         else:
@@ -882,21 +888,20 @@ class AkuvoxAPI:
 
     @classmethod
     def _apply_face_import_fields(cls, item: Dict[str, Any]) -> None:
-        """Mirror the Akuvox web UI face-link fields when a file was imported."""
+        """Mirror the Akuvox web UI face-link field when a file was imported."""
 
         filename = cls._face_import_filename_from_item(item)
         if not filename:
             return
 
         item["FaceFileName"] = filename
-        item["importFile"] = {"fileName": filename, "fileData": {}}
+        item.pop("importFile", None)
+        item.pop("ImportFile", None)
 
         face_url = item.get("FaceUrl") or item.get("FaceURL")
         if cls._is_device_face_import_reference(face_url):
-            item["FaceUrl"] = cls._normalize_device_face_import_reference(face_url, filename)
+            item.pop("FaceUrl", None)
             item.pop("FaceURL", None)
-        elif face_url in (None, ""):
-            item["FaceUrl"] = f"/mnt/Face/{filename}"
 
     @classmethod
     def _normalize_device_face_import_reference(cls, reference: Any, filename: str) -> str:
@@ -1168,16 +1173,18 @@ class AkuvoxAPI:
                 except Exception:
                     face_source = d.get("FaceUrl")
 
+            self._apply_face_import_fields(d)
             if self._should_force_face_register(face_source):
                 if for_set:
                     current = d.get("FaceRegisterStatus")
                     if self._coerce_int(current) != 1:
                         d["FaceRegisterStatus"] = "1"
+                elif self._face_import_filename_from_item(d):
+                    d.pop("FaceRegister", None)
                 else:
                     current = d.get("FaceRegister")
                     if self._coerce_int(current) != 1:
                         d["FaceRegister"] = 1
-            self._apply_face_import_fields(d)
             if for_set:
                 d.setdefault("PrivatePIN", "")
                 d.setdefault("AnalogNumber", "")
@@ -1364,7 +1371,7 @@ class AkuvoxAPI:
         if action == "del":
             rel_paths = ("/api/user/",)
         elif action == "add":
-            rel_paths = (f"/api/user/{action}",)
+            rel_paths = ("/api/", f"/api/user/{action}")
         elif action == "set":
             rel_paths = (
                 "/api/user/",
@@ -2263,10 +2270,39 @@ class AkuvoxAPI:
         return base
 
     async def face_delete_bulk(self, user_ids: Iterable[str]) -> None:
-        """Delete face images associated with the provided UserID values."""
+        """Delete face images associated with the provided device ID/UserID values."""
 
-        ids = [str(uid).strip() for uid in (user_ids or []) if str(uid).strip()]
+        requested = [str(uid).strip() for uid in (user_ids or []) if str(uid).strip()]
+        if not requested:
+            return
+
+        resolved_ids: Set[str] = set()
+        unresolved: Set[str] = set(requested)
+
+        try:
+            users = await self.user_list()
+        except Exception:
+            users = []
+
+        for value in requested:
+            if value.isdigit():
+                resolved_ids.add(value)
+
+        for record in users or []:
+            if not isinstance(record, dict):
+                continue
+            dev_id = str(record.get("ID") or "").strip()
+            user_id = str(record.get("UserID") or record.get("UserId") or "").strip()
+            name = str(record.get("Name") or "").strip()
+            aliases = {alias for alias in (dev_id, user_id, name) if alias}
+            if aliases & unresolved:
+                if dev_id:
+                    resolved_ids.add(dev_id)
+                unresolved -= aliases
+
+        ids = [str(uid) for uid in dict.fromkeys(resolved_ids) if str(uid)]
         if not ids:
+            _LOGGER.debug("Face delete skipped; no device IDs resolved for %s", requested)
             return
 
         paths = (
@@ -2283,7 +2319,11 @@ class AkuvoxAPI:
                 "data": {"UserID": uid, "UserId": uid},
             }
             try:
-                await self._post_api(payload, rel_paths=paths)
+                result = await self._post_api(payload, rel_paths=paths)
+                retcode, message = self._parse_result_status(result)
+                if not _retcode_is_success(retcode):
+                    detail = f" ({message})" if message else ""
+                    _LOGGER.debug("Face delete returned retcode %s for ID %s%s", retcode, uid, detail)
             except Exception as err:
                 _LOGGER.debug("Face delete failed for %s: %s", uid, err)
 
@@ -2548,10 +2588,11 @@ class AkuvoxAPI:
             if text in (dev_id, user_id, name):
                 if dev_id:
                     target_ids.append(dev_id)
-                if user_id:
-                    face_ids.add(user_id)
+                    face_ids.add(dev_id)
 
         if target_ids:
+            if face_ids:
+                await self.face_delete_bulk(face_ids)
             try:
                 await self._api_user("delete", [{"ID": tid} for tid in target_ids])
             except Exception:
@@ -2571,7 +2612,7 @@ class AkuvoxAPI:
             if deletion_attempted and text:
                 face_ids.add(text)
 
-        if face_ids:
+        if face_ids and not target_ids:
             await self.face_delete_bulk(face_ids)
 
     async def user_delete_bulk(
@@ -2595,9 +2636,11 @@ class AkuvoxAPI:
             wanted_ids = set(ids)
             for u in users or []:
                 dev_id = str(u.get("ID") or "").strip()
-                user_id = str(u.get("UserID") or u.get("UserId") or "").strip()
-                if dev_id and dev_id in wanted_ids and user_id:
-                    face_targets.add(user_id)
+                if dev_id and dev_id in wanted_ids:
+                    face_targets.add(dev_id)
+
+        if face_targets:
+            await self.face_delete_bulk(face_targets)
 
         try:
             await self._api_user("delete", [{"ID": did} for did in ids])
@@ -2607,9 +2650,6 @@ class AkuvoxAPI:
                     await self._api_user("delete", [{"ID": did}])
                 except Exception:
                     pass
-
-        if face_targets:
-            await self.face_delete_bulk(face_targets)
 
     async def user_delete_all(self) -> None:
         try:
@@ -2624,8 +2664,7 @@ class AkuvoxAPI:
             user_id = str(u.get("UserID") or u.get("UserId") or "").strip()
             if dev_id:
                 device_ids.append(dev_id)
-            if user_id:
-                face_ids.add(user_id)
+                face_ids.add(dev_id)
 
         if device_ids:
             await self.user_delete_bulk(device_ids, face_user_ids=face_ids)
@@ -2652,8 +2691,7 @@ class AkuvoxAPI:
             if user_id in wanted or name in wanted or dev_id in wanted:
                 if dev_id:
                     dev_ids.append(dev_id)
-                if user_id:
-                    face_ids.add(str(user_id))
+                    face_ids.add(str(dev_id))
 
         if not dev_ids:
             if face_ids:

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -444,14 +444,22 @@ def _build_face_upload_payload(
 
     if face_reference not in (None, ""):
         reference_text = str(face_reference).strip()
-        payload["FaceUrl"] = reference_text
         filename = face_filename_from_reference(reference_text, user_id)
         if filename:
             payload["FaceFileName"] = filename
-            payload["importFile"] = {"fileName": filename, "fileData": {}}
+        normalized_reference = reference_text.replace("\\", "/").lower()
+        if normalized_reference.startswith("/mnt/face/") or normalized_reference.startswith(
+            "mnt/face/"
+        ):
+            payload.pop("FaceUrl", None)
+        elif reference_text and not filename:
+            payload["FaceUrl"] = reference_text
 
     payload.pop("faceInfo", None)
-    payload["FaceRegister"] = 1
+    if payload.get("FaceUrl"):
+        payload["FaceRegister"] = 1
+    else:
+        payload.pop("FaceRegister", None)
     payload.setdefault("Type", "0")
 
     return payload

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -1255,7 +1255,8 @@ def _apply_face_import_fields(
         return False
 
     payload["FaceFileName"] = filename
-    payload["importFile"] = {"fileName": filename, "fileData": {}}
+    payload.pop("importFile", None)
+    payload.pop("ImportFile", None)
     return True
 
 
@@ -1291,7 +1292,11 @@ def _ensure_face_payload_fields(
         sources=sources,
     )
 
-    if face_url and not (import_linked and (not raw_face_url or _face_reference_is_device_import(raw_face_url))):
+    import_file_link = import_linked and (
+        not raw_face_url or _face_reference_is_device_import(raw_face_url)
+    )
+
+    if face_url and not import_file_link:
         payload["FaceUrl"] = str(face_url)
     elif import_linked:
         payload.pop("FaceUrl", None)
@@ -1316,7 +1321,9 @@ def _ensure_face_payload_fields(
             face_flag = flag
             break
 
-    if face_url and register_value != "1":
+    if import_file_link:
+        payload.pop("FaceRegister", None)
+    elif face_url and register_value != "1":
         payload["FaceRegister"] = 1
     elif face_flag:
         payload["FaceRegister"] = 1
@@ -1478,7 +1485,8 @@ def _prepare_user_set_payload(
 
     if face_filename_value:
         payload["FaceFileName"] = face_filename_value
-        payload["importFile"] = {"fileName": face_filename_value, "fileData": {}}
+        payload.pop("importFile", None)
+        payload.pop("ImportFile", None)
 
     if face_url_value is not None and not (
         face_filename_value and _face_reference_is_device_import(raw_face_url_value)
@@ -5226,8 +5234,11 @@ class SyncManager:
             face_device_reference = face_reference
 
         payload = dict(desired or {})
-        payload["FaceUrl"] = face_device_reference
-        payload["FaceRegister"] = 1
+        payload["FaceFileName"] = filename
+        payload.pop("FaceUrl", None)
+        payload.pop("FaceURL", None)
+        payload.pop("FaceRegister", None)
+        payload.pop("importFile", None)
         add_payload = _prepare_user_add_payload(
             ha_key,
             payload,

--- a/custom_components/akuvox_ac/tests/test_api_face_payload.py
+++ b/custom_components/akuvox_ac/tests/test_api_face_payload.py
@@ -101,7 +101,7 @@ class _FormDataStub:
         self.fields.append((args, kwargs))
 
 
-def test_build_face_upload_payload_includes_legacy_import_fields():
+def test_build_face_upload_payload_links_imported_face_by_filename_only():
     payload = _build_face_upload_payload(
         {"name": "Test User"},
         {"ID": "12", "UserID": "HA001", "Name": "Old Name"},
@@ -109,9 +109,10 @@ def test_build_face_upload_payload_includes_legacy_import_fields():
         "/mnt/Face/HA001.jpg",
     )
 
-    assert payload["FaceUrl"] == "/mnt/Face/HA001.jpg"
     assert payload["FaceFileName"] == "HA001.jpg"
-    assert payload["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
+    assert "FaceUrl" not in payload
+    assert "importFile" not in payload
+    assert "FaceRegister" not in payload
 
 
 def test_normalize_user_add_keeps_face_filename_for_modern_firmware():
@@ -124,9 +125,9 @@ def test_normalize_user_add_keeps_face_filename_for_modern_firmware():
     )
 
     assert normalized[0]["FaceFileName"] == "HA001.jpg"
-    assert normalized[0]["FaceUrl"] == "/mnt/Face/HA001.jpg"
-    assert normalized[0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
-    assert normalized[0]["FaceRegister"] == 1
+    assert "FaceUrl" not in normalized[0]
+    assert "importFile" not in normalized[0]
+    assert "FaceRegister" not in normalized[0]
 
 
 def test_normalize_user_set_uses_web_face_import_fields_for_device_file():
@@ -147,8 +148,8 @@ def test_normalize_user_set_uses_web_face_import_fields_for_device_file():
     )
 
     assert normalized[0]["FaceFileName"] == "HA001.jpg"
-    assert normalized[0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
-    assert normalized[0]["FaceUrl"] == "/mnt/Face/HA001.jpg"
+    assert "importFile" not in normalized[0]
+    assert "FaceUrl" not in normalized[0]
     assert normalized[0]["FaceRegisterStatus"] == "1"
 
 
@@ -169,10 +170,10 @@ def test_normalize_user_add_links_uploaded_face_with_device_path():
         for_set=False,
     )
 
-    assert normalized[0]["FaceUrl"] == "/mnt/Face/CODEXFACE2.jpg"
     assert normalized[0]["FaceFileName"] == "CODEXFACE2.jpg"
-    assert normalized[0]["importFile"] == {"fileName": "CODEXFACE2.jpg", "fileData": {}}
-    assert normalized[0]["FaceRegister"] == 1
+    assert "FaceUrl" not in normalized[0]
+    assert "importFile" not in normalized[0]
+    assert "FaceRegister" not in normalized[0]
 
 
 def test_normalize_user_set_preserves_face_url_field():

--- a/custom_components/akuvox_ac/tests/test_contact_sync.py
+++ b/custom_components/akuvox_ac/tests/test_contact_sync.py
@@ -281,8 +281,8 @@ def test_upload_face_asset_links_device_import_path(tmp_path):
     assert api.delete_calls == ["42", "HA001", "Lee Fletcher"]
     assert "FaceUrl" not in api.add_calls[0][0]
     assert api.add_calls[0][0]["FaceFileName"] == "HA001.jpg"
-    assert api.add_calls[0][0]["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
-    assert api.add_calls[0][0]["FaceRegister"] == 1
+    assert "importFile" not in api.add_calls[0][0]
+    assert "FaceRegister" not in api.add_calls[0][0]
     assert users_store.upserts[-1] == (
         "HA001",
         {"face_status": "pending", "face_synced_at": "", "face_error_count": 0},

--- a/custom_components/akuvox_ac/tests/test_paused_user_sync.py
+++ b/custom_components/akuvox_ac/tests/test_paused_user_sync.py
@@ -95,7 +95,7 @@ def test_prepare_user_set_payload_links_uploaded_face_like_web_ui():
 
     assert "FaceUrl" not in payload
     assert payload["FaceFileName"] == "HA001.jpg"
-    assert payload["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
+    assert "importFile" not in payload
     assert payload["FaceRegisterStatus"] == "1"
 
 
@@ -112,8 +112,8 @@ def test_prepare_user_add_payload_links_uploaded_face_like_web_ui():
 
     assert "FaceUrl" not in payload
     assert payload["FaceFileName"] == "HA001.jpg"
-    assert payload["importFile"] == {"fileName": "HA001.jpg", "fileData": {}}
-    assert payload["FaceRegister"] == 1
+    assert "importFile" not in payload
+    assert "FaceRegister" not in payload
 
 
 def test_record_matches_desired_fields_treats_face_register_status_as_registered():


### PR DESCRIPTION
## Summary
- Match the Akuvox web UI face registration flow after `filetool/import`: link the uploaded image by `FaceFileName` only, without synthesizing `/mnt/Face/...` into `FaceUrl`, without `importFile`, and without forcing `FaceRegister` on `user.add`.
- Send `user.add` through the generic `/api/` endpoint first, matching the browser flow that successfully registered the disposable face test user.
- Resolve face deletions to the device numeric `ID` before calling `face/del`, and mark API diagnostics with failed JSON `retcode` values as unsuccessful even when HTTP status is 200.
- Update face payload tests so the expected payload matches the live device behavior.

## Live Device Checks
- Direct Home Assistant URL in `FaceUrl` was accepted with `retcode: 0`, but after polling it still left `FaceRegister: "0"`, so it does not activate face registration on this unit.
- Browser-style upload to `/api/web/filetool/import?destFile=Face&index=` followed by generic `/api/` `user.add` with `FaceFileName` only returned `retcode: 0`; the disposable user record came back with `FaceRegister: "1"` and an empty `FaceUrl`.
- `face/del` with the numeric device `ID` returned `retcode: 0`; the previous HA `UserID` payload was the source of the `error param` response.
- Disposable test users were cleaned up after the checks.

## Testing
- `python -m py_compile custom_components/akuvox_ac/api.py custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/http.py`
- `git diff --check`
- Focused live API checks for face upload/linking and numeric-ID face deletion

Full pytest was not available in the bundled Python runtime (`No module named pytest`).