### PR TITLE
feat: show cloud and local user sources

### DIFF
--- a/custom_components/akuvox_ac/tests/test_dashboard_user_source.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_user_source.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_dashboard_templates_show_cloud_and_local_user_sources():
+    www = Path(__file__).resolve().parents[1] / "www"
+
+    for filename in ("index.html", "index-mob.html"):
+        html = (www / filename).read_text(encoding="utf-8")
+
+        assert "<th>Source</th>" in html
+        assert "function userSourceBadge(user)" in html
+        assert "const label = cloud ? 'Cloud' : 'Local'" in html
+        assert "class=\"badge user-source-badge ${kind}\"" in html
+        assert ".badge-cloud{" in html
+        assert ".badge-local{" in html
+        assert "user?.isCloud ? 'cloud' : 'local'" in html
+        assert "<td>${userSourceBadge(u)}</td>" in html
+
+    desktop = (www / "index.html").read_text(encoding="utf-8")
+    mobile = (www / "index-mob.html").read_text(encoding="utf-8")
+
+    assert "const columnCount = showPinColumn ? 8 : 7;" in desktop
+    assert '<td colspan="7" class="text-muted">Loading' in desktop
+    assert '<td colspan="8" class="text-muted">Loading' in mobile
+    assert "colspan=\"8\" class=\"text-muted\">No users" in mobile

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -25,6 +25,8 @@
     .badge-online{background:#0dcaf0;color:#111;--status-color:#0dcaf0}
     .badge-rebooting{background:#6f42c1;--status-color:#6f42c1}
     .badge-inactive{background:#6c757d;color:#fff;--status-color:#6c757d}
+    .badge-cloud{background:#0d6efd;color:#fff;--status-color:#0d6efd}
+    .badge-local{background:#6c757d;color:#fff;--status-color:#6c757d}
     .badge.bg-secondary{--status-color:#6c757d}
     .status-indicator{--status-color:currentColor;display:inline-flex;align-items:center;gap:.35rem}
     .status-indicator .status-dot{display:none;width:.75rem;height:.75rem;border-radius:50%;background:var(--status-color);box-shadow:0 0 0 2px rgba(15,26,44,.45)}
@@ -796,6 +798,13 @@ function badge(text, kind, attrs = ''){
   return `<span class="badge status-indicator ${k}" title="${label}" aria-label="${label}"${attr}><span class="status-dot" aria-hidden="true"></span><span class="status-text">${label}</span></span>`;
 }
 
+function userSourceBadge(user){
+  const cloud = !!user?.isCloud;
+  const label = cloud ? 'Cloud' : 'Local';
+  const kind = cloud ? 'badge-cloud' : 'badge-local';
+  return `<span class="badge user-source-badge ${kind}">${label}</span>`;
+}
+
 function renderKPIs(k){
   const nextEl = document.getElementById('kpiNext');
   const eventsLastEl = document.getElementById('kpiEventsLast');
@@ -952,6 +961,7 @@ function userMatchesSearch(user, term){
     user?.access_schedule,
     user?.schedule_name,
     user?.access_level,
+    user?.isCloud ? 'cloud' : 'local',
     ...(Array.isArray(user?.groups) ? user.groups : [])
   ]
     .map(normalizeSearchText)
@@ -1859,6 +1869,7 @@ function renderUsers(devs, registryUsers, kpis){
     if (u.isCloud) {
       return `<tr>
         <td>${u.name}</td>
+        <td>${userSourceBadge(u)}</td>
         <td colspan="6" class="text-danger text-center fw-semibold">This user is synced from the cloud and can not be altered</td>
       </tr>`;
     }
@@ -1940,6 +1951,7 @@ function renderUsers(devs, registryUsers, kpis){
 
     return `<tr>
       <td>${u.name}</td>
+      <td>${userSourceBadge(u)}</td>
       <td>${chips || '—'}</td>
       <td>${accessBadge}</td>
       <td>${faceBadge}</td>
@@ -1954,7 +1966,7 @@ function renderUsers(devs, registryUsers, kpis){
     kpiUsers.textContent = String(listSorted.length);
   }
 
-  $('#tblUsers').innerHTML = rows || '<tr><td colspan="7" class="text-muted">No users</td></tr>';
+  $('#tblUsers').innerHTML = rows || '<tr><td colspan="8" class="text-muted">No users</td></tr>';
 
   $('#tblUsers').querySelectorAll('button[data-act="delete"]').forEach(btn => {
     btn.addEventListener('click', async () => {
@@ -2687,9 +2699,9 @@ setInterval(refresh, 5000);
           <div id="usersTableWrap">
             <table class="table table-sm table-dark mb-0 table-center">
               <thead>
-                <tr><th>Name</th><th>Groups</th><th>Access</th><th>Face Recognition</th><th>Errors</th><th>Last Access</th><th>Actions</th></tr>
+                <tr><th>Name</th><th>Source</th><th>Groups</th><th>Access</th><th>Face Recognition</th><th>Errors</th><th>Last Access</th><th>Actions</th></tr>
               </thead>
-              <tbody id="tblUsers"><tr><td colspan="7" class="text-muted">Loading…</td></tr></tbody>
+              <tbody id="tblUsers"><tr><td colspan="8" class="text-muted">Loading…</td></tr></tbody>
             </table>
           </div>
         </div>

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -25,6 +25,8 @@
     .badge-online{background:#0dcaf0;color:#111;--status-color:#0dcaf0}
     .badge-rebooting{background:#6f42c1;--status-color:#6f42c1}
     .badge-inactive{background:#6c757d;color:#fff;--status-color:#6c757d}
+    .badge-cloud{background:#0d6efd;color:#fff;--status-color:#0d6efd}
+    .badge-local{background:#6c757d;color:#fff;--status-color:#6c757d}
     .badge.bg-secondary{--status-color:#6c757d}
     .status-indicator{--status-color:currentColor;display:inline-flex;align-items:center;gap:.35rem}
     .status-indicator .status-dot{display:none;width:.75rem;height:.75rem;border-radius:50%;background:var(--status-color);box-shadow:0 0 0 2px rgba(15,26,44,.45)}
@@ -855,6 +857,13 @@ function badge(text, kind, attrs = ''){
   return `<span class="badge status-indicator ${k}" title="${label}" aria-label="${label}"${attr}><span class="status-dot" aria-hidden="true"></span><span class="status-text">${label}</span></span>`;
 }
 
+function userSourceBadge(user){
+  const cloud = !!user?.isCloud;
+  const label = cloud ? 'Cloud' : 'Local';
+  const kind = cloud ? 'badge-cloud' : 'badge-local';
+  return `<span class="badge user-source-badge ${kind}">${label}</span>`;
+}
+
 function renderKPIs(k){
   const nextEl = document.getElementById('kpiNext');
   const eventsLastEl = document.getElementById('kpiEventsLast');
@@ -1011,6 +1020,7 @@ function userMatchesSearch(user, term){
     user?.access_schedule,
     user?.schedule_name,
     user?.access_level,
+    user?.isCloud ? 'cloud' : 'local',
     ...(Array.isArray(user?.groups) ? user.groups : [])
   ]
     .map(normalizeSearchText)
@@ -1699,7 +1709,7 @@ function attachPinRevealHandlers(container){
 function renderUsersTableHeader(tableBody, showPinColumn){
   const headerRow = tableBody?.closest('table')?.querySelector('thead tr');
   if (!headerRow) return;
-  headerRow.innerHTML = `<th>Name</th>${showPinColumn ? '<th>Pin</th>' : ''}<th>Face Recognition</th><th>Access</th><th>Last Access</th><th>Access Schedule</th><th>Actions</th>`;
+  headerRow.innerHTML = `<th>Name</th><th>Source</th>${showPinColumn ? '<th>Pin</th>' : ''}<th>Face Recognition</th><th>Access</th><th>Last Access</th><th>Access Schedule</th><th>Actions</th>`;
 }
 
 function renderUsers(devs, registryUsers, kpis){
@@ -2038,7 +2048,7 @@ function renderUsers(devs, registryUsers, kpis){
   });
 
   const showPinColumn = dedupedByName.some(u => String(u.pin || '').trim());
-  const columnCount = showPinColumn ? 7 : 6;
+  const columnCount = showPinColumn ? 8 : 7;
   renderUsersTableHeader(tableBody, showPinColumn);
 
   const listById = new Map(list.map(user => [String(user.id || ''), user]));
@@ -2131,6 +2141,7 @@ function renderUsers(devs, registryUsers, kpis){
 
     return `<tr>
       <td>${escapeHtml(u.name)}</td>
+      <td>${userSourceBadge(u)}</td>
       ${pinColumn}
       <td>${faceBadge}</td>
       <td>${accessBadge}</td>
@@ -2938,9 +2949,9 @@ setInterval(refresh, 5000);
           <div id="usersTableWrap">
             <table class="table table-sm table-dark mb-0 table-center">
               <thead>
-                <tr><th>Name</th><th>Face Recognition</th><th>Access</th><th>Last Access</th><th>Access Schedule</th><th>Actions</th></tr>
+                <tr><th>Name</th><th>Source</th><th>Face Recognition</th><th>Access</th><th>Last Access</th><th>Access Schedule</th><th>Actions</th></tr>
               </thead>
-              <tbody id="tblUsers"><tr><td colspan="6" class="text-muted">Loading…</td></tr></tbody>
+              <tbody id="tblUsers"><tr><td colspan="7" class="text-muted">Loading…</td></tr></tbody>
             </table>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- add a `Source` column beside each dashboard user name
- display blue `Cloud` and grey `Local` badges using the existing merged user source marker
- keep source text visible on narrow/mobile layouts instead of collapsing it to a status dot
- make `cloud` and `local` available through user search
- update loading, empty-state, optional PIN, and cloud-managed row column spans
- add regression coverage for both desktop and mobile templates

## Validation

- 1 focused source-column test passed
- 131 integration tests passed with the same 2 baseline failures deselected
- JavaScript syntax verified for both dashboard templates
- desktop and mobile-width visual previews checked
- `git diff --check` passed

## Release

The conventional `feat:` title advances the integration from `v3.9.1` to `v3.10.0`.