### PR TITLE
feat: add access method to notifications

### DIFF
--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -1727,6 +1727,70 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
                 return text
         return ""
 
+    @staticmethod
+    def _access_method_label(event: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Return the user-facing access method reported by a door event."""
+
+        if not isinstance(event, dict):
+            return None
+
+        for key in (
+            "AccessMethod",
+            "OpenMethod",
+            "OpenDoorType",
+            "AccessMode",
+            "Method",
+            "CredentialType",
+            "Type",
+            "EventType",
+            "Event",
+            "Description",
+            "Mode",
+            "Way",
+        ):
+            value = event.get(key)
+            if value in (None, ""):
+                continue
+            text = re.sub(r"[_-]+", " ", _safe_str(value)).strip().casefold()
+            if not text:
+                continue
+            compact = re.sub(r"[^a-z0-9]+", "", text)
+
+            if re.search(r"\bface\b|\bfacial\b", text):
+                return "Face"
+            if (
+                "dtmf" in compact
+                or "calltoopen" in compact
+                or "openbycall" in compact
+                or "callunlock" in compact
+                or re.search(r"\bphone call\b|\bsip call\b", text)
+            ):
+                return "Call"
+            if (
+                compact in {"pin", "privatepin", "publicpin", "passcode", "keypad", "code"}
+                or re.search(
+                    r"\bprivate pin\b|\bpublic pin\b|\bpin code\b|\bpasscode\b"
+                    r"|\bkeypad\b|\baccess code\b|\bdoor code\b|\bpassword\b",
+                    text,
+                )
+            ):
+                return "code"
+
+        return None
+
+    def _access_granted_notification_message(
+        self,
+        event: Optional[Dict[str, Any]],
+        user_name: Optional[str] = None,
+    ) -> str:
+        who = user_name
+        if not who and isinstance(event, dict):
+            who = self._extract_event_user_name(event) or self._extract_event_user_id(event)
+        who = who or "Unknown user"
+        method = self._access_method_label(event)
+        suffix = f" via {method}" if method else ""
+        return f"{who} opened the gate{suffix}."
+
     def _notification_target_items(
         self,
         targets: List[Any],
@@ -1915,21 +1979,29 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             await self._async_save_notification_diagnostics()
             return
 
-        message = _safe_str(event.get("Event") or event.get("EventType") or "Akuvox access granted")
+        user_label = self._extract_event_user_name(event) or self._extract_event_user_id(event)
+        message = self._access_granted_notification_message(event, user_label)
+        access_method = self._access_method_label(event)
+        notification_data: Dict[str, Any] = {
+            "event": event,
+            "device_name": self.device_name,
+        }
+        if access_method:
+            notification_data["access_method"] = access_method
         data = {
             "message": message,
             "title": self.device_name,
-            "data": {"event": event, "device_name": self.device_name},
+            "data": notification_data,
         }
 
         notification_diag_dirty = False
         for target in notify_targets:
             target_label = self._format_notification_target(target)
-            user_label = self._extract_event_user_name(event) or self._extract_event_user_id(event) or "Unknown user"
+            user_label = user_label or "Unknown user"
             try:
                 await service.async_call("notify", target, data, blocking=False)
                 self._append_event(
-                    f"System notification sent to {target_label} — {user_label} accessed the gate"
+                    f"System notification sent to {target_label} — {message.rstrip('.')}"
                 )
                 notification_diag_dirty = self._record_notification_diagnostic(
                     source="access_event",
@@ -2016,7 +2088,10 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             who = self._extract_event_user_name(event) if event else None
             if not who:
                 who = user_id or "Unknown user"
-            message = f"{who} opened the gate."
+            message = self._access_granted_notification_message(event, who)
+            access_method = self._access_method_label(event)
+            if access_method:
+                data["access_method"] = access_method
         else:
             message = summary or f"{event_type} on {self.device_name}"
 

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -230,7 +230,15 @@ def test_derive_targets_from_raw_ignores_specific_users_when_disabled():
     assert _derive_targets_from_raw(targets, "user_granted", user_id="HA012") == []
 
 
-def test_dispatch_notification_appends_system_event_on_success():
+@pytest.mark.parametrize(
+    ("event_type", "expected_message"),
+    [
+        ("Private PIN", "Neil smalley opened the gate via code."),
+        ("Face", "Neil smalley opened the gate via Face."),
+        ("DTMF", "Neil smalley opened the gate via Call."),
+    ],
+)
+def test_dispatch_notification_includes_access_method(event_type, expected_message):
     storage = _StorageStub()
     coord = _build_coordinator(_APIStub([]), storage)
     coord.events = []
@@ -238,6 +246,7 @@ def test_dispatch_notification_appends_system_event_on_success():
 
     event = {
         "Event": "Door unlocked",
+        "Type": event_type,
         "UserName": "Neil smalley",
         "Date": "2026-01-08",
         "Time": "08:30:00",
@@ -245,10 +254,11 @@ def test_dispatch_notification_appends_system_event_on_success():
 
     asyncio.run(coord._dispatch_notification(event, ["mobile_app_elles_iphone"]))
 
+    assert coord.hass.services.calls[0]["data"]["message"] == expected_message
     assert len(coord.events) == 1
     assert (
         coord.events[0]["Event"]
-        == "System notification sent to elles iphone — Neil smalley accessed the gate"
+        == f"System notification sent to elles iphone — {expected_message.rstrip('.')}"
     )
     diag = storage.data["notification_diagnostics"]
     assert diag[0]["status"] == "sent"
@@ -276,6 +286,34 @@ def test_dispatch_notification_appends_system_event_on_failure():
     diag = storage.data["notification_diagnostics"]
     assert diag[0]["status"] == "failed"
     assert diag[0]["error"] == "push unavailable"
+
+
+@pytest.mark.parametrize(
+    ("event", "expected_message"),
+    [
+        ({"UserName": "Alice", "Type": "Private PIN"}, "Alice opened the gate via code."),
+        ({"UserName": "Alice", "Type": "Face"}, "Alice opened the gate via Face."),
+        ({"UserName": "Alice", "Type": "DTMF"}, "Alice opened the gate via Call."),
+        ({"UserName": "Alice", "Type": "Unknown"}, "Alice opened the gate."),
+    ],
+)
+def test_send_alert_notification_includes_access_method(event, expected_message):
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.hass.services = _ServiceStub()
+    coord.hass.data = {DOMAIN: {"settings_store": _SettingsStub(["mobile_app_admin_phone"])}}
+
+    asyncio.run(
+        coord._send_alert_notification(
+            "user_granted",
+            user_id="HA007",
+            summary="access granted",
+            extra={"event": event},
+        )
+    )
+
+    assert coord.hass.services.calls[0]["data"]["message"] == expected_message
+    assert storage.data["notification_diagnostics"][0]["message"] == expected_message
 
 
 def test_send_alert_notification_records_system_notification():


### PR DESCRIPTION
## Summary

- identify Akuvox access methods from door event fields
- format access notifications as `Name opened the gate via code`, `via Face`, or `via Call`
- apply the same wording to per-user access notifications and granted-access alert rules
- preserve the existing generic message when firmware does not report a recognized method
- include the recognized method in notification payload data

## Validation

- 8 focused access notification tests passed
- 130 integration tests passed with the same 2 baseline failures deselected
- Python compilation passed
- `git diff --check` passed

## Release

The conventional `feat:` title advances the integration from `v3.8.0` to `v3.9.0` through the repository release workflow.