### PR TITLE
fix: make mobile back return to previous page

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -40,6 +40,13 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
 
     assert 'id="mobileBackBtn"' in shell
     assert 'id="mobileMenuBtn"' in shell
+    assert "const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';" in shell
+    assert "function getAppHistoryIndex(state = history.state)" in shell
+    assert "const nextIndex = replaceState ? currentIndex : currentIndex + 1;" in shell
+    assert "if (getAppHistoryIndex() > 0)" in shell
+    assert "history.back();" in shell
+    assert "function setMobileStage(stage, { preserveGroups = false, syncHistory = true } = {})" in shell
+    assert "setMobileStage('content', { syncHistory: false });" in shell
     assert "const mobileMenuBtn = document.getElementById('mobileMenuBtn');" in shell
     assert "setMobileStage('nav');" in shell
 

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -492,6 +492,7 @@
 
 const UI_ROOT = '/akuvox-ac';
 const DEFAULT_VIEW = 'index';
+const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';
 let expandedGroup = null;
 const MOBILE_BREAKPOINT = '(max-width: 720px)';
 const mobileMedia = window.matchMedia(MOBILE_BREAKPOINT);
@@ -809,7 +810,7 @@ function syncHistoryStage(forceStage){
   } catch (err) {}
 }
 
-function setMobileStage(stage, { preserveGroups = false } = {}){
+function setMobileStage(stage, { preserveGroups = false, syncHistory = true } = {}){
   if (!isMobileMode) {
     mobileStage = 'content';
     return;
@@ -820,7 +821,7 @@ function setMobileStage(stage, { preserveGroups = false } = {}){
   }
   applyMobileFlags();
   updateGroupExpansion();
-  syncHistoryStage();
+  if (syncHistory) syncHistoryStage();
 }
 
 function handleMobileMediaChange(ev){
@@ -1167,8 +1168,21 @@ function setActiveNav(view){
   updateGroupExpansion();
 }
 
+function getAppHistoryIndex(state = history.state){
+  const raw = state && state[APP_HISTORY_INDEX_KEY];
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
 function updateHistory(view, params, { replaceState = false } = {}){
-  const state = { view, params, mobileStage: isMobileMode ? mobileStage : 'content' };
+  const currentIndex = getAppHistoryIndex();
+  const nextIndex = replaceState ? currentIndex : currentIndex + 1;
+  const state = {
+    view,
+    params,
+    mobileStage: isMobileMode ? mobileStage : 'content',
+    [APP_HISTORY_INDEX_KEY]: nextIndex
+  };
   const search = new URLSearchParams();
   Object.entries(params || {}).forEach(([k,v]) => {
     if (v !== undefined && v !== null && v !== '') search.set(k, v);
@@ -1315,7 +1329,9 @@ async function runDashboardAction(action){
   const frame = document.getElementById('viewFrame');
   const previousHref = frame?.dataset.currentHref || '';
 
-  if (isMobileMode) setMobileStage('content', { preserveGroups: true });
+  if (isMobileMode) {
+    setMobileStage('content', { preserveGroups: true, syncHistory: false });
+  }
   loadView('index', { section: 'global-actions' });
   const changed = frame && frame.dataset.currentHref !== previousHref;
 
@@ -1446,7 +1462,7 @@ document.querySelectorAll('.mobile-launcher [data-view], .mobile-launcher [data-
       updateGroupExpansion();
     }
     if (!hasView) return;
-    if (isMobileMode) setMobileStage('content');
+    if (isMobileMode) setMobileStage('content', { syncHistory: false });
     loadView(view, params, { replaceState: false });
   });
 });
@@ -1494,6 +1510,10 @@ if (mobileBackBtn) {
   mobileBackBtn.addEventListener('click', (ev) => {
     ev.preventDefault();
     if (!isMobileMode) return;
+    if (getAppHistoryIndex() > 0) {
+      history.back();
+      return;
+    }
     setMobileStage('nav');
   });
 }


### PR DESCRIPTION
## What changed
- make the shared mobile Back button traverse the previous Akuvox page in browser history
- preserve the launcher history entry when opening a first-level page
- keep Menu as the explicit direct route to the mobile dashboard launcher
- fall back to the launcher when a page was opened directly with no app-owned history
- add regression assertions for the guarded history behavior

## Root cause
The mobile shell recorded page transitions with `history.pushState`, but the Back button ignored that history and always switched the shell to the launcher stage. Launcher navigation also updated the current history entry before pushing the destination, so the previous state was not preserved correctly.

## User impact
Back now follows the page path used to arrive at the current screen. For example, Global Settings -> Diagnostics -> Back returns to Global Settings. The same behavior applies to device, user, event, and other nested mobile pages because their navigation is handled by the shared shell.

## Validation
- `pytest custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py -q` -> 3 passed
- full component suite -> 139 passed, 2 known baseline tests deselected
- inline JavaScript parse check passed
- `git diff --check` passed

The in-app browser was unavailable in this session, so live click-through verification could not be performed.