### PR TITLE
fix: keep mobile diagnostics tabs on one row

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_diagnostics_tabs.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_diagnostics_tabs.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_mobile_diagnostics_tabs_use_single_scrollable_row():
+    www = Path(__file__).resolve().parents[1] / "www"
+    mobile = (www / "diagnostics-mob.html").read_text(encoding="utf-8")
+
+    assert 'class="nav nav-tabs diag-tabs"' in mobile
+    assert "flex-wrap:nowrap;" in mobile
+    assert "overflow-x:auto;" in mobile
+    assert "-webkit-overflow-scrolling:touch;" in mobile
+    assert "flex:0 0 auto;" in mobile
+    assert "white-space:nowrap;" in mobile

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -194,6 +194,19 @@
     .badge.notification-status.ready{ background:rgba(13,202,240,0.18); color:#9ee7ff; }
     @media (max-width: 768px){
       .diag-container{ max-width:100%; padding:0 1rem; }
+      .diag-tabs{
+        flex-wrap:nowrap;
+        overflow-x:auto;
+        overflow-y:hidden;
+        width:100%;
+        -webkit-overflow-scrolling:touch;
+        overscroll-behavior-x:contain;
+        scrollbar-width:thin;
+      }
+      .diag-tabs .nav-link{
+        flex:0 0 auto;
+        white-space:nowrap;
+      }
       .diag-toggle{ padding:0.85rem 1rem; }
       .diag-body{ padding:1rem; }
       .diag-request{ padding:0.65rem 0.85rem; }


### PR DESCRIPTION
## What changed
- keep the mobile Device Diagnostics tab navigation on a single row
- enable native horizontal touch scrolling for tabs that extend beyond the viewport
- prevent individual tab labels from shrinking or wrapping
- add a regression test for the responsive tab CSS

## Why
Bootstrap's default nav styling allowed the diagnostics tabs to wrap across multiple rows on mobile, using too much vertical space and making navigation harder to scan.

## Validation
- `pytest custom_components/akuvox_ac/tests/test_mobile_diagnostics_tabs.py -q`
- full integration suite: 133 passed, 2 deselected
- `git diff --check`

The two deselected tests are existing environment-dependent baseline exclusions.