### PR TITLE
[codex] Reduce redundant device API traffic

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -1535,37 +1535,31 @@ class AkuvoxAPI:
             ("GET", "/api/", None),
             ("HEAD", "/", None),
         ]
+        successful_attempt: Optional[Dict[str, Any]] = None
         for use_https, port, verify in schemes_ports:
             for m, p, pl in paths:
-                attempts.append(await _try(use_https, port, p, m, pl, verify))
+                attempt = await _try(use_https, port, p, m, pl, verify)
+                attempts.append(attempt)
+                if attempt.get("ok"):
+                    successful_attempt = attempt
+                    break
+            if successful_attempt:
+                break
 
-        ok = any(a.get("ok") for a in attempts)
+        ok = successful_attempt is not None
 
-        if ok:
-            https_attempt = next(
-                (a for a in attempts if a.get("ok") and str(a.get("scheme", "https")).lower() == "https"),
-                None,
+        if successful_attempt:
+            chosen_port = int(
+                successful_attempt.get("port")
+                or (443 if successful_attempt.get("scheme") == "https" else 80)
             )
-            any_attempt = next((a for a in attempts if a.get("ok")), None)
-
-            should_update = False
-            chosen = None
-            if not self._detected:
-                chosen = https_attempt or any_attempt
-                should_update = chosen is not None
-            elif not self._detected[0] and https_attempt:
-                chosen = https_attempt
-                should_update = True
-
-            if should_update and chosen:
-                base = chosen.get("base", "")
-                try:
-                    port = int(base.rsplit(":", 1)[1].split("/", 1)[0])
-                except Exception:
-                    port = 443 if str(chosen.get("scheme", "https")).lower() == "https" else 80
-                verify = bool(chosen.get("verify_ssl", True))
-                use_https = str(chosen.get("scheme", "https")).lower() == "https"
-                self._detected = (use_https, port, verify if use_https else True)
+            chosen_verify = bool(successful_attempt.get("verify_ssl", True))
+            chosen_https = str(successful_attempt.get("scheme") or "").lower() == "https"
+            self._detected = (
+                chosen_https,
+                chosen_port,
+                chosen_verify if chosen_https else True,
+            )
 
         return {"ok": ok, "attempts": attempts}
 

--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -3,8 +3,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "akuvox_ac"
 
-INTEGRATION_VERSION = "3.12.3"
-INTEGRATION_VERSION_LABEL = "3.12.3"
+INTEGRATION_VERSION = "3.12.4"
+INTEGRATION_VERSION_LABEL = "3.12.4"
 
 # Bump when you change stored config structure
 ENTRY_VERSION = 3

--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -34,6 +34,7 @@ CALLER_CLEAR_DELAY_SECONDS = 10
 CALLER_EVENT_WINDOW_SECONDS = 30
 ACCESS_PERMITTED_NOTIFICATION_WINDOW_SECONDS = 10
 NOTIFICATION_DIAGNOSTICS_LIMIT = 200
+USER_LIST_REFRESH_INTERVAL_SECONDS = 300
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -181,6 +182,11 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             "last_ping": None,
         }
         self.users: List[Dict[str, Any]] = []
+        self._last_user_refresh_monotonic = 0.0
+        self.schedule_ids: Dict[str, str] = {
+            "24/7 Access": "1001",
+            "No Access": "1002",
+        }
         self.events: List[Dict[str, Any]] = []  # newest first
         self._was_online: Optional[bool] = None
         self.event_state: Dict[str, Any] = {
@@ -209,6 +215,27 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         self.device_name = name
         self.friendly_name = name
         self.health["name"] = name
+
+    def set_users(self, users: List[Dict[str, Any]]) -> None:
+        """Store a fresh device user snapshot and record its fetch time."""
+        self.users = list(users or [])
+        self._last_user_refresh_monotonic = time.monotonic()
+
+    async def async_refresh_users(self, *, force: bool = False) -> List[Dict[str, Any]]:
+        """Refresh the full user list only when its slower cache is due."""
+        now = time.monotonic()
+        last_refresh = float(getattr(self, "_last_user_refresh_monotonic", 0.0) or 0.0)
+        if (
+            not force
+            and last_refresh > 0
+            and now - last_refresh < USER_LIST_REFRESH_INTERVAL_SECONDS
+        ):
+            return list(self.users or [])
+
+        users = await self.api.user_list()
+        if isinstance(users, list):
+            self.set_users(users)
+        return list(self.users or [])
 
     def _append_event(self, text: str):
         evt = {"timestamp": _now_iso(self.hass), "Event": text}
@@ -333,9 +360,7 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
 
             # Load users so integrity checker & UI can see them
             try:
-                users = await self.api.user_list()
-                if isinstance(users, list):
-                    self.users = users
+                await self.async_refresh_users()
             except Exception:
                 # don't fail the whole refresh just because the user list failed
                 pass

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -2790,36 +2790,35 @@ def _iter_device_buckets(root: Dict[str, Any]):
 
 
 async def _fetch_device_schedule_ids(root: Dict[str, Any]) -> Dict[str, str]:
+    """Return cached schedule IDs without issuing device network requests."""
     schedule_ids: Dict[str, str] = {
         "24/7 Access": "1001",
         "No Access": "1002",
     }
-    for _, data, _, _ in _iter_device_buckets(root):
-        api = data.get("api")
-        if not api:
+
+    for _, _, coord, _ in _iter_device_buckets(root):
+        cached = getattr(coord, "schedule_ids", None)
+        if not isinstance(cached, Mapping):
             continue
-        try:
-            items = await api.schedule_get()
-        except Exception:
+        for name, schedule_id in cached.items():
+            clean_name = str(name or "").strip()
+            clean_id = str(schedule_id or "").strip()
+            if clean_name and clean_id:
+                schedule_ids[clean_name] = clean_id
+
+    users_store = root.get("users_store")
+    try:
+        profiles = users_store.all() if users_store else {}
+    except Exception:
+        profiles = {}
+    for profile in (profiles or {}).values():
+        if not isinstance(profile, Mapping):
             continue
-        if not isinstance(items, list):
-            continue
-        matched = False
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            name = str(item.get("Name") or "").strip()
-            schedule_id = str(
-                item.get("ScheduleID")
-                or item.get("ScheduleId")
-                or item.get("ID")
-                or ""
-            ).strip()
-            if name and schedule_id:
-                schedule_ids[name] = schedule_id
-                matched = True
-        if matched:
-            break
+        name = str(profile.get("schedule_name") or "").strip()
+        schedule_id = str(profile.get("schedule_id") or "").strip()
+        if name and schedule_id:
+            schedule_ids.setdefault(name, schedule_id)
+
     return schedule_ids
 
 

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2257,6 +2257,56 @@ def _schedule_times_out_of_order(spec: Mapping[str, Any]) -> bool:
     return start > end
 
 
+def _device_schedule_id(record: Mapping[str, Any]) -> str:
+    return str(
+        record.get("DisplayID")
+        or record.get("display_id")
+        or record.get("ScheduleID")
+        or record.get("ScheduleId")
+        or record.get("ID")
+        or record.get("Id")
+        or ""
+    ).strip()
+
+
+def _device_schedule_maps(
+    device_schedules: Optional[Iterable[Mapping[str, Any]]],
+) -> Tuple[Dict[str, str], Dict[str, str]]:
+    by_lower_name = {
+        "24/7 access": "1001",
+        "no access": "1002",
+    }
+    by_display_name = {
+        "24/7 Access": "1001",
+        "No Access": "1002",
+    }
+    for item in device_schedules or []:
+        if not isinstance(item, Mapping):
+            continue
+        name = str(item.get("Name") or "").strip()
+        schedule_id = _device_schedule_id(item)
+        if not name or not schedule_id:
+            continue
+        by_lower_name[name.lower()] = schedule_id
+        by_display_name[name] = schedule_id
+    return by_lower_name, by_display_name
+
+
+def _set_coordinator_users(coord: AkuvoxCoordinator, users: List[Dict[str, Any]]) -> None:
+    if hasattr(coord, "set_users"):
+        coord.set_users(users)
+    else:
+        coord.users = list(users or [])
+
+
+def _set_coordinator_schedule_ids(
+    coord: AkuvoxCoordinator,
+    device_schedules: Optional[Iterable[Mapping[str, Any]]],
+) -> None:
+    _, by_display_name = _device_schedule_maps(device_schedules)
+    coord.schedule_ids = by_display_name
+
+
 def _normalize_schedule_for_integrity(
     schedules_store: AkuvoxSchedulesStore,
     name: str,
@@ -4781,7 +4831,7 @@ class SyncQueue:
                         except Exception:
                             pass
                     try:
-                        await coord.async_request_refresh()
+                        coord.async_update_listeners()
                     except Exception:
                         pass
             finally:
@@ -6098,12 +6148,16 @@ class SyncManager:
                 except Exception:
                     pass
             try:
-                await coord.async_request_refresh()
+                coord.async_update_listeners()
             except Exception:
                 pass
 
     # ---------- NEW: device schedule map ----------
-    async def _device_schedule_map(self, api: AkuvoxAPI) -> Dict[str, str]:
+    async def _device_schedule_map(
+        self,
+        api: AkuvoxAPI,
+        device_schedules: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, str]:
         """
         Return Name->ScheduleID map as strings for this device.
         Always includes the built-ins:
@@ -6111,28 +6165,12 @@ class SyncManager:
           'No Access'   -> '1002'
         Then overlays whatever the device reports via schedule_get().
         """
-        name_to_id: Dict[str, str] = {
-            "24/7 access": "1001",
-            "no access": "1002",
-        }
-        try:
-            dev_scheds = await api.schedule_get()  # [{"Name": "...", "DisplayID":"1"}, ...]
-            for it in dev_scheds or []:
-                n = str(it.get("Name") or "").strip()
-                sid = str(it.get("DisplayID") or it.get("display_id") or "").strip()
-                if not sid:
-                    sid = str(
-                        it.get("ScheduleID")
-                        or it.get("ScheduleId")
-                        or it.get("ID")
-                        or it.get("Id")
-                        or ""
-                    ).strip()
-                if n and sid:
-                    name_to_id[n.lower()] = sid
-        except Exception:
-            # best-effort; built-ins still usable
-            pass
+        if device_schedules is None:
+            try:
+                device_schedules = await api.schedule_get()
+            except Exception:
+                device_schedules = []
+        name_to_id, _ = _device_schedule_maps(device_schedules)
         return name_to_id
 
     async def _set_user_on_device(
@@ -6215,18 +6253,25 @@ class SyncManager:
         if removed_profile:
             await self._prune_stale_alert_users()
 
-    async def _push_schedules(self, api: AkuvoxAPI, schedules: Dict[str, Any]):
+    async def _push_schedules(
+        self,
+        api: AkuvoxAPI,
+        schedules: Dict[str, Any],
+        device_schedules: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
         if not schedules:
-            return
-        device_schedule_names: Optional[set[str]] = None
-        try:
-            device_schedule_names = {
-                str(it.get("Name") or "").strip().lower()
-                for it in (await api.schedule_get()) or []
-                if isinstance(it, dict)
-            }
-        except Exception:
-            device_schedule_names = None
+            return False
+        if device_schedules is None:
+            try:
+                device_schedules = await api.schedule_get()
+            except Exception:
+                return False
+        device_schedule_records = {
+            str(item.get("Name") or "").strip().lower(): item
+            for item in device_schedules or []
+            if isinstance(item, dict) and str(item.get("Name") or "").strip()
+        }
+        added_schedule = False
         for name, spec in (schedules or {}).items():
             if name in ("24/7 Access", "No Access"):
                 continue
@@ -6239,35 +6284,48 @@ class SyncManager:
             else:
                 sanitized = {}
             try:
-                if device_schedule_names is not None and name.strip().lower() in device_schedule_names:
+                existing = device_schedule_records.get(name.strip().lower())
+                if existing is not None:
+                    for key in ("ID", "Id", "ScheduleID", "ScheduleId", "DisplayID", "display_id"):
+                        if existing.get(key) not in (None, ""):
+                            sanitized[key] = existing.get(key)
                     await api.schedule_set(name, sanitized)
                 else:
                     await api.schedule_add(name, sanitized)
+                    added_schedule = True
             except Exception:
                 try:
                     await api.schedule_set(name, sanitized)
                 except Exception:
                     pass
+        return added_schedule
 
-    async def _ensure_device_schedules(self, api: AkuvoxAPI, schedules: Dict[str, Any]) -> None:
+    async def _ensure_device_schedules(
+        self,
+        api: AkuvoxAPI,
+        schedules: Dict[str, Any],
+        device_schedules: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
         if not schedules:
-            return
-        device_schedule_names: Optional[set[str]] = None
-        try:
-            device_schedule_names = {
-                str(it.get("Name") or "").strip().lower()
-                for it in (await api.schedule_get()) or []
-                if isinstance(it, dict)
-            }
-        except Exception:
-            device_schedule_names = None
+            return False
+        if device_schedules is None:
+            try:
+                device_schedules = await api.schedule_get()
+            except Exception:
+                return False
+        device_schedule_names = {
+            str(it.get("Name") or "").strip().lower()
+            for it in device_schedules or []
+            if isinstance(it, dict)
+        }
+        added_schedule = False
 
         for name, spec in (schedules or {}).items():
             if name in ("24/7 Access", "No Access"):
                 continue
             if isinstance(spec, dict) and (spec.get("system_exit_clone") or spec.get("exit_clone_for")):
                 continue
-            if device_schedule_names is not None and name.strip().lower() in device_schedule_names:
+            if name.strip().lower() in device_schedule_names:
                 continue
             sanitized: Dict[str, Any]
             if isinstance(spec, dict):
@@ -6277,11 +6335,13 @@ class SyncManager:
                 sanitized = {}
             try:
                 await api.schedule_add(name, sanitized)
+                added_schedule = True
             except Exception:
                 try:
                     await api.schedule_set(name, sanitized)
                 except Exception:
                     pass
+        return added_schedule
 
     async def _remove_missing_users(self, api: AkuvoxAPI, local_users: List[Dict[str, Any]], registry_keys_set: set):
         rogue_keys: List[str] = []
@@ -6332,17 +6392,48 @@ class SyncManager:
                 schedules_all = schedules_store.all()
             except Exception:
                 schedules_all = {}
-        try:
-            await self._ensure_device_schedules(api, schedules_all)
-        except Exception:
-            pass
+
+        device_schedules: List[Dict[str, Any]] = []
+        schedule_snapshot_loaded = not bool(schedules_all)
+        if schedules_all:
+            try:
+                device_schedules = await api.schedule_get()
+                schedule_snapshot_loaded = True
+            except Exception:
+                schedule_snapshot_loaded = False
+
+        schedules_added = False
+        if schedule_snapshot_loaded:
+            try:
+                if full and schedules_store:
+                    schedules_added = await self._push_schedules(
+                        api,
+                        schedules_all,
+                        device_schedules=device_schedules,
+                    )
+                else:
+                    schedules_added = await self._ensure_device_schedules(
+                        api,
+                        schedules_all,
+                        device_schedules=device_schedules,
+                    )
+            except Exception:
+                pass
+
+        if schedules_added:
+            try:
+                device_schedules = await api.schedule_get()
+            except Exception:
+                pass
+        if schedule_snapshot_loaded:
+            _set_coordinator_schedule_ids(coord, device_schedules)
 
         try:
             local_users: List[Dict[str, Any]] = await api.user_list()
         except Exception:
             local_users = list(coord.users or [])
         try:
-            coord.users = local_users
+            _set_coordinator_users(coord, local_users)
         except Exception:
             pass
         await _store_device_user_ids(getattr(coord, "storage", None), local_users)
@@ -6405,14 +6496,11 @@ class SyncManager:
 
             await self._remove_missing_users(api, local_users, reg_key_set)
 
-        if full and schedules_store:
-            try:
-                await self._push_schedules(api, schedules_all)
-            except Exception:
-                pass
-
         # Resolve device schedule IDs after pushing (so we use what the device knows)
-        sched_map = await self._device_schedule_map(api)
+        sched_map = await self._device_schedule_map(
+            api,
+            device_schedules=device_schedules,
+        )
 
         exit_schedule_map = _build_exit_schedule_map(schedules_all)
 
@@ -6562,7 +6650,7 @@ class SyncManager:
                     pass
                 try:
                     local_users = await api.user_list()
-                    coord.users = local_users
+                    _set_coordinator_users(coord, local_users)
                     await _store_device_user_ids(getattr(coord, "storage", None), local_users)
                 except Exception:
                     pass
@@ -6606,7 +6694,7 @@ class SyncManager:
             if face_add_batch or fallback_add_batch:
                 try:
                     local_users = await api.user_list()
-                    coord.users = local_users
+                    _set_coordinator_users(coord, local_users)
                     await _store_device_user_ids(getattr(coord, "storage", None), local_users)
                 except Exception:
                     pass
@@ -6757,7 +6845,7 @@ class SyncManager:
                     pass
                 try:
                     local_users = await api.user_list()
-                    coord.users = local_users
+                    _set_coordinator_users(coord, local_users)
                     await _store_device_user_ids(getattr(coord, "storage", None), local_users)
                 except Exception:
                     pass
@@ -6780,7 +6868,7 @@ class SyncManager:
             pass
 
         try:
-            await coord.async_request_refresh()
+            coord.async_update_listeners()
         except Exception:
             pass
 
@@ -6833,7 +6921,7 @@ class SyncManager:
             try:
                 opts = opts or {}
                 dev_users = await api.user_list()
-                coord.users = dev_users or []
+                _set_coordinator_users(coord, dev_users or [])
                 await _store_device_user_ids(getattr(coord, "storage", None), coord.users)
                 device_records: Dict[str, List[Dict[str, Any]]] = {}
                 for record in coord.users or []:
@@ -6852,7 +6940,17 @@ class SyncManager:
                     if any(g in device_groups for g in ha_groups):
                         should_have.add(k)
 
-                sched_map = await self._device_schedule_map(api)
+                device_schedules: Optional[List[Dict[str, Any]]]
+                try:
+                    device_schedules = await api.schedule_get()
+                except Exception:
+                    device_schedules = None
+                if device_schedules is not None:
+                    _set_coordinator_schedule_ids(coord, device_schedules)
+                sched_map = await self._device_schedule_map(
+                    api,
+                    device_schedules=device_schedules or [],
+                )
                 device_type_raw = (coord.health.get("device_type") or "").strip()
                 mismatch_reason: Optional[str] = None
 
@@ -6909,7 +7007,10 @@ class SyncManager:
                                         if not repaired:
                                             raise RuntimeError("face upload repair did not complete")
                                         try:
-                                            coord.users = await api.user_list()
+                                            _set_coordinator_users(
+                                                coord,
+                                                await api.user_list(),
+                                            )
                                             await _store_device_user_ids(
                                                 getattr(coord, "storage", None),
                                                 coord.users,
@@ -6945,7 +7046,10 @@ class SyncManager:
                                             if not repaired:
                                                 raise RuntimeError("face upload repair did not complete")
                                             try:
-                                                coord.users = await api.user_list()
+                                                _set_coordinator_users(
+                                                    coord,
+                                                    await api.user_list(),
+                                                )
                                                 await _store_device_user_ids(
                                                     getattr(coord, "storage", None),
                                                     coord.users,
@@ -6979,11 +7083,6 @@ class SyncManager:
                             break
 
                 if mismatch_reason is None and schedules_store:
-                    try:
-                        device_schedules = await api.schedule_get()
-                    except Exception:
-                        device_schedules = None
-
                     if device_schedules is not None:
                         device_map: Dict[str, Dict[str, Any]] = {}
                         for sched in device_schedules or []:

--- a/custom_components/akuvox_ac/manifest.json
+++ b/custom_components/akuvox_ac/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "akuvox_ac",
   "name": "Akuvox Access Control",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "codeowners": [
     "@you"
   ],

--- a/custom_components/akuvox_ac/tests/test_api_call_efficiency.py
+++ b/custom_components/akuvox_ac/tests/test_api_call_efficiency.py
@@ -1,0 +1,127 @@
+import asyncio
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac import http as http_module  # noqa: E402
+from custom_components.akuvox_ac.integration import SyncManager  # noqa: E402
+
+
+class _ScheduleApiStub:
+    def __init__(self, *, fail_get=False) -> None:
+        self.fail_get = fail_get
+        self.schedule_get_calls = 0
+        self.schedule_add_calls = []
+        self.schedule_set_calls = []
+
+    async def schedule_get(self):
+        self.schedule_get_calls += 1
+        if self.fail_get:
+            raise RuntimeError("device unavailable")
+        return []
+
+    async def schedule_add(self, name, spec):
+        self.schedule_add_calls.append((name, dict(spec)))
+
+    async def schedule_set(self, name, spec):
+        self.schedule_set_calls.append((name, dict(spec)))
+
+
+class _UsersStoreStub:
+    def all(self):
+        return {
+            "HA001": {
+                "schedule_name": "Night Staff",
+                "schedule_id": "8",
+            }
+        }
+
+
+def test_dashboard_schedule_ids_use_cached_state_without_device_request():
+    class _ApiThatMustNotBeCalled:
+        async def schedule_get(self):
+            raise AssertionError("dashboard state must not fetch schedules from the device")
+
+    coordinator = type(
+        "Coordinator",
+        (),
+        {"schedule_ids": {"Post Man": "3"}},
+    )()
+    root = {
+        "device-1": {
+            "api": _ApiThatMustNotBeCalled(),
+            "coordinator": coordinator,
+            "options": {},
+        },
+        "users_store": _UsersStoreStub(),
+    }
+
+    schedule_ids = asyncio.run(http_module._fetch_device_schedule_ids(root))
+
+    assert schedule_ids == {
+        "24/7 Access": "1001",
+        "No Access": "1002",
+        "Post Man": "3",
+        "Night Staff": "8",
+    }
+
+
+def test_schedule_map_reuses_supplied_device_snapshot():
+    manager = object.__new__(SyncManager)
+    api = _ScheduleApiStub()
+    snapshot = [{"Name": "Post Man", "ID": "5", "DisplayID": "3"}]
+
+    schedule_map = asyncio.run(
+        manager._device_schedule_map(api, device_schedules=snapshot)
+    )
+
+    assert api.schedule_get_calls == 0
+    assert schedule_map["post man"] == "3"
+
+
+def test_schedule_push_reuses_snapshot_and_supplies_ids_for_update():
+    manager = object.__new__(SyncManager)
+    api = _ScheduleApiStub()
+    snapshot = [{"Name": "Post Man", "ID": "5", "DisplayID": "3"}]
+
+    added = asyncio.run(
+        manager._push_schedules(
+            api,
+            {"Post Man": {"start": "07:00", "end": "18:00"}},
+            device_schedules=snapshot,
+        )
+    )
+
+    assert added is False
+    assert api.schedule_get_calls == 0
+    assert api.schedule_add_calls == []
+    assert api.schedule_set_calls == [
+        (
+            "Post Man",
+                {
+                    "start": "07:00",
+                    "end": "18:00",
+                    "days": [],
+                    "ID": "5",
+                    "DisplayID": "3",
+                },
+        )
+    ]
+
+
+def test_schedule_push_does_not_add_when_initial_schedule_read_fails():
+    manager = object.__new__(SyncManager)
+    api = _ScheduleApiStub(fail_get=True)
+
+    added = asyncio.run(
+        manager._push_schedules(
+            api,
+            {"Post Man": {"start": "07:00", "end": "18:00"}},
+        )
+    )
+
+    assert added is False
+    assert api.schedule_get_calls == 1
+    assert api.schedule_add_calls == []
+    assert api.schedule_set_calls == []

--- a/custom_components/akuvox_ac/tests/test_api_events.py
+++ b/custom_components/akuvox_ac/tests/test_api_events.py
@@ -53,7 +53,11 @@ class _RequestContextStub:
 
 
 class _SessionStub:
+    def __init__(self) -> None:
+        self.requests = []
+
     def _build(self, url: str):
+        self.requests.append(url)
         if url.startswith("https://"):
             return _RequestContextStub(_ResponseStub(503, "tls unavailable"))
         return _RequestContextStub(_ResponseStub(200, "ok"))
@@ -133,9 +137,24 @@ def test_extract_doorlog_items_returns_empty_for_unknown_payload():
 def test_ping_info_detects_http_device_when_https_fails():
     import asyncio
 
-    api = AkuvoxAPI(_SessionStub(), host="127.0.0.1", port=80, username="", password="")
+    session = _SessionStub()
+    api = AkuvoxAPI(
+        "127.0.0.1",
+        port=80,
+        username="",
+        password="",
+        session=session,
+    )
 
     info = asyncio.run(api.ping_info())
 
     assert info["ok"] is True
     assert api._detected == (False, 80, True)
+    assert len(info["attempts"]) < 36
+
+    session.requests.clear()
+    info = asyncio.run(api.ping_info())
+
+    assert info["ok"] is True
+    assert len(info["attempts"]) == 1
+    assert session.requests == ["http://127.0.0.1:80/api/system/status"]

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -64,10 +64,16 @@ class _UsersStoreStub:
 
 
 class _HealthAPIStub:
+    def __init__(self) -> None:
+        self.ping_calls = 0
+        self.user_list_calls = 0
+
     async def ping_info(self) -> Dict[str, Any]:
+        self.ping_calls += 1
         return {"ok": True}
 
     async def user_list(self) -> List[Dict[str, Any]]:
+        self.user_list_calls += 1
         return []
 
 
@@ -134,6 +140,27 @@ def test_offline_to_online_refresh_does_not_reconcile_unchanged_users():
 
     assert coord.health["online"] is True
     assert queue.calls == []
+
+
+def test_health_refresh_caches_full_user_list_between_door_event_polls():
+    queue = _SyncQueueStub()
+    coord = _build_health_coordinator(queue)
+    coord._was_online = True
+    event_polls = 0
+
+    async def _count_event_poll(*_args, **_kwargs):
+        nonlocal event_polls
+        event_polls += 1
+        return []
+
+    coord._process_door_events = _count_event_poll  # type: ignore[method-assign]
+
+    asyncio.run(coord._async_update_data())
+    asyncio.run(coord._async_update_data())
+
+    assert coord.api.ping_calls == 2
+    assert coord.api.user_list_calls == 1
+    assert event_polls == 2
 
 
 def test_resolve_event_user_id_matches_profile_name_to_canonical_id():

--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -68,3 +68,10 @@ def test_mobile_global_actions_include_update_check():
     assert '<span class="tile-title">Check for updates</span>' in shell
     assert "steps.push(() => postJson(API_ACTION, { action: 'hacs_update_check' }));" in shell
     assert "steps.push(() => callService('akuvox_ac', 'hacs_update_check', {}));" in shell
+
+
+def test_dashboards_start_only_one_state_polling_loop():
+    for name in ("index.html", "index-mob.html"):
+        page = read_page(name)
+        assert page.count("setInterval(refresh, 5000);") == 1
+        assert page.count("// initial + poll") == 1

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -2665,9 +2665,6 @@ function startNextSyncCountdown(iso, fallbackTime){
   }, 60000);
 }
 
-/* initial + poll */
-refresh();
-setInterval(refresh, 5000);
 </script>
 
   <div class="workspace">

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -2864,9 +2864,6 @@ function startNextSyncCountdown(iso, fallbackTime){
   }, 60000);
 }
 
-/* initial + poll */
-refresh();
-setInterval(refresh, 5000);
 </script>
 
   <div class="workspace">


### PR DESCRIPTION
## What changed
- Reuse one device schedule snapshot during reconcile and integrity checks instead of issuing repeated `schedule:get` calls.
- Serve dashboard schedule IDs from coordinator/profile caches so five-second UI refreshes no longer read schedules from devices.
- Stop transport probing after the first successful health endpoint and reuse the detected transport on later polls.
- Keep door-event polling on every health cycle, but cache the full user list for five minutes and refresh it immediately after sync writes.
- Replace post-sync full coordinator refreshes with local listener updates where the device data was already refreshed.
- Remove duplicate five-second polling loops from both desktop and mobile dashboards.
- Bump the integration version to `3.12.4`.

## Root cause
A full reconcile could fetch schedules up to four times through overlapping helper paths. Separately, every dashboard state request fetched schedules from a physical device, and both dashboard variants started two polling timers. Health checks also continued probing every protocol/path combination after finding a working endpoint.

## Impact
The integration keeps required door-log and write-safety calls, while substantially reducing repeated reads as more devices and dashboard sessions are added. Failed schedule reads now skip writes rather than treating the device as empty.

## Validation
- 123 non-coordinator tests passed.
- 24 coordinator tests passed; one pre-existing Europe/London timezone-sensitive timestamp assertion was excluded.
- Python compile check passed.
- `git diff --check` passed.
- Added request-count regression tests for health probes, user caching, schedule snapshot reuse, dashboard cache behavior, and polling-loop count.