### PR TITLE
[codex] Recognize call access notifications

### DIFF
--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -3,8 +3,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "akuvox_ac"
 
-INTEGRATION_VERSION = "3.12.4"
-INTEGRATION_VERSION_LABEL = "3.12.4"
+INTEGRATION_VERSION = "3.12.5"
+INTEGRATION_VERSION_LABEL = "3.12.5"
 
 # Bump when you change stored config structure
 ENTRY_VERSION = 3

--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -1786,7 +1786,8 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             if re.search(r"\bface\b|\bfacial\b", text):
                 return "Face"
             if (
-                "dtmf" in compact
+                compact == "call"
+                or "dtmf" in compact
                 or "calltoopen" in compact
                 or "openbycall" in compact
                 or "callunlock" in compact

--- a/custom_components/akuvox_ac/manifest.json
+++ b/custom_components/akuvox_ac/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "akuvox_ac",
   "name": "Akuvox Access Control",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "codeowners": [
     "@you"
   ],

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -263,6 +263,7 @@ def test_derive_targets_from_raw_ignores_specific_users_when_disabled():
     [
         ("Private PIN", "Neil smalley opened the gate via code."),
         ("Face", "Neil smalley opened the gate via Face."),
+        ("Call", "Neil smalley opened the gate via Call."),
         ("DTMF", "Neil smalley opened the gate via Call."),
     ],
 )
@@ -321,6 +322,7 @@ def test_dispatch_notification_appends_system_event_on_failure():
     [
         ({"UserName": "Alice", "Type": "Private PIN"}, "Alice opened the gate via code."),
         ({"UserName": "Alice", "Type": "Face"}, "Alice opened the gate via Face."),
+        ({"UserName": "Alice", "Type": "Call"}, "Alice opened the gate via Call."),
         ({"UserName": "Alice", "Type": "DTMF"}, "Alice opened the gate via Call."),
         ({"UserName": "Alice", "Type": "Unknown"}, "Alice opened the gate."),
     ],


### PR DESCRIPTION
## What changed
- Recognise the standalone door-event method `Call` as call-to-open access.
- Preserve the existing handling for `DTMF`, `call to open`, `open by call`, and `call unlock` values.
- Add regression coverage to both access-notification delivery paths.
- Bump the integration version to `3.12.5`.

## Root cause
PR #379 added method-aware access notifications, but its call matcher covered DTMF and compound call-to-open phrases rather than the plain `Call` value displayed by the device event history. Those events could therefore fall back to `<name> opened the gate.` without `via Call`.

## Result
Notifications now consistently produce:
- `<name> opened the gate via code.`
- `<name> opened the gate via Face.`
- `<name> opened the gate via Call.`

## Validation
- 123 non-coordinator tests passed.
- 26 coordinator tests passed; one pre-existing Europe/London timezone-sensitive timestamp assertion was excluded.
- Focused method-aware notification tests: 9 passed.
- Python compile and `git diff --check` passed.