### PR TITLE
feat: add scheduled device reboots

### DIFF
--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -32,6 +32,7 @@ CONF_PARTICIPATE   = "participate_in_sync"
 CONF_POLL_INTERVAL = "poll_interval"
 CONF_DEVICE_GROUPS = "device_groups"
 CONF_RELAY_ROLES  = "relay_roles"
+CONF_AUTO_REBOOT = "auto_reboot"
 
 # Relay roles
 RELAY_ROLE_NONE       = "none"

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -37,6 +37,7 @@ from .const import (
     DOMAIN,
     CONF_DEVICE_GROUPS,
     CONF_RELAY_ROLES,
+    CONF_AUTO_REBOOT,
     INTEGRATION_VERSION,
     INTEGRATION_VERSION_LABEL,
     DEFAULT_DIAGNOSTICS_HISTORY_LIMIT,
@@ -56,6 +57,7 @@ from .const import (
 from .relay import alarm_capable as relay_alarm_capable, normalize_roles as normalize_relay_roles
 from .ha_id import ha_id_from_int, is_ha_id, normalize_ha_id, normalize_user_id
 from .access_history import AccessHistory, categorize_event
+from .reboot_schedule import normalize_reboot_schedule
 
 COMPONENT_ROOT = Path(__file__).parent
 STATIC_ROOT = COMPONENT_ROOT / "www"
@@ -3019,6 +3021,7 @@ def _serialize_devices(root: Dict[str, Any]) -> tuple[List[Dict[str, Any]], bool
             "participate_in_sync": bool(opts.get("participate_in_sync", True)),
             "sync_groups": list(opts.get("sync_groups") or ["Default"]),
             "relay_roles": relay_roles,
+            CONF_AUTO_REBOOT: normalize_reboot_schedule(opts.get(CONF_AUTO_REBOOT)),
         }
         dev["alarm_capable"] = relay_alarm_capable(relay_roles)
         devices.append(dev)
@@ -3893,6 +3896,35 @@ class AkuvoxUIAction(AkuvoxUIView):
                     except Exception:
                         pass
                 return web.json_response({"ok": True, "exit_device": enabled})
+            except Exception as e:
+                return err(e)
+
+        if action == "set_device_auto_reboot":
+            if not entry_id:
+                return err("entry_id required")
+            try:
+                schedule = normalize_reboot_schedule(payload, strict=True)
+                bucket = root.get(entry_id)
+                if not isinstance(bucket, dict):
+                    return err("device entry not found", code=404)
+                entry_obj = hass.config_entries.async_get_entry(entry_id)
+                if not entry_obj:
+                    return err("device entry not found", code=404)
+                opts = bucket.get("options")
+                if not isinstance(opts, dict):
+                    opts = {}
+                    bucket["options"] = opts
+                opts[CONF_AUTO_REBOOT] = schedule
+
+                new_options = dict(entry_obj.options)
+                new_options[CONF_AUTO_REBOOT] = schedule
+                hass.config_entries.async_update_entry(entry_obj, options=new_options)
+
+                manager = root.get("sync_manager")
+                if manager and hasattr(manager, "_scheduled_reboot_last_run"):
+                    manager._scheduled_reboot_last_run.pop(entry_id, None)
+
+                return web.json_response({"ok": True, "auto_reboot": schedule})
             except Exception as e:
                 return err(e)
 

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -54,6 +54,7 @@ from .const import (
     CONF_POLL_INTERVAL,
     CONF_DEVICE_GROUPS,
     CONF_RELAY_ROLES,
+    CONF_AUTO_REBOOT,
     ENTRY_VERSION,
     ADMIN_DASHBOARD_ICON,
     ADMIN_DASHBOARD_TITLE,
@@ -69,6 +70,7 @@ from .relay import (
 )
 
 from .api import AkuvoxAPI
+from .reboot_schedule import normalize_reboot_schedule, reboot_schedule_is_due
 from .coordinator import AkuvoxCoordinator
 from .access_history import AccessHistory
 from .http import (
@@ -4777,7 +4779,12 @@ class SyncManager:
         self._face_enroll_poll_interval_seconds = 3.0
         self._face_enroll_poll_timeout_seconds = 45.0
         self._apply_integrity_interval(self._integrity_minutes)
-        self._reboot_unsub = None
+        self._scheduled_reboot_last_run: Dict[str, str] = {}
+        self._reboot_unsub = async_track_time_change(
+            hass,
+            self._scheduled_reboot_cb,
+            second=0,
+        )
         self._interval_unsub = async_track_time_interval(
             hass,
             self._interval_sync_cb,
@@ -5962,6 +5969,38 @@ class SyncManager:
         settings: AkuvoxSettingsStore = self._settings_store()
         self.hass.async_create_task(settings.set_auto_reboot(time_hhmm, days))
 
+    async def _scheduled_reboot_cb(self, now: datetime):
+        active_entry_ids: Set[str] = set()
+        for entry_id, coord, api, opts in self._devices():
+            active_entry_ids.add(entry_id)
+            schedule = normalize_reboot_schedule(opts.get(CONF_AUTO_REBOOT))
+            if not reboot_schedule_is_due(schedule, now):
+                continue
+
+            slot = f"{now.date().isoformat()}T{schedule['time']}"
+            if self._scheduled_reboot_last_run.get(entry_id) == slot:
+                continue
+            self._scheduled_reboot_last_run[entry_id] = slot
+
+            try:
+                await api.system_reboot()
+            except Exception as err:
+                _LOGGER.warning("Scheduled reboot failed for %s: %s", entry_id, err)
+                try:
+                    coord._append_event(f"Scheduled reboot failed: {err}")  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+                continue
+
+            _mark_coordinator_rebooting(coord, triggered_by="automatic schedule")
+            try:
+                await coord.async_request_refresh()
+            except Exception:
+                pass
+
+        for entry_id in set(self._scheduled_reboot_last_run) - active_entry_ids:
+            self._scheduled_reboot_last_run.pop(entry_id, None)
+
     async def add_missing_users(self, entry_id: Optional[str] = None):
         targets: List[Tuple[str, AkuvoxCoordinator]] = []
         for entry, coord, *_ in self._devices():
@@ -7107,6 +7146,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     initial_groups = list(cfg.get(CONF_DEVICE_GROUPS, ["Default"])) or ["Default"]
     exit_device = bool(cfg.get("exit_device", False))
+    auto_reboot = normalize_reboot_schedule(cfg.get(CONF_AUTO_REBOOT))
 
     root[entry.entry_id] = {
         "api": api,
@@ -7117,6 +7157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "sync_groups": initial_groups,
             "exit_device": exit_device,
             "relay_roles": relay_roles,
+            CONF_AUTO_REBOOT: auto_reboot,
         },
     }
 
@@ -7924,12 +7965,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 "relay_b": new_cfg.get("relay_b_role"),
             }
         new_relay_roles = normalize_relay_roles(raw_roles, new_cfg.get(CONF_DEVICE_TYPE, "Intercom"))
+        new_auto_reboot = normalize_reboot_schedule(new_cfg.get(CONF_AUTO_REBOOT))
         hass.data[DOMAIN][entry.entry_id]["options"].update(
             {
                 "participate_in_sync": bool(new_cfg.get(CONF_PARTICIPATE, True)),
                 "sync_groups": new_groups,
                 "exit_device": bool(new_cfg.get("exit_device", False)),
                 "relay_roles": new_relay_roles,
+                CONF_AUTO_REBOOT: new_auto_reboot,
             }
         )
 

--- a/custom_components/akuvox_ac/reboot_schedule.py
+++ b/custom_components/akuvox_ac/reboot_schedule.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any, Dict
+
+DEFAULT_REBOOT_TIME = "03:00"
+REBOOT_DAY_KEYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+_DAY_ALIASES = {
+    "mon": "mon",
+    "monday": "mon",
+    "tue": "tue",
+    "tues": "tue",
+    "tuesday": "tue",
+    "wed": "wed",
+    "wednesday": "wed",
+    "thu": "thu",
+    "thur": "thu",
+    "thurs": "thu",
+    "thursday": "thu",
+    "fri": "fri",
+    "friday": "fri",
+    "sat": "sat",
+    "saturday": "sat",
+    "sun": "sun",
+    "sunday": "sun",
+}
+
+
+def _normalize_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _normalize_time(value: Any, *, strict: bool) -> str:
+    text = str(value or DEFAULT_REBOOT_TIME).strip()
+    match = re.fullmatch(r"(\d{1,2}):(\d{2})", text)
+    if not match:
+        if strict:
+            raise ValueError("Reboot time must use HH:MM format")
+        return DEFAULT_REBOOT_TIME
+
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    if hour > 23 or minute > 59:
+        if strict:
+            raise ValueError("Reboot time is outside the valid 24-hour range")
+        return DEFAULT_REBOOT_TIME
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _normalize_days(value: Any, *, strict: bool) -> list[str]:
+    if value in (None, ""):
+        raw_days = []
+    elif isinstance(value, str):
+        raw_days = [value]
+    elif isinstance(value, (list, tuple, set)):
+        raw_days = list(value)
+    else:
+        if strict:
+            raise ValueError("Reboot days must be a list")
+        raw_days = []
+
+    selected = set()
+    for raw_day in raw_days:
+        normalized = _DAY_ALIASES.get(str(raw_day or "").strip().lower())
+        if normalized:
+            selected.add(normalized)
+        elif strict:
+            raise ValueError(f"Invalid reboot day: {raw_day}")
+
+    return [day for day in REBOOT_DAY_KEYS if day in selected]
+
+
+def normalize_reboot_schedule(value: Any, *, strict: bool = False) -> Dict[str, Any]:
+    raw = dict(value) if isinstance(value, Mapping) else {}
+    enabled = _normalize_enabled(raw.get("enabled", False))
+    schedule = {
+        "enabled": enabled,
+        "time": _normalize_time(raw.get("time"), strict=strict),
+        "days": _normalize_days(raw.get("days"), strict=strict),
+    }
+    if schedule["enabled"] and not schedule["days"]:
+        if strict:
+            raise ValueError("Select at least one reboot day")
+        schedule["enabled"] = False
+    return schedule
+
+
+def reboot_schedule_is_due(value: Any, now: datetime) -> bool:
+    schedule = normalize_reboot_schedule(value)
+    if not schedule["enabled"]:
+        return False
+    return (
+        now.strftime("%a").lower() in schedule["days"]
+        and now.strftime("%H:%M") == schedule["time"]
+    )

--- a/custom_components/akuvox_ac/tests/test_auto_reboot.py
+++ b/custom_components/akuvox_ac/tests/test_auto_reboot.py
@@ -1,0 +1,135 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import custom_components.akuvox_ac.integration as integration
+from custom_components.akuvox_ac.const import CONF_AUTO_REBOOT, DOMAIN
+from custom_components.akuvox_ac.reboot_schedule import (
+    normalize_reboot_schedule,
+    reboot_schedule_is_due,
+)
+
+
+class _ApiStub:
+    def __init__(self):
+        self.reboot_calls = 0
+
+    async def system_reboot(self):
+        self.reboot_calls += 1
+
+
+class _CoordinatorStub:
+    def __init__(self):
+        self.health = {"online": True, "status": "online"}
+        self.events = []
+        self.refresh_calls = 0
+
+    def _append_event(self, event):
+        self.events.append(event)
+
+    async def async_request_refresh(self):
+        self.refresh_calls += 1
+
+
+def test_reboot_schedule_defaults_off():
+    assert normalize_reboot_schedule(None) == {
+        "enabled": False,
+        "time": "03:00",
+        "days": [],
+    }
+
+
+def test_reboot_schedule_normalizes_days_and_time():
+    assert normalize_reboot_schedule(
+        {
+            "enabled": True,
+            "time": "3:05",
+            "days": ["Thursday", "tues", "Tuesday"],
+        },
+        strict=True,
+    ) == {
+        "enabled": True,
+        "time": "03:05",
+        "days": ["tue", "thu"],
+    }
+
+
+@pytest.mark.parametrize(
+    "schedule,error",
+    [
+        ({"enabled": True, "time": "25:00", "days": ["tue"]}, "24-hour"),
+        ({"enabled": True, "time": "03:00", "days": []}, "at least one"),
+        ({"enabled": True, "time": "03:00", "days": ["noday"]}, "Invalid reboot day"),
+    ],
+)
+def test_reboot_schedule_rejects_invalid_enabled_values(schedule, error):
+    with pytest.raises(ValueError, match=error):
+        normalize_reboot_schedule(schedule, strict=True)
+
+
+def test_reboot_schedule_due_uses_weekday_and_time():
+    schedule = {
+        "enabled": True,
+        "time": "03:00",
+        "days": ["tue", "thu"],
+    }
+    assert reboot_schedule_is_due(schedule, datetime(2026, 6, 9, 3, 0))
+    assert not reboot_schedule_is_due(schedule, datetime(2026, 6, 9, 3, 1))
+    assert not reboot_schedule_is_due(schedule, datetime(2026, 6, 10, 3, 0))
+
+
+def test_scheduled_reboot_targets_only_due_device_once_per_slot():
+    due_api = _ApiStub()
+    due_coord = _CoordinatorStub()
+    other_api = _ApiStub()
+    other_coord = _CoordinatorStub()
+    root = {
+        "due": {
+            "api": due_api,
+            "coordinator": due_coord,
+            "options": {
+                CONF_AUTO_REBOOT: {
+                    "enabled": True,
+                    "time": "03:00",
+                    "days": ["tue", "thu"],
+                }
+            },
+        },
+        "other": {
+            "api": other_api,
+            "coordinator": other_coord,
+            "options": {
+                CONF_AUTO_REBOOT: {
+                    "enabled": True,
+                    "time": "03:00",
+                    "days": ["wed"],
+                }
+            },
+        },
+    }
+    manager = object.__new__(integration.SyncManager)
+    manager.hass = SimpleNamespace(data={DOMAIN: root})
+    manager._scheduled_reboot_last_run = {}
+
+    scheduled_time = datetime(2026, 6, 9, 3, 0)
+    asyncio.run(manager._scheduled_reboot_cb(scheduled_time))
+    asyncio.run(manager._scheduled_reboot_cb(scheduled_time))
+
+    assert due_api.reboot_calls == 1
+    assert due_coord.refresh_calls == 1
+    assert due_coord.health["status"] == "rebooting"
+    assert any("automatic schedule" in event for event in due_coord.events)
+    assert other_api.reboot_calls == 0
+    assert other_coord.refresh_calls == 0
+
+
+def test_device_edit_templates_include_auto_reboot_controls():
+    www = Path(__file__).resolve().parents[1] / "www"
+    for filename in ("device_edit.html", "device_edit-mob.html"):
+        html = (www / filename).read_text(encoding="utf-8")
+        assert 'id="autoRebootToggle"' in html
+        assert 'id="autoRebootTime"' in html
+        assert "set_device_auto_reboot" in html

--- a/custom_components/akuvox_ac/www/device_edit-mob.html
+++ b/custom_components/akuvox_ac/www/device_edit-mob.html
@@ -82,6 +82,42 @@
     </div>
   </div>
 
+  <!-- Automatic reboot -->
+  <div class="card mb-3" id="autoRebootCard">
+    <div class="card-header">Automatic Reboot</div>
+    <div class="card-body">
+      <div class="form-check form-switch mb-3">
+        <input class="form-check-input" type="checkbox" role="switch" id="autoRebootToggle">
+        <label class="form-check-label" for="autoRebootToggle">Enable scheduled reboots for this device</label>
+      </div>
+      <div class="row g-3 align-items-end">
+        <div class="col-sm-5 col-lg-4">
+          <label class="form-label" for="autoRebootTime">Reboot time</label>
+          <input class="form-control" type="time" id="autoRebootTime" value="03:00" step="60">
+        </div>
+        <div class="col-12">
+          <div class="form-label mb-2">Reboot days</div>
+          <div class="d-flex flex-wrap gap-3" id="autoRebootDays">
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="mon" id="rebootMon"><label class="form-check-label" for="rebootMon">Mon</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="tue" id="rebootTue"><label class="form-check-label" for="rebootTue">Tue</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="wed" id="rebootWed"><label class="form-check-label" for="rebootWed">Wed</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="thu" id="rebootThu"><label class="form-check-label" for="rebootThu">Thu</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="fri" id="rebootFri"><label class="form-check-label" for="rebootFri">Fri</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="sat" id="rebootSat"><label class="form-check-label" for="rebootSat">Sat</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="sun" id="rebootSun"><label class="form-check-label" for="rebootSun">Sun</label></div>
+          </div>
+        </div>
+      </div>
+      <div class="form-text mt-3">The schedule uses Home Assistant's local time zone.</div>
+      <div class="d-flex align-items-center gap-3 mt-3">
+        <button class="btn btn-primary" id="btnSaveAutoReboot">
+          <i class="bi bi-calendar-check"></i> Save reboot schedule
+        </button>
+        <div class="form-text mt-0" id="autoRebootStatus"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- Groups editor -->
   <div class="card" id="groupsCard">
     <div class="card-header d-flex align-items-center justify-content-between">
@@ -671,6 +707,7 @@ let CURRENT_DEVICE = null;
 let relayStatusTimer = null;
 let relaySaving = false;
 let exitSaving = false;
+let autoRebootSaving = false;
 
 function relayValueNormalized(value, fallback = 'door'){
   const raw = (value ?? '').toString().trim().toLowerCase();
@@ -852,6 +889,102 @@ async function handleExitToggleChange(){
   }
 }
 
+const AUTO_REBOOT_DAY_ORDER = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+
+function normalizeAutoReboot(schedule){
+  const raw = schedule && typeof schedule === 'object' ? schedule : {};
+  const days = Array.isArray(raw.days)
+    ? AUTO_REBOOT_DAY_ORDER.filter(day => raw.days.includes(day))
+    : [];
+  return {
+    enabled: !!raw.enabled,
+    time: /^\d{2}:\d{2}$/.test(String(raw.time || '')) ? String(raw.time) : '03:00',
+    days
+  };
+}
+
+function selectedAutoRebootDays(){
+  return Array.from(document.querySelectorAll('.auto-reboot-day:checked'))
+    .map(input => input.value)
+    .filter(day => AUTO_REBOOT_DAY_ORDER.includes(day));
+}
+
+function setAutoRebootStatus(text, tone = 'muted'){
+  const status = document.getElementById('autoRebootStatus');
+  if (!status) return;
+  status.textContent = text || '';
+  status.className = 'form-text mt-0';
+  if (tone === 'error') status.classList.add('text-danger');
+  else if (tone === 'success') status.classList.add('text-success');
+  else status.classList.add('text-muted');
+}
+
+function updateAutoRebootControls(){
+  const enabled = !!document.getElementById('autoRebootToggle')?.checked;
+  const timeInput = document.getElementById('autoRebootTime');
+  if (timeInput) timeInput.disabled = !enabled || autoRebootSaving;
+  document.querySelectorAll('.auto-reboot-day').forEach(input => {
+    input.disabled = !enabled || autoRebootSaving;
+  });
+}
+
+function applyAutoRebootUI(schedule){
+  const normalized = normalizeAutoReboot(schedule);
+  const toggle = document.getElementById('autoRebootToggle');
+  const timeInput = document.getElementById('autoRebootTime');
+  if (toggle) toggle.checked = normalized.enabled;
+  if (timeInput) timeInput.value = normalized.time;
+  document.querySelectorAll('.auto-reboot-day').forEach(input => {
+    input.checked = normalized.days.includes(input.value);
+  });
+  updateAutoRebootControls();
+}
+
+async function saveAutoReboot(){
+  if (autoRebootSaving || !CURRENT_DEVICE) return;
+  const toggle = document.getElementById('autoRebootToggle');
+  const timeInput = document.getElementById('autoRebootTime');
+  const saveButton = document.getElementById('btnSaveAutoReboot');
+  const payload = {
+    enabled: !!toggle?.checked,
+    time: timeInput?.value || '03:00',
+    days: selectedAutoRebootDays()
+  };
+  if (payload.enabled && !payload.days.length){
+    setAutoRebootStatus('Select at least one reboot day.', 'error');
+    return;
+  }
+
+  autoRebootSaving = true;
+  if (toggle) toggle.disabled = true;
+  if (saveButton) saveButton.disabled = true;
+  updateAutoRebootControls();
+  setAutoRebootStatus('Saving…');
+  try {
+    const res = await apiPost(actionUrl, {
+      action: 'set_device_auto_reboot',
+      entry_id: ENTRY_ID,
+      payload
+    });
+    CURRENT_DEVICE.auto_reboot = normalizeAutoReboot(res?.auto_reboot || payload);
+    applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
+    setAutoRebootStatus(
+      CURRENT_DEVICE.auto_reboot.enabled ? 'Schedule saved ✓' : 'Automatic reboot is off',
+      'success'
+    );
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
+    setAutoRebootStatus('Save failed', 'error');
+    alert('Failed to update automatic reboot schedule: ' + (err && err.message ? err.message : err));
+  } finally {
+    autoRebootSaving = false;
+    if (toggle) toggle.disabled = false;
+    if (saveButton) saveButton.disabled = false;
+    updateAutoRebootControls();
+  }
+}
+
 /* API-ish helpers built atop /state and /action */
 async function getState(){ return apiGet(stateUrl); }
 async function getDevice(){
@@ -864,6 +997,7 @@ async function getDevice(){
     relay_b: relayValueNormalized(roles.relay_b, 'none')
   };
   dev.exit_device = !!dev.exit_device;
+  dev.auto_reboot = normalizeAutoReboot(dev.auto_reboot);
   if (typeof dev.alarm_capable === 'boolean') dev.alarm_capable = !!dev.alarm_capable;
   else dev.alarm_capable = computeAlarmCapable(dev);
   // Current groups: prefer sync_groups → groups → Default
@@ -902,12 +1036,19 @@ async function init(){
         relay_b: dev.relay_roles?.relay_b || 'none'
       },
       exit_device: !!dev.exit_device,
+      auto_reboot: normalizeAutoReboot(dev.auto_reboot),
       alarm_capable: computeAlarmCapable(dev)
     };
     applyRelayUI(CURRENT_DEVICE);
+    applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
     document.getElementById('relayASelect')?.addEventListener('change', saveRelayRoles);
     document.getElementById('relayBSelect')?.addEventListener('change', saveRelayRoles);
     document.getElementById('exitDeviceToggle')?.addEventListener('change', handleExitToggleChange);
+    document.getElementById('autoRebootToggle')?.addEventListener('change', () => {
+      updateAutoRebootControls();
+      setAutoRebootStatus('');
+    });
+    document.getElementById('btnSaveAutoReboot')?.addEventListener('click', saveAutoReboot);
 
     const onlyDefault = Array.isArray(allGroups) && allGroups.length <= 1;
 

--- a/custom_components/akuvox_ac/www/device_edit.html
+++ b/custom_components/akuvox_ac/www/device_edit.html
@@ -82,6 +82,42 @@
     </div>
   </div>
 
+  <!-- Automatic reboot -->
+  <div class="card mb-3" id="autoRebootCard">
+    <div class="card-header">Automatic Reboot</div>
+    <div class="card-body">
+      <div class="form-check form-switch mb-3">
+        <input class="form-check-input" type="checkbox" role="switch" id="autoRebootToggle">
+        <label class="form-check-label text-white" for="autoRebootToggle">Enable scheduled reboots for this device</label>
+      </div>
+      <div class="row g-3 align-items-end">
+        <div class="col-sm-5 col-lg-4">
+          <label class="form-label text-white" for="autoRebootTime">Reboot time</label>
+          <input class="form-control" type="time" id="autoRebootTime" value="03:00" step="60">
+        </div>
+        <div class="col-12">
+          <div class="form-label text-white mb-2">Reboot days</div>
+          <div class="d-flex flex-wrap gap-3" id="autoRebootDays">
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="mon" id="rebootMon"><label class="form-check-label" for="rebootMon">Mon</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="tue" id="rebootTue"><label class="form-check-label" for="rebootTue">Tue</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="wed" id="rebootWed"><label class="form-check-label" for="rebootWed">Wed</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="thu" id="rebootThu"><label class="form-check-label" for="rebootThu">Thu</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="fri" id="rebootFri"><label class="form-check-label" for="rebootFri">Fri</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="sat" id="rebootSat"><label class="form-check-label" for="rebootSat">Sat</label></div>
+            <div class="form-check"><input class="form-check-input auto-reboot-day" type="checkbox" value="sun" id="rebootSun"><label class="form-check-label" for="rebootSun">Sun</label></div>
+          </div>
+        </div>
+      </div>
+      <div class="form-text mt-3">The schedule uses Home Assistant's local time zone.</div>
+      <div class="d-flex align-items-center gap-3 mt-3">
+        <button class="btn btn-primary" id="btnSaveAutoReboot">
+          <i class="bi bi-calendar-check"></i> Save reboot schedule
+        </button>
+        <div class="form-text mt-0" id="autoRebootStatus"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- Groups editor -->
   <div class="card" id="groupsCard">
     <div class="card-header d-flex align-items-center justify-content-between">
@@ -674,6 +710,7 @@ let CURRENT_DEVICE = null;
 let relayStatusTimer = null;
 let relaySaving = false;
 let exitSaving = false;
+let autoRebootSaving = false;
 
 function relayValueNormalized(value, fallback = 'door'){
   const raw = (value ?? '').toString().trim().toLowerCase();
@@ -855,6 +892,102 @@ async function handleExitToggleChange(){
   }
 }
 
+const AUTO_REBOOT_DAY_ORDER = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+
+function normalizeAutoReboot(schedule){
+  const raw = schedule && typeof schedule === 'object' ? schedule : {};
+  const days = Array.isArray(raw.days)
+    ? AUTO_REBOOT_DAY_ORDER.filter(day => raw.days.includes(day))
+    : [];
+  return {
+    enabled: !!raw.enabled,
+    time: /^\d{2}:\d{2}$/.test(String(raw.time || '')) ? String(raw.time) : '03:00',
+    days
+  };
+}
+
+function selectedAutoRebootDays(){
+  return Array.from(document.querySelectorAll('.auto-reboot-day:checked'))
+    .map(input => input.value)
+    .filter(day => AUTO_REBOOT_DAY_ORDER.includes(day));
+}
+
+function setAutoRebootStatus(text, tone = 'muted'){
+  const status = document.getElementById('autoRebootStatus');
+  if (!status) return;
+  status.textContent = text || '';
+  status.className = 'form-text mt-0';
+  if (tone === 'error') status.classList.add('text-danger');
+  else if (tone === 'success') status.classList.add('text-success');
+  else status.classList.add('text-muted');
+}
+
+function updateAutoRebootControls(){
+  const enabled = !!document.getElementById('autoRebootToggle')?.checked;
+  const timeInput = document.getElementById('autoRebootTime');
+  if (timeInput) timeInput.disabled = !enabled || autoRebootSaving;
+  document.querySelectorAll('.auto-reboot-day').forEach(input => {
+    input.disabled = !enabled || autoRebootSaving;
+  });
+}
+
+function applyAutoRebootUI(schedule){
+  const normalized = normalizeAutoReboot(schedule);
+  const toggle = document.getElementById('autoRebootToggle');
+  const timeInput = document.getElementById('autoRebootTime');
+  if (toggle) toggle.checked = normalized.enabled;
+  if (timeInput) timeInput.value = normalized.time;
+  document.querySelectorAll('.auto-reboot-day').forEach(input => {
+    input.checked = normalized.days.includes(input.value);
+  });
+  updateAutoRebootControls();
+}
+
+async function saveAutoReboot(){
+  if (autoRebootSaving || !CURRENT_DEVICE) return;
+  const toggle = document.getElementById('autoRebootToggle');
+  const timeInput = document.getElementById('autoRebootTime');
+  const saveButton = document.getElementById('btnSaveAutoReboot');
+  const payload = {
+    enabled: !!toggle?.checked,
+    time: timeInput?.value || '03:00',
+    days: selectedAutoRebootDays()
+  };
+  if (payload.enabled && !payload.days.length){
+    setAutoRebootStatus('Select at least one reboot day.', 'error');
+    return;
+  }
+
+  autoRebootSaving = true;
+  if (toggle) toggle.disabled = true;
+  if (saveButton) saveButton.disabled = true;
+  updateAutoRebootControls();
+  setAutoRebootStatus('Saving…');
+  try {
+    const res = await apiPost(actionUrl, {
+      action: 'set_device_auto_reboot',
+      entry_id: ENTRY_ID,
+      payload
+    });
+    CURRENT_DEVICE.auto_reboot = normalizeAutoReboot(res?.auto_reboot || payload);
+    applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
+    setAutoRebootStatus(
+      CURRENT_DEVICE.auto_reboot.enabled ? 'Schedule saved ✓' : 'Automatic reboot is off',
+      'success'
+    );
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
+    setAutoRebootStatus('Save failed', 'error');
+    alert('Failed to update automatic reboot schedule: ' + (err && err.message ? err.message : err));
+  } finally {
+    autoRebootSaving = false;
+    if (toggle) toggle.disabled = false;
+    if (saveButton) saveButton.disabled = false;
+    updateAutoRebootControls();
+  }
+}
+
 /* API-ish helpers built atop /state and /action */
 async function getState(){ return apiGet(stateUrl); }
 async function getDevice(){
@@ -867,6 +1000,7 @@ async function getDevice(){
     relay_b: relayValueNormalized(roles.relay_b, 'none')
   };
   dev.exit_device = !!dev.exit_device;
+  dev.auto_reboot = normalizeAutoReboot(dev.auto_reboot);
   if (typeof dev.alarm_capable === 'boolean') dev.alarm_capable = !!dev.alarm_capable;
   else dev.alarm_capable = computeAlarmCapable(dev);
   // Current groups: prefer sync_groups → groups → Default
@@ -905,12 +1039,19 @@ async function init(){
         relay_b: dev.relay_roles?.relay_b || 'none'
       },
       exit_device: !!dev.exit_device,
+      auto_reboot: normalizeAutoReboot(dev.auto_reboot),
       alarm_capable: computeAlarmCapable(dev)
     };
     applyRelayUI(CURRENT_DEVICE);
+    applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
     document.getElementById('relayASelect')?.addEventListener('change', saveRelayRoles);
     document.getElementById('relayBSelect')?.addEventListener('change', saveRelayRoles);
     document.getElementById('exitDeviceToggle')?.addEventListener('change', handleExitToggleChange);
+    document.getElementById('autoRebootToggle')?.addEventListener('change', () => {
+      updateAutoRebootControls();
+      setAutoRebootStatus('');
+    });
+    document.getElementById('btnSaveAutoReboot')?.addEventListener('click', saveAutoReboot);
 
     const onlyDefault = Array.isArray(allGroups) && allGroups.length <= 1;
 

--- a/scripts/release-pr-version.cjs
+++ b/scripts/release-pr-version.cjs
@@ -81,6 +81,38 @@ function compareVersions(left, right) {
   return 0;
 }
 
+function nextVersion(previousTag, pr) {
+  const parts = String(previousTag || "")
+    .replace(/^v/, "")
+    .split(".")
+    .map(Number);
+  if (
+    parts.length < 3
+    || parts.slice(0, 3).some((part) => !Number.isInteger(part) || part < 0)
+  ) {
+    throw new Error(`Invalid previous version tag: ${previousTag}`);
+  }
+
+  const title = String(pr?.title || "").trim();
+  const body = String(pr?.body || "");
+  const breaking = /^[a-z]+(?:\([^)]*\))?!:/i.test(title)
+    || /(^|\n)BREAKING CHANGE:/i.test(body);
+  const feature = /^feat(?:\([^)]*\))?:/i.test(title);
+
+  let [major, minor, patch] = parts;
+  if (breaking) {
+    major += 1;
+    minor = 0;
+    patch = 0;
+  } else if (feature) {
+    minor += 1;
+    patch = 0;
+  } else {
+    patch += 1;
+  }
+  return `${major}.${minor}.${patch}`;
+}
+
 async function githubJson(url) {
   const headers = {
     Accept: "application/vnd.github+json",
@@ -294,6 +326,15 @@ async function main() {
     console.log(pr?.number || "");
     return;
   }
+  if (process.argv[2] === "--next-version") {
+    console.log(
+      nextVersion(process.argv[3], {
+        title: process.argv[4] || "",
+        body: process.argv[5] || "",
+      }),
+    );
+    return;
+  }
 
   const associatedPr = await associatedPullRequest();
   if (!associatedPr?.number) {
@@ -302,9 +343,11 @@ async function main() {
   }
 
   const pr = await pullRequestDetails(associatedPr.number);
-  const version = versionFromPrNumber(associatedPr.number);
-  const tag = `v${version}`;
   const previousTag = latestVersionTag();
+  const version = previousTag
+    ? nextVersion(previousTag, pr)
+    : versionFromPrNumber(associatedPr.number);
+  const tag = `v${version}`;
 
   if (tagExists(tag)) {
     console.log(`${tag} already exists; skipping release.`);


### PR DESCRIPTION
## Summary
- add an off-by-default automatic reboot schedule to each device settings page
- let users select a local time and one or more weekdays on desktop and mobile
- persist schedules per device and execute only matching devices with duplicate-run protection
- update release automation to derive the next SemVer from the latest tag and conventional PR title

## Validation
- `124 passed, 2 deselected` (the two deselected tests are existing baseline failures reproduced on unchanged `main`)
- Python compilation passed
- desktop and mobile inline JavaScript syntax passed
- release calculation verified: `v3.7.16` + `feat:` => `v3.8.0`

## Release impact
Minor: this merge should automatically publish `v3.8.0`.