### PR TITLE
fix: improve device settings label contrast

### DIFF
--- a/custom_components/akuvox_ac/tests/test_auto_reboot.py
+++ b/custom_components/akuvox_ac/tests/test_auto_reboot.py
@@ -133,3 +133,4 @@ def test_device_edit_templates_include_auto_reboot_controls():
         assert 'id="autoRebootToggle"' in html
         assert 'id="autoRebootTime"' in html
         assert "set_device_auto_reboot" in html
+        assert ".form-label, .form-check-label{ color:#fff!important; }" in html

--- a/custom_components/akuvox_ac/www/device_edit-mob.html
+++ b/custom_components/akuvox_ac/www/device_edit-mob.html
@@ -19,6 +19,7 @@
     .wrap{ max-width:820px; margin:2rem auto; padding:0 1rem; }
     .card{ background:var(--card); border:1px solid var(--border); }
     .card-header{ border-bottom:1px solid var(--border); color:var(--text); font-weight:600 }
+    .form-label, .form-check-label{ color:#fff!important; }
     .form-text, .text-muted{ color:var(--muted)!important }
     .hidden{ display:none!important; }
     .chip{display:inline-flex;align-items:center;gap:.35rem;background:#0f1f37;border:1px solid #243a61;border-radius:999px;padding:.15rem .5rem;font-size:.9rem}

--- a/custom_components/akuvox_ac/www/device_edit.html
+++ b/custom_components/akuvox_ac/www/device_edit.html
@@ -19,6 +19,7 @@
     .wrap{ max-width:820px; margin:2rem auto; padding:0 1rem; }
     .card{ background:var(--card); border:1px solid var(--border); }
     .card-header{ border-bottom:1px solid var(--border); color:var(--text); font-weight:600 }
+    .form-label, .form-check-label{ color:#fff!important; }
     .form-text, .text-muted{ color:var(--muted)!important }
     .hidden{ display:none!important; }
     .chip{display:inline-flex;align-items:center;gap:.35rem;background:#0f1f37;border:1px solid #243a61;border-radius:999px;padding:.15rem .5rem;font-size:.9rem}


### PR DESCRIPTION
## Summary

- force device settings form labels and checkbox labels to white
- apply the contrast fix to both desktop and mobile templates
- keep supporting help text on the existing muted colour
- add a regression assertion covering both templates

## Validation

- 8 automatic reboot/device settings tests passed
- template contrast rules verified in both files
- `git diff --check` passed

## Release

The `fix:` title advances the integration from `v3.9.0` to `v3.9.1`.