### PR TITLE
fix: isolate mobile navigation history

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -41,8 +41,13 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
     assert 'id="mobileBackBtn"' in shell
     assert 'id="mobileMenuBtn"' in shell
     assert "const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';" in shell
+    assert "const APP_HISTORY_SESSION_KEY = 'akuvoxHistorySession';" in shell
+    assert "const APP_HISTORY_SESSION_ID = (() => {" in shell
     assert "function getAppHistoryIndex(state = history.state)" in shell
+    assert "state[APP_HISTORY_SESSION_KEY] !== APP_HISTORY_SESSION_ID" in shell
     assert "const nextIndex = replaceState ? currentIndex : currentIndex + 1;" in shell
+    assert "[APP_HISTORY_SESSION_KEY]: APP_HISTORY_SESSION_ID" in shell
+    assert "updateHistory(initialView, params, { replaceState: true });\n  await ensureDashboardSignedPaths();" in shell
     assert "if (getAppHistoryIndex() > 0)" in shell
     assert "history.back();" in shell
     assert "function setMobileStage(stage, { preserveGroups = false, syncHistory = true } = {})" in shell
@@ -54,3 +59,12 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
         page = read_page(name)
         assert 'id="btnBack"' not in page
         assert 'id="backBtn"' not in page
+
+
+def test_mobile_global_actions_include_update_check():
+    shell = read_page("head-mob.html")
+
+    assert 'data-action="hacs_update_check"' in shell
+    assert '<span class="tile-title">Check for updates</span>' in shell
+    assert "steps.push(() => postJson(API_ACTION, { action: 'hacs_update_check' }));" in shell
+    assert "steps.push(() => callService('akuvox_ac', 'hacs_update_check', {}));" in shell

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -461,6 +461,13 @@
           </div>
           <i class="bi bi-lightning-charge-fill"></i>
         </button>
+        <button class="mobile-tile sub" type="button" data-action="hacs_update_check">
+          <div class="tile-text">
+            <span class="tile-title">Check for updates</span>
+            <small>Check HACS for a newer integration version</small>
+          </div>
+          <i class="bi bi-cloud-arrow-down-fill"></i>
+        </button>
       </div>
     </div>
     <button class="mobile-tile" type="button" data-view="settings">
@@ -493,6 +500,15 @@
 const UI_ROOT = '/akuvox-ac';
 const DEFAULT_VIEW = 'index';
 const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';
+const APP_HISTORY_SESSION_KEY = 'akuvoxHistorySession';
+const APP_HISTORY_SESSION_ID = (() => {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (err) {}
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+})();
 let expandedGroup = null;
 const MOBILE_BREAKPOINT = '(max-width: 720px)';
 const mobileMedia = window.matchMedia(MOBILE_BREAKPOINT);
@@ -1169,6 +1185,7 @@ function setActiveNav(view){
 }
 
 function getAppHistoryIndex(state = history.state){
+  if (!state || state[APP_HISTORY_SESSION_KEY] !== APP_HISTORY_SESSION_ID) return 0;
   const raw = state && state[APP_HISTORY_INDEX_KEY];
   const parsed = Number(raw);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0;
@@ -1181,7 +1198,8 @@ function updateHistory(view, params, { replaceState = false } = {}){
     view,
     params,
     mobileStage: isMobileMode ? mobileStage : 'content',
-    [APP_HISTORY_INDEX_KEY]: nextIndex
+    [APP_HISTORY_INDEX_KEY]: nextIndex,
+    [APP_HISTORY_SESSION_KEY]: APP_HISTORY_SESSION_ID
   };
   const search = new URLSearchParams();
   Object.entries(params || {}).forEach(([k,v]) => {
@@ -1311,6 +1329,7 @@ function describeAction(action){
   const normalized = String(action || '').toLowerCase();
   if (normalized.includes('reboot')) return 'reboot all devices';
   if (normalized.includes('sync')) return 'force a full sync';
+  if (normalized.includes('update')) return 'check for updates';
   return 'run the requested action';
 }
 
@@ -1356,6 +1375,13 @@ async function runDashboardAction(action){
     steps.push(() => postJson(API_ACTION, { action: 'force_full_sync' }));
     steps.push(() => callService('akuvox_ac', 'force_full_sync', {}));
     steps.push(() => callService('akuvox_ac', 'sync_now', {}));
+  } else if (
+    normalized === 'hacs_update_check'
+    || normalized === 'hacs_auto_update'
+    || normalized === 'check_for_updates'
+  ) {
+    steps.push(() => postJson(API_ACTION, { action: 'hacs_update_check' }));
+    steps.push(() => callService('akuvox_ac', 'hacs_update_check', {}));
   } else {
     if (!changed && frame) {
       reloadActiveView({ updateHistory: false });
@@ -1559,10 +1585,11 @@ window.addEventListener('popstate', (event) => {
 });
 
 (async function init(){
-  await ensureDashboardSignedPaths();
   const searchParams = new URLSearchParams(location.search);
   const initialView = normalizeView(searchParams.get('view') || DEFAULT_VIEW);
   const params = paramsFromSearch(location.search);
+  updateHistory(initialView, params, { replaceState: true });
+  await ensureDashboardSignedPaths();
   loadView(initialView, params, { replaceState: true });
   fetchVersion();
 })();


### PR DESCRIPTION
## What changed
- scope mobile navigation history to the currently loaded shell session
- stamp the launcher history entry synchronously before asynchronous dashboard startup
- ignore stale history depth left by a prior load, preventing Back from opening unrelated dashboard pages
- add a third mobile Global Actions tile for **Check for updates**
- route the new tile through the existing `hacs_update_check` API action with its Home Assistant service fallback
- extend mobile dashboard regression coverage

## Root cause
The previous fix used a numeric history depth but did not identify which shell load created those history entries. Browsers can preserve `history.state` across reloads, so a newly loaded mobile shell could inherit an old non-zero depth and call `history.back()` into an unrelated page. There was also a short startup window before the initial launcher entry was stamped.

## User impact
- Menu -> User overview -> Back returns to the mobile launcher
- Menu -> Event history -> Back returns to the mobile launcher
- Menu -> Device management -> Back returns to the mobile launcher
- nested navigation such as Global settings -> Diagnostics -> Back still returns to Global settings
- Global Actions now includes a mobile Check for updates control

## Validation
- focused mobile dashboard tests: 4 passed
- full component suite: 140 passed, 2 known baseline tests deselected
- inline JavaScript parse check passed
- route-history simulation verified stale reset, launcher Back, and nested Back behavior
- `git diff --check` passed

The in-app browser could not open the local file because local-file navigation is blocked by its security policy, so validation used the actual inline shell script and automated tests.