### PR TITLE
feat: improve mobile dashboard navigation and filters

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+WWW = Path(__file__).resolve().parents[1] / "www"
+
+
+def read_page(name):
+    return (WWW / name).read_text(encoding="utf-8")
+
+
+def test_standalone_mobile_event_history_has_category_filter():
+    mobile = read_page("event_history-mob.html")
+
+    assert 'id="eventFilter"' in mobile
+    assert '<option value="all">All events</option>' in mobile
+    assert '<option value="system">System events</option>' in mobile
+    assert '<option value="access">Access events</option>' in mobile
+    assert "let eventFilterMode = 'access';" in mobile
+    assert "function applyCategoryFilter(events)" in mobile
+    assert "evt._category === 'access' || evt._category === 'call'" in mobile
+    assert "renderFilteredEvents();" in mobile
+
+
+def test_mobile_user_sort_recovers_from_unknown_stored_value():
+    overview = read_page("user_overview-mob.html")
+    dashboard = read_page("index-mob.html")
+
+    for mobile in (overview, dashboard):
+        assert "function normalizeUserSort(value)" in mobile
+        assert "Organise by last access" in mobile
+        assert "Organise by user ID" in mobile
+        assert "Organise by name" in mobile
+
+    assert "return USER_SORT_VALUES.has(normalized) ? normalized : 'name';" in overview
+    assert "return ['last_access', 'ha_id', 'name'].includes(normalized) ? normalized : 'ha_id';" in dashboard
+
+
+def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
+    shell = read_page("head-mob.html")
+
+    assert 'id="mobileBackBtn"' in shell
+    assert 'id="mobileMenuBtn"' in shell
+    assert "const mobileMenuBtn = document.getElementById('mobileMenuBtn');" in shell
+    assert "setMobileStage('nav');" in shell
+
+    for name in ("device_edit-mob.html", "diagnostics-mob.html", "schedules-mob.html"):
+        page = read_page(name)
+        assert 'id="btnBack"' not in page
+        assert 'id="backBtn"' not in page

--- a/custom_components/akuvox_ac/www/device_edit-mob.html
+++ b/custom_components/akuvox_ac/www/device_edit-mob.html
@@ -33,7 +33,6 @@
 <div class="wrap">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h2 class="mb-0" id="pageTitle">Edit Device</h2>
-    <a class="btn btn-outline-light btn-sm" id="btnBack"><i class="bi bi-arrow-left"></i> Back</a>
   </div>
 
   <!-- Device summary -->
@@ -1018,7 +1017,6 @@ async function createGroup(name){
 async function init(){
   if (!ENTRY_ID) { showError('Missing device id in URL (?entry_id=ENTRY_ID)'); return; }
 
-  document.getElementById('btnBack').addEventListener('click', (e)=>{ e.preventDefault(); goBack(); });
   document.getElementById('btnCancel').addEventListener('click', (e)=>{ e.preventDefault(); goBack(); });
 
   try{

--- a/custom_components/akuvox_ac/www/diagnostics-mob.html
+++ b/custom_components/akuvox_ac/www/diagnostics-mob.html
@@ -607,7 +607,6 @@ function openInApp(view, params = {}, options = {}) {
 
 <div class="diag-container container py-3">
   <div class="d-flex align-items-center gap-2 flex-wrap">
-    <button class="btn btn-outline-light" id="btnBack"><i class="bi bi-arrow-left"></i> Back</button>
     <h2 class="m-0 flex-grow-1 text-white">Device Diagnostics</h2>
     <button class="btn btn-outline-info" id="btnDownloadSupportBundle" type="button"><i class="bi bi-file-earmark-text"></i> View logs</button>
     <button class="btn btn-outline-info" id="btnRefresh"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
@@ -2312,10 +2311,6 @@ async function viewSupportLogs(){
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('btnBack')?.addEventListener('click', (ev) => {
-    ev.preventDefault();
-    openInApp('settings', {}, { replaceState: false });
-  });
   document.getElementById('btnRefresh')?.addEventListener('click', (ev) => {
     ev.preventDefault();
     loadDiagnostics();

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -18,6 +18,11 @@
     header.page-header{display:flex;align-items:center;gap:0.75rem;}
     header.page-header h1{flex:1;font-size:1.35rem;margin:0;}
     header.page-header .btn{white-space:nowrap;}
+    .event-toolbar{display:flex;align-items:center;gap:0.75rem;background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.75rem;}
+    .event-toolbar label{color:var(--muted);font-size:0.85rem;white-space:nowrap;}
+    .event-toolbar .form-select{flex:1;background-color:#0e1a2c;color:var(--text);border-color:#243a61;}
+    .event-toolbar .form-select:focus{background-color:#0e1a2c;color:var(--text);border-color:var(--info);box-shadow:0 0 0 0.2rem rgba(13,202,240,.25);}
+    .event-toolbar .form-select option{background:#0e1a2c;color:var(--text);}
     .summary-grid{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
     .summary-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.4rem;}
     .summary-card .label{color:var(--muted);font-size:0.85rem;text-transform:uppercase;letter-spacing:0.08em;}
@@ -41,6 +46,7 @@
       header.page-header{flex-wrap:wrap;}
       header.page-header h1{flex-basis:100%;font-size:1.25rem;}
       header.page-header .btn{flex:1 1 calc(50% - 0.5rem);}
+      .event-toolbar{align-items:stretch;flex-direction:column;gap:0.4rem;}
     }
   </style>
 </head>
@@ -50,6 +56,14 @@
     <h1>Event History</h1>
     <button class="btn btn-outline-info btn-sm" id="refreshBtn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
   </header>
+  <div class="event-toolbar">
+    <label for="eventFilter">Show events</label>
+    <select id="eventFilter" class="form-select form-select-sm" aria-label="Filter event history">
+      <option value="all">All events</option>
+      <option value="system">System events</option>
+      <option value="access">Access events</option>
+    </select>
+  </div>
   <section class="summary-grid" aria-label="Event summary">
     <div class="summary-card">
       <span class="label">Events</span>
@@ -457,6 +471,8 @@ function signedPath(key, fallback){
 const stateUrl  = signedPath('state', '/api/akuvox_ac/ui/state');
 const actionUrl = signedPath('action', '/api/akuvox_ac/ui/action');
 const UI_ROOT   = '/akuvox-ac';
+let eventFilterMode = 'access';
+let cachedEvents = [];
 
 function buildHref(slug, params = {}) {
   const search = new URLSearchParams();
@@ -549,6 +565,10 @@ function handleAuthError(err) {
 }
 
 document.getElementById('refreshBtn').addEventListener('click', (ev) => { ev.preventDefault(); refresh(); });
+document.getElementById('eventFilter').addEventListener('change', (ev) => {
+  eventFilterMode = ev.target?.value || 'access';
+  renderFilteredEvents();
+});
 
 function escapeHtml(value){
   const lookup = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
@@ -558,6 +578,71 @@ function escapeHtml(value){
 function getEventStatusText(evt){
   if (!evt || typeof evt !== 'object') return '';
   return evt.Result || evt.Event || evt.status_label || evt.status || evt.action || evt.Message || evt.Description || '';
+}
+
+function hasMeaningfulValue(obj, key) {
+  if (!obj) return false;
+  const value = obj[key];
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim() !== '';
+  return true;
+}
+
+function normalizeEventCategory(value){
+  if (value === null || value === undefined) return '';
+  const text = String(value).trim().toLowerCase();
+  if (text === 'access' || text === 'call' || text === 'system') return text;
+  return '';
+}
+
+function categorizeEvent(event, device) {
+  const evt = event || {};
+  const normalizedType = String(evt.Type ?? evt.type ?? '').trim().toLowerCase();
+  if (normalizedType === 'dtmf') return 'call';
+  if (normalizedType === 'face') return 'access';
+  if (['private pin', 'privatepin', 'pin', 'passcode'].includes(normalizedType)) return 'access';
+
+  const textParts = [];
+  [
+    'EventType', 'Type', 'EventCategory', 'Category', 'LogType', 'LogTypeName',
+    'CallType', 'SubType', 'Event', 'Result', 'action', 'Message', 'Description', 'Detail',
+  ].forEach((key) => {
+    const value = evt[key];
+    if (value !== undefined && value !== null && String(value).trim()) {
+      textParts.push(String(value).trim());
+    }
+  });
+  if (device && typeof device === 'object') {
+    [device.device_type, device.deviceModel, device.device_model, device.model].forEach((value) => {
+      if (value !== undefined && value !== null && String(value).trim()) {
+        textParts.push(String(value).trim());
+      }
+    });
+  }
+  const combined = textParts.join(' ').toLowerCase();
+  const callKeys = [
+    'CallNo', 'CallNum', 'CallNumber', 'CallType', 'CallMode', 'CallStatus',
+    'PriorityCall', 'RoomNumber', 'RoomNo', 'Terminal', 'Intercom', 'SipAccount', 'SipNumber',
+  ];
+  const accessKeys = [
+    'AccessMode', 'Method', 'AccessType', 'AccessPoint', 'Door', 'DoorName', 'Reader',
+    'OpenType', 'User', 'UserID', 'UserName', 'Name', 'CardNo', 'CardNumber',
+    'Credential', 'CredentialType', 'Pin', 'PIN', 'Passcode', 'Password',
+    'AccessResult', 'AccessStatus', 'OpenResult',
+  ];
+
+  if (callKeys.some((key) => hasMeaningfulValue(evt, key))
+      || /\bcall\b|doorbell|ringback|\bsip\b|intercom|monitor/i.test(combined)) {
+    return 'call';
+  }
+  if (/system|integrity|mismatch|sync|reboot|restart|online|offline|power|network|alarm|error|update|config|firmware|tamper|maintenance|diagnostic/i.test(combined)) {
+    return 'system';
+  }
+  if (accessKeys.some((key) => hasMeaningfulValue(evt, key))
+      || /\baccess\b|\bdoor\b|unlock|granted|denied|card|pin|keypad|entry|credential|passcode|face|finger/i.test(combined)) {
+    return 'access';
+  }
+  return 'system';
 }
 
 function getEventTypeLabel(evt){
@@ -901,6 +986,7 @@ function gatherEvents(devices, aggregated, userLookup){
     if (when) normalized._when = when;
     normalized._ts = epoch;
     normalized._device = deviceName;
+    normalized._category = normalizeEventCategory(normalized._category) || categorizeEvent(normalized, deviceRef);
     applyUserLookup(normalized, userLookup);
     events.push(normalized);
   }
@@ -968,6 +1054,27 @@ function renderEvents(events){
   });
 }
 
+function applyCategoryFilter(events){
+  if (eventFilterMode === 'all') return events;
+  return events.filter((evt) => {
+    if (eventFilterMode === 'access') {
+      return evt._category === 'access' || evt._category === 'call';
+    }
+    return evt._category === eventFilterMode;
+  });
+}
+
+function renderFilteredEvents(){
+  const { filterLabel, events: userEvents } = applyUserFilter(cachedEvents);
+  const filtered = applyCategoryFilter(userEvents);
+  const title = document.querySelector('header.page-header h1');
+  if (title) {
+    title.textContent = filterLabel ? `Event History • ${filterLabel}` : 'Event History';
+  }
+  renderSummary(filtered);
+  renderEvents(filtered);
+}
+
 async function refresh(){
   try {
     document.getElementById('refreshBtn').setAttribute('disabled', 'disabled');
@@ -976,14 +1083,8 @@ async function refresh(){
     const aggregated = Array.isArray(state?.access_events) ? state.access_events : [];
     const registryUsers = state.registry_users || [];
     const userLookup = buildUserLookup(devices, registryUsers);
-    const events = gatherEvents(devices, aggregated, userLookup);
-    const { filterLabel, events: filtered } = applyUserFilter(events);
-    const title = document.querySelector('header.page-header h1');
-    if (title && filterLabel) {
-      title.textContent = `Event History • ${filterLabel}`;
-    }
-    renderSummary(filtered);
-    renderEvents(filtered);
+    cachedEvents = gatherEvents(devices, aggregated, userLookup);
+    renderFilteredEvents();
     const ts = new Date();
     document.getElementById('lastUpdated').textContent = `Updated ${ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
   } catch (err) {
@@ -996,6 +1097,7 @@ async function refresh(){
   }
 }
 
+document.getElementById('eventFilter').value = eventFilterMode;
 refresh();
 </script>
 </body>

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -249,6 +249,7 @@
       color: var(--muted);
       text-align: right;
     }
+    .mobile-menu-btn,
     .mobile-back-btn {
       display: none;
       align-items: center;
@@ -262,9 +263,12 @@
       cursor: pointer;
       transition: all .2s ease;
     }
+    .mobile-menu-btn .bi,
     .mobile-back-btn .bi {
       font-size: 1.1rem;
     }
+    .mobile-menu-btn:focus,
+    .mobile-menu-btn:hover,
     .mobile-back-btn:focus,
     .mobile-back-btn:hover {
       background: rgba(13,202,240,.12);
@@ -306,6 +310,7 @@
       body.mobile-stage-content .mobile-launcher { display: none; }
       body.mobile-stage-content .frame-wrap,
       body.mobile-stage-content footer.app-footer { display: block; }
+      body.mobile-stage-content .mobile-menu-btn,
       body.mobile-stage-content .mobile-back-btn { display: inline-flex; }
     }
   </style>
@@ -317,6 +322,10 @@
       <div class="brand">
         <h1 class="visually-hidden">Akuvox Access Control</h1>
         <span class="logo-mark" aria-hidden="true"><i class="bi bi-shield-lock-fill"></i></span>
+        <button class="mobile-menu-btn" type="button" id="mobileMenuBtn">
+          <i class="bi bi-grid-fill"></i>
+          <span>Menu</span>
+        </button>
       </div>
       <button class="mobile-back-btn" type="button" id="mobileBackBtn">
         <i class="bi bi-chevron-left"></i>
@@ -1483,6 +1492,15 @@ document.querySelectorAll('#navQuickActions [data-action], .mobile-launcher [dat
 const mobileBackBtn = document.getElementById('mobileBackBtn');
 if (mobileBackBtn) {
   mobileBackBtn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    if (!isMobileMode) return;
+    setMobileStage('nav');
+  });
+}
+
+const mobileMenuBtn = document.getElementById('mobileMenuBtn');
+if (mobileMenuBtn) {
+  mobileMenuBtn.addEventListener('click', (ev) => {
     ev.preventDefault();
     if (!isMobileMode) return;
     setMobileStage('nav');

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -475,9 +475,14 @@ let LAST_USERS_STATE = null;
 function loadUserSort(){
   try {
     const raw = localStorage.getItem('akuvox_user_sort');
-    if (raw) return String(raw);
+    if (raw) return normalizeUserSort(raw);
   } catch (err) {}
   return 'ha_id';
+}
+
+function normalizeUserSort(value){
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['last_access', 'ha_id', 'name'].includes(normalized) ? normalized : 'ha_id';
 }
 
 function saveUserSort(value){
@@ -978,7 +983,7 @@ function setUserSearch(value){
 }
 
 function setUserSort(value){
-  USER_SORT = value || 'ha_id';
+  USER_SORT = normalizeUserSort(value);
   saveUserSort(USER_SORT);
 }
 
@@ -2750,9 +2755,9 @@ setInterval(refresh, 5000);
           <input id="userSearch" class="form-control form-control-sm" type="search" placeholder="Search users" aria-label="Search users" />
         </div>
         <select id="userSort" class="form-select form-select-sm" aria-label="Organise users">
-          <option value="last_access">last access</option>
-          <option value="ha_id">user id</option>
-          <option value="name">name</option>
+          <option value="last_access">Organise by last access</option>
+          <option value="ha_id">Organise by user ID</option>
+          <option value="name">Organise by name</option>
         </select>
       </div>
       <div class="footer-note"></div>

--- a/custom_components/akuvox_ac/www/schedules-mob.html
+++ b/custom_components/akuvox_ac/www/schedules-mob.html
@@ -852,27 +852,12 @@ async function load(){
     <div class="mt-3 d-flex gap-2">
       <button class="btn btn-success" onclick="save()">Save</button>
       <button class="btn btn-danger" onclick="del()">Delete</button>
-      <a class="btn btn-secondary" id="backBtn" href="#">Back</a>
     </div>
   </div>
 </div>
 <script>
 initTimeInputFormatting();
 load();
-(function initBackButton(){
-  try {
-    const back = document.getElementById('backBtn');
-    if (!back) return;
-    const href = buildHref('index');
-    back.setAttribute('href', href);
-    back.addEventListener('click', (ev) => {
-      const delivered = requestParentNav('index', {}, { replaceState: false });
-      if (delivered) {
-        ev.preventDefault();
-      }
-    });
-  } catch (err) {}
-})();
 </script>
 </body>
 </html>

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -130,9 +130,9 @@
       <input id="userSearch" class="form-control form-control-sm" type="search" placeholder="Search users" aria-label="Search users" />
     </div>
     <select id="userSort" class="form-select form-select-sm" aria-label="Organise users">
-      <option value="last_access">last access</option>
-      <option value="ha_id">user id</option>
-      <option value="name">name</option>
+      <option value="last_access">Organise by last access</option>
+      <option value="ha_id">Organise by user ID</option>
+      <option value="name">Organise by name</option>
     </select>
   </div>
   <section class="user-list" id="userList" aria-live="polite"></section>
@@ -573,6 +573,7 @@ const PAUSED_USERS_KEY = 'akuvox_paused_users';
 const PAUSE_SCHEDULE_ID = '1002';
 const PAUSE_SCHEDULE_NAME = 'No Access';
 const USER_SORT_KEY = 'akuvox_user_sort';
+const USER_SORT_VALUES = new Set(['last_access', 'ha_id', 'name']);
 let USER_SEARCH = '';
 let USER_SORT = 'name';
 let LAST_USERS = [];
@@ -598,10 +599,15 @@ function savePausedUsers(map){
 function loadUserSort(){
   try {
     const stored = sessionStorage.getItem(USER_SORT_KEY) || localStorage.getItem(USER_SORT_KEY);
-    return stored || 'name';
+    return normalizeUserSort(stored);
   } catch (err) {
     return 'name';
   }
+}
+
+function normalizeUserSort(value){
+  const normalized = String(value || '').trim().toLowerCase();
+  return USER_SORT_VALUES.has(normalized) ? normalized : 'name';
 }
 
 function saveUserSort(value){
@@ -892,7 +898,7 @@ function setUserSearch(value){
 }
 
 function setUserSort(value){
-  USER_SORT = value || 'name';
+  USER_SORT = normalizeUserSort(value);
   saveUserSort(USER_SORT);
 }
 


### PR DESCRIPTION
## What changed
- add the missing All/System/Access selector to the standalone mobile Event History page
- default that selector to Access events, matching the dashboard behavior
- recover safely from stale or unknown saved user-sort values so the mobile sort field always shows a label
- make the sort labels explicit: Organise by last access, user ID, or name
- remove embedded Back buttons from Device Settings, Diagnostics, and Schedules
- keep the shared shell Back button as the single page-level Back control
- add a Menu button beside the mobile logo that opens the dashboard launcher directly
- add regression coverage for all three areas

## Root causes
- the previous event filter was added to the dashboard view, but not the standalone Event History page shown from the mobile menu
- an unsupported persisted sort value sets a native select to no matching option, which renders it blank
- several older child pages retained their own navigation controls after the shared mobile shell gained a Back button

## Validation
- focused mobile regression tests: 5 passed
- full integration suite: 136 passed, 2 existing environment-dependent exclusions
- all modified inline JavaScript blocks parse successfully
- duplicate child-page Back control scan passes
- `git diff --check`