### PR TITLE
[codex] Complete mobile actions and denied-call alerts

### DIFF
--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -3,8 +3,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "akuvox_ac"
 
-INTEGRATION_VERSION = "3.12.5"
-INTEGRATION_VERSION_LABEL = "3.12.5"
+INTEGRATION_VERSION = "3.12.6"
+INTEGRATION_VERSION_LABEL = "3.12.6"
 
 # Bump when you change stored config structure
 ENTRY_VERSION = 3

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1454,6 +1454,24 @@ async def _process_inbound_call_webhook(
 
     hass.bus.async_fire(EVENT_INBOUND_CALL, event_payload)
 
+    if result == INBOUND_CALL_RESULT_DENIED:
+        device_data = root.get(best.get("entry_id")) or {}
+        coordinator = device_data.get("coordinator") if isinstance(device_data, dict) else None
+        notifier = getattr(coordinator, "_send_alert_notification", None)
+        if callable(notifier):
+            try:
+                await notifier(
+                    "any_denied",
+                    user_id=display_number or None,
+                    summary=status_label,
+                    extra={"event": history_event},
+                )
+            except Exception as err:
+                _LOGGER.debug(
+                    "Failed to dispatch denied inbound-call notification: %s",
+                    err,
+                )
+
     _LOGGER.debug(
         "Inbound call webhook result=%s device=%s number=%s user=%s key_holder=%s",
         result,

--- a/custom_components/akuvox_ac/manifest.json
+++ b/custom_components/akuvox_ac/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "akuvox_ac",
   "name": "Akuvox Access Control",
-  "version": "3.12.5",
+  "version": "3.12.6",
   "codeowners": [
     "@you"
   ],

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -258,6 +258,18 @@ def test_derive_targets_from_raw_ignores_specific_users_when_disabled():
     assert _derive_targets_from_raw(targets, "user_granted", user_id="HA012") == []
 
 
+def test_derive_targets_from_raw_notifies_any_denied_without_known_user():
+    targets = {
+        "mobile_app_security_phone": {
+            "any_denied": True,
+        }
+    }
+
+    assert _derive_targets_from_raw(targets, "any_denied", user_id=None) == [
+        "mobile_app_security_phone"
+    ]
+
+
 @pytest.mark.parametrize(
     ("event_type", "expected_message"),
     [
@@ -366,6 +378,29 @@ def test_send_alert_notification_records_system_notification():
     assert diag[0]["channel"] == "alert_notification"
     assert diag[0]["event_type"] == "user_granted"
     assert diag[0]["message"] == "Alice opened the gate."
+
+
+@pytest.mark.parametrize(
+    ("user_id", "expected_message"),
+    [
+        (None, "Access denied for Unknown user on Akuvox."),
+        ("07920671814", "Access denied for 07920671814 on Akuvox."),
+    ],
+)
+def test_send_alert_notification_reports_unknown_denied_user(
+    user_id,
+    expected_message,
+):
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.hass.services = _ServiceStub()
+    coord.hass.data = {
+        DOMAIN: {"settings_store": _SettingsStub(["mobile_app_security_phone"])}
+    }
+
+    asyncio.run(coord._send_alert_notification("any_denied", user_id=user_id))
+
+    assert coord.hass.services.calls[0]["data"]["message"] == expected_message
 
 
 def test_access_permitted_button_records_would_notify_targets_when_skipped():

--- a/custom_components/akuvox_ac/tests/test_inbound_call_notifications.py
+++ b/custom_components/akuvox_ac/tests/test_inbound_call_notifications.py
@@ -1,0 +1,71 @@
+import asyncio
+import datetime as dt
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac.const import (  # noqa: E402
+    DOMAIN,
+    INBOUND_CALL_RESULT_DENIED,
+)
+from custom_components.akuvox_ac.http import _process_inbound_call_webhook  # noqa: E402
+
+
+class _CallApiStub:
+    async def call_log(self):
+        return [
+            {
+                "ID": "call-1",
+                "Type": "received",
+                "Number": "07920671814",
+                "Timestamp": dt.datetime.now().isoformat(),
+            }
+        ]
+
+
+class _CoordinatorStub:
+    def __init__(self):
+        self.device_name = "Gate"
+        self.health = {"device_type": "Intercom"}
+        self.notifications = []
+
+    async def _send_alert_notification(self, event_type, **kwargs):
+        self.notifications.append((event_type, kwargs))
+
+
+class _BusStub:
+    def __init__(self):
+        self.events = []
+
+    def async_fire(self, event_type, payload):
+        self.events.append((event_type, payload))
+
+
+def test_unknown_inbound_call_uses_any_denied_notification_rule():
+    coordinator = _CoordinatorStub()
+    hass = type(
+        "Hass",
+        (),
+        {
+            "data": {
+                DOMAIN: {
+                    "device-1": {
+                        "api": _CallApiStub(),
+                        "coordinator": coordinator,
+                    }
+                }
+            },
+            "bus": _BusStub(),
+        },
+    )()
+
+    result = asyncio.run(_process_inbound_call_webhook(hass))
+
+    assert result["result"] == INBOUND_CALL_RESULT_DENIED
+    assert len(coordinator.notifications) == 1
+    event_type, kwargs = coordinator.notifications[0]
+    assert event_type == "any_denied"
+    assert kwargs["user_id"] == "07920671814"
+    assert kwargs["summary"] == "Inbound call - access Denied (07920671814)"
+    assert kwargs["extra"]["event"]["CallNumber"] == "07920671814"

--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -64,8 +64,17 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
 def test_mobile_global_actions_include_update_check():
     shell = read_page("head-mob.html")
 
-    assert 'data-action="hacs_update_check"' in shell
+    assert shell.count('data-action="hacs_update_check"') == 2
+    assert (
+        '<button type="button" class="quick-btn" data-action="hacs_update_check">'
+        in shell
+    )
+    assert (
+        '<button class="mobile-tile sub" type="button" data-action="hacs_update_check">'
+        in shell
+    )
     assert '<span class="tile-title">Check for updates</span>' in shell
+    assert '<span>Check for updates</span>' in shell
     assert "steps.push(() => postJson(API_ACTION, { action: 'hacs_update_check' }));" in shell
     assert "steps.push(() => callService('akuvox_ac', 'hacs_update_check', {}));" in shell
 

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -374,6 +374,10 @@
           <i class="bi bi-lightning-charge-fill"></i>
           <span>Force full sync</span>
         </button>
+        <button type="button" class="quick-btn" data-action="hacs_update_check">
+          <i class="bi bi-cloud-arrow-down-fill"></i>
+          <span>Check for updates</span>
+        </button>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## What changed
- Added **Check for updates** to the compact mobile Global Actions menu as well as the existing full mobile action tiles.
- Routed denied inbound calls, including unknown telephone numbers, through the existing **Any User Denied Access** notification rule.
- Preserved the caller number in denied-access notifications so operators can identify an unknown caller.
- Bumped the integration version from `3.12.5` to `3.12.6`.

## Root cause
Inbound call denials were recorded in event history and emitted on the Home Assistant event bus, but they never called the alert notification dispatcher. The mobile update action already had backend wiring, but was absent from the compact Global Actions menu.

## User impact
With **Any User Denied Access** enabled, an unknown denied caller such as `07920671814` now produces:

- Title: `Akuvox • Gate`
- Message: `Access denied for 07920671814 on Gate.`

## Validation
- Broad suite: `152 passed, 2 deselected`
- Focused notification/mobile suite: `35 passed, 1 deselected`
- Python compilation passed
- `git diff --check` passed
- Mobile phone-width visual preview confirmed all three Global Actions buttons