### PR TITLE
fix: avoid recreating users after restart

### DIFF
--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -172,7 +172,10 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             "ip": "",
             "online": False,
             "status": "offline",
-            "sync_status": "pending",
+            # Restarting Home Assistant or the device does not imply that
+            # credentials are out of sync. Explicit changes and integrity
+            # checks move this state to pending when work is actually needed.
+            "sync_status": "in_sync",
             "last_sync": None,
             "last_error": None,
             "last_ping": None,
@@ -268,7 +271,6 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
                     self.health.pop("rebooting_until", None)
                 if prev is False:
                     self._append_event("Device came online")
-                    await self._kick_sync_now()
                 elif prev is None and not self.health.get("last_sync"):
                     # Avoid repairing users during HA startup before FaceData routes
                     # are guaranteed to be registered. Pending profile work is picked

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2141,7 +2141,59 @@ def _record_matches_desired_fields(local: Dict[str, Any], desired: Dict[str, Any
             raw = record.get("FaceRegisterStatus")
         return _normalize_boolish(raw)
 
+    aliases: Dict[str, Tuple[str, ...]] = {
+        "ScheduleRelay": ("ScheduleRelay", "Schedule-Relay"),
+        "PrivatePIN": ("PrivatePIN", "Pin", "PIN"),
+        "PhoneNum": ("PhoneNum", "Phone"),
+        "BLEAuthCode": ("BLEAuthCode", "BLE_AuthCode"),
+        "ID": ("ID", "Id", "id"),
+        "UserID": ("UserID", "UserId", "user_id"),
+    }
+
+    def _local_value(key: str) -> Any:
+        for candidate in aliases.get(key, (key,)):
+            if candidate in local:
+                return local.get(candidate)
+        return None
+
+    def _schedule_id(record: Dict[str, Any]) -> str:
+        direct = record.get("ScheduleID")
+        if direct not in (None, ""):
+            return _text(direct)
+        schedules = record.get("Schedule")
+        if isinstance(schedules, (list, tuple)) and schedules:
+            return _text(schedules[0])
+        return ""
+
+    def _plates(value: Any) -> Tuple[str, ...]:
+        if not isinstance(value, (list, tuple)):
+            return ()
+        result: List[str] = []
+        for entry in value:
+            if isinstance(entry, Mapping):
+                plate = (
+                    entry.get("Plate")
+                    or entry.get("plate")
+                    or entry.get("Value")
+                    or entry.get("value")
+                )
+            else:
+                plate = entry
+            text = _text(plate).upper()
+            if text:
+                result.append(text)
+        return tuple(result)
+
+    ignored_keys = {
+        # These are transport/default fields. The canonical schedule relay,
+        # face state, and user-visible fields below carry the actual intent.
+        "Type",
+        "ScheduleID",
+    }
+
     for key, desired_value in desired.items():
+        if key in ignored_keys:
+            continue
         if key == "FaceRegister":
             expected_face = _normalize_boolish(desired_value)
             actual_face = _face_flag(local)
@@ -2157,9 +2209,26 @@ def _record_matches_desired_fields(local: Dict[str, Any], desired: Dict[str, Any
             if expected_face is True and actual_face is True:
                 continue
 
-        local_value = local.get(key)
+        if key == "ScheduleRelay":
+            desired_schedule = _text(desired_value)
+            local_schedule = _text(_local_value(key))
+            if local_schedule != desired_schedule:
+                return False
+            continue
+
+        if key == "LicensePlate":
+            if _plates(_local_value(key)) != _plates(desired_value):
+                return False
+            continue
+
+        local_value = _local_value(key)
         if _text(local_value) != _text(desired_value):
             return False
+
+    desired_schedule_id = _schedule_id(desired)
+    local_schedule_id = _schedule_id(local)
+    if desired_schedule_id and local_schedule_id and desired_schedule_id != local_schedule_id:
+        return False
 
     return True
 
@@ -4553,7 +4622,7 @@ class SyncQueue:
             health = getattr(coord, "health", {}) or {}
             status = str(health.get("sync_status") or "").strip().lower()
             online = bool(health.get("online", True))
-            if online and status and status != "in_sync":
+            if online and status == "pending":
                 return True
 
         users_store = root.get("users_store")

--- a/custom_components/akuvox_ac/tests/test_contact_sync.py
+++ b/custom_components/akuvox_ac/tests/test_contact_sync.py
@@ -721,6 +721,40 @@ def test_sync_queue_kicks_stale_face_error_without_existing_eta():
     assert scheduled
 
 
+def test_sync_queue_ignores_non_pending_device_health_states():
+    scheduled = []
+    coordinator = SimpleNamespace(
+        health={"online": True, "sync_status": "in_progress"}
+    )
+    hass = SimpleNamespace(
+        data={integration.DOMAIN: {"device-1": {"coordinator": coordinator}}}
+    )
+    queue = object.__new__(integration.SyncQueue)
+    queue.hass = hass
+    queue._handle = None
+    queue._lock = None
+    queue._pending_all = False
+    queue._pending_devices = set()
+    queue._pending_full = False
+    queue._pending_full_devices = set()
+    queue._pending_reason_all = None
+    queue._pending_reason_devices = {}
+    queue.next_sync_eta = None
+    queue._last_mark = None
+    queue._last_delay_from_default = False
+    queue._active = False
+    queue._tick_unsub = None
+    queue._startup_unsub = None
+    queue._schedule_task = lambda coro: (scheduled.append(coro), coro.close())
+
+    queue.ensure_future_run()
+
+    assert queue._pending_all is False
+    assert queue._pending_reason_all is None
+    assert queue.next_sync_eta is None
+    assert scheduled == []
+
+
 def test_sync_queue_waits_for_face_retry_cooldown():
     scheduled = []
     retry_after = (integration.dt_util.now() + timedelta(minutes=10)).isoformat()

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -125,14 +125,15 @@ def test_initial_online_refresh_does_not_sync_during_startup():
     assert queue.calls == []
 
 
-def test_offline_to_online_refresh_still_syncs():
+def test_offline_to_online_refresh_does_not_reconcile_unchanged_users():
     queue = _SyncQueueStub()
     coord = _build_health_coordinator(queue)
     coord._was_online = False
 
     asyncio.run(coord._async_update_data())
 
-    assert queue.calls == ["device-1"]
+    assert coord.health["online"] is True
+    assert queue.calls == []
 
 
 def test_resolve_event_user_id_matches_profile_name_to_canonical_id():

--- a/custom_components/akuvox_ac/tests/test_paused_user_sync.py
+++ b/custom_components/akuvox_ac/tests/test_paused_user_sync.py
@@ -133,6 +133,71 @@ def test_record_matches_desired_fields_treats_face_register_status_as_registered
     assert integration._record_matches_desired_fields(local, desired) is True
 
 
+def test_record_matches_desired_fields_accepts_device_aliases_and_empty_plate_slots():
+    local = {
+        "ID": "42",
+        "UserID": "HA001",
+        "Name": "User One",
+        "DoorNum": "1",
+        "LiftFloorNum": "0",
+        "Schedule": ["1001"],
+        "Schedule-Relay": "1001-1;",
+        "WebRelay": "0",
+        "Group": integration.HA_CONTACT_GROUP_NAME,
+        "PriorityCall": "0",
+        "DialAccount": "0",
+        "C4EventNo": "0",
+        "AuthMode": "0",
+        "LicensePlate": [{}, {}, {}, {}, {}],
+        "CardCode": "",
+        "BLEAuthCode": "",
+        "PrivatePIN": "1234",
+        "PhoneNum": "0123456789",
+        "FaceRegisterStatus": "0",
+    }
+    desired = {
+        "ID": "42",
+        "UserID": "HA001",
+        "Name": "User One",
+        "DoorNum": "1",
+        "LiftFloorNum": "0",
+        "ScheduleID": "1001",
+        "ScheduleRelay": "1001-1;",
+        "WebRelay": "0",
+        "Group": integration.HA_CONTACT_GROUP_NAME,
+        "PriorityCall": "0",
+        "DialAccount": "0",
+        "C4EventNo": "0",
+        "AuthMode": "0",
+        "LicensePlate": [],
+        "CardCode": "",
+        "BLEAuthCode": "",
+        "Type": "0",
+        "PrivatePIN": "1234",
+        "PhoneNum": "0123456789",
+        "FaceRegister": "0",
+    }
+
+    assert integration._record_matches_desired_fields(local, desired) is True
+
+
+def test_record_matches_desired_fields_still_detects_real_schedule_change():
+    local = {
+        "UserID": "HA001",
+        "Name": "User One",
+        "Schedule": ["1001"],
+        "Schedule-Relay": "1001-1;",
+    }
+    desired = {
+        "UserID": "HA001",
+        "Name": "User One",
+        "ScheduleID": "1003",
+        "ScheduleRelay": "1003-1;",
+    }
+
+    assert integration._record_matches_desired_fields(local, desired) is False
+
+
 def test_face_register_status_satisfies_integrity_face_check():
     diffs = integration._integrity_field_differences(
         {"UserID": "HA001", "Name": "User One", "FaceRegisterStatus": "1"},


### PR DESCRIPTION
## What changed
- treat coordinator startup as in sync instead of creating synthetic pending work
- stop launching user reconciliation merely because a device comes back online after a reboot or outage
- restrict automatic pending detection to explicit `pending` device states
- normalize device field aliases when comparing existing users with desired users
- treat padded empty license-plate slots as equivalent to no configured plates
- retain detection of genuine changes such as schedules, PINs, phones, groups, and face state

## Root cause
A coordinator was initialized with `sync_status="pending"`, so Home Assistant/integration startup triggered `auto-detected pending state` even when no user changed. Once reconciliation ran, device response keys such as `Schedule-Relay` were compared directly with desired keys such as `ScheduleRelay`, and five empty license-plate slots were compared with an empty desired list. Those equivalent values appeared different, causing unchanged users to enter the delete-and-recreate update path.

A simple device offline-to-online transition also explicitly invoked reconciliation. A reboot does not by itself imply lost credentials, so this automatic reconciliation has been removed. Explicit queued edits and integrity mismatches continue to sync.

## Validation
- focused restart/pending/comparison regressions: 6 passed
- full integration suite: 139 passed, 2 existing environment-dependent exclusions
- Python compilation passes
- `git diff --check`