### PR TITLE
[codex] Fix cloud user source detection

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -59,6 +59,21 @@ def _json_copy(value: Any) -> Any:
             return str(value)
 
 
+def _normalize_user_source(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Expose the firmware user source under the dashboard-compatible key."""
+
+    normalized = dict(record)
+    for key in ("SourceType", "sourceType", "source_type", "Source", "source"):
+        value = record.get(key)
+        if value in (None, ""):
+            continue
+        source = str(value).strip()
+        if source:
+            normalized["Source"] = source
+            break
+    return normalized
+
+
 def _truncate_string(value: str, limit: int = 800) -> str:
     """Trim very long strings so diagnostics stay manageable."""
 
@@ -1731,7 +1746,12 @@ class AkuvoxAPI:
                     r = await self._post_api(payload, rel_paths=(rel,))
                     items = r.get("data", {}).get("item")
                     if isinstance(items, list):
-                        return items
+                        return [
+                            _normalize_user_source(item)
+                            if isinstance(item, dict)
+                            else item
+                            for item in items
+                        ]
                 except Exception:
                     pass
         return []

--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -3,8 +3,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "akuvox_ac"
 
-INTEGRATION_VERSION = "3.12.6"
-INTEGRATION_VERSION_LABEL = "3.12.6"
+INTEGRATION_VERSION = "3.12.7"
+INTEGRATION_VERSION_LABEL = "3.12.7"
 
 # Bump when you change stored config structure
 ENTRY_VERSION = 3

--- a/custom_components/akuvox_ac/manifest.json
+++ b/custom_components/akuvox_ac/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "akuvox_ac",
   "name": "Akuvox Access Control",
-  "version": "3.12.6",
+  "version": "3.12.7",
   "codeowners": [
     "@you"
   ],

--- a/custom_components/akuvox_ac/tests/test_api_user_source.py
+++ b/custom_components/akuvox_ac/tests/test_api_user_source.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from custom_components.akuvox_ac.api import AkuvoxAPI, _normalize_user_source
+
+
+def test_normalize_user_source_prefers_firmware_source_type():
+    record = {
+        "UserID": "cloud-user",
+        "Source": "Local",
+        "SourceType": "Cloud",
+    }
+
+    normalized = _normalize_user_source(record)
+
+    assert normalized["Source"] == "Cloud"
+    assert record["Source"] == "Local"
+
+
+def test_user_list_exposes_source_type_as_source():
+    api = object.__new__(AkuvoxAPI)
+
+    async def post_api(payload, *, rel_paths):
+        return {
+            "data": {
+                "item": [
+                    {
+                        "UserID": "cloud-user",
+                        "Name": "Cloud User",
+                        "SourceType": "Cloud",
+                    },
+                    {
+                        "UserID": "HA001",
+                        "Name": "Local User",
+                        "SourceType": "Local",
+                    },
+                ]
+            }
+        }
+
+    api._post_api = post_api
+
+    users = asyncio.run(api.user_list())
+
+    assert users[0]["Source"] == "Cloud"
+    assert users[1]["Source"] == "Local"

--- a/custom_components/akuvox_ac/tests/test_dashboard_user_source.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_user_source.py
@@ -8,18 +8,26 @@ def test_dashboard_templates_show_cloud_and_local_user_sources():
         html = (www / filename).read_text(encoding="utf-8")
 
         assert "<th>Source</th>" in html
+        assert "function isCloudManagedUser(record)" in html
+        assert "record?.SourceType" in html
         assert "function userSourceBadge(user)" in html
+        assert "const cloud = isCloudManagedUser(user)" in html
         assert "const label = cloud ? 'Cloud' : 'Local'" in html
         assert "class=\"badge user-source-badge ${kind}\"" in html
         assert ".badge-cloud{" in html
         assert ".badge-local{" in html
-        assert "user?.isCloud ? 'cloud' : 'local'" in html
+        assert "isCloudManagedUser(user) ? 'cloud' : 'local'" in html
+        assert "const isCloud = isCloudManagedUser(u)" in html
         assert "<td>${userSourceBadge(u)}</td>" in html
 
     desktop = (www / "index.html").read_text(encoding="utf-8")
     mobile = (www / "index-mob.html").read_text(encoding="utf-8")
+    overview = (www / "user_overview-mob.html").read_text(encoding="utf-8")
 
     assert "const columnCount = showPinColumn ? 8 : 7;" in desktop
     assert '<td colspan="7" class="text-muted">Loading' in desktop
     assert '<td colspan="8" class="text-muted">Loading' in mobile
     assert "colspan=\"8\" class=\"text-muted\">No users" in mobile
+    assert "function isCloudManagedUser(record)" in overview
+    assert "record?.SourceType" in overview
+    assert "const isCloud = isCloudManagedUser(u)" in overview

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -806,8 +806,32 @@ function badge(text, kind, attrs = ''){
   return `<span class="badge status-indicator ${k}" title="${label}" aria-label="${label}"${attr}><span class="status-dot" aria-hidden="true"></span><span class="status-text">${label}</span></span>`;
 }
 
+function userSourceValue(record){
+  const candidates = [
+    record?.SourceType,
+    record?.sourceType,
+    record?.source_type,
+    record?.Source,
+    record?.source
+  ];
+  for (const value of candidates) {
+    const text = String(value ?? '').trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function isCloudManagedUser(record){
+  if (!record || typeof record !== 'object') return false;
+  const source = userSourceValue(record).toLowerCase().replace(/[\s_-]+/g, '');
+  if (source === 'cloud' || source.includes('cloud') || source === 'smartplus') return true;
+  return [record.cloud, record.Cloud, record.isCloud, record.is_cloud].some(value =>
+    value === true || value === 1 || ['true', '1', 'yes'].includes(String(value ?? '').trim().toLowerCase())
+  );
+}
+
 function userSourceBadge(user){
-  const cloud = !!user?.isCloud;
+  const cloud = isCloudManagedUser(user);
   const label = cloud ? 'Cloud' : 'Local';
   const kind = cloud ? 'badge-cloud' : 'badge-local';
   return `<span class="badge user-source-badge ${kind}">${label}</span>`;
@@ -969,7 +993,7 @@ function userMatchesSearch(user, term){
     user?.access_schedule,
     user?.schedule_name,
     user?.access_level,
-    user?.isCloud ? 'cloud' : 'local',
+    isCloudManagedUser(user) ? 'cloud' : 'local',
     ...(Array.isArray(user?.groups) ? user.groups : [])
   ]
     .map(normalizeSearchText)
@@ -989,7 +1013,7 @@ function setUserSort(value){
 
 function deviceUserKey(record){
   if (!record || typeof record !== 'object') return '';
-  const source = canonicalString(record.Source || record.source).toLowerCase();
+  const cloud = isCloudManagedUser(record);
   const userId = canonicalString(record.UserID || record.UserId || record.user_id);
   if (userId) return userId;
 
@@ -998,7 +1022,7 @@ function deviceUserKey(record){
   const card = canonicalString(record.CardCode || record.card_code);
   const name = canonicalString(record.Name || record.name);
 
-  if (source === 'cloud') {
+  if (cloud) {
     if (contactId) return `cloud:${contactId}`;
     if (phone) return `cloud:phone:${phone}`;
     if (card) return `cloud:card:${card}`;
@@ -1658,7 +1682,7 @@ function renderUsers(devs, registryUsers, kpis){
     (d._users || d.users || []).forEach(u => {
       const key = deviceUserKey(u);
       if (!key) return;
-      const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
+      const isCloud = isCloudManagedUser(u);
       const accessEnabled = u.AccessEnabled !== false;
       const userGroups = normalizeGroupsList(u.Groups || u.groups || deviceGroups);
       const hasGroupAccess = userGroups.some(g => String(g).trim().toLowerCase() !== 'no access');

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -857,8 +857,32 @@ function badge(text, kind, attrs = ''){
   return `<span class="badge status-indicator ${k}" title="${label}" aria-label="${label}"${attr}><span class="status-dot" aria-hidden="true"></span><span class="status-text">${label}</span></span>`;
 }
 
+function userSourceValue(record){
+  const candidates = [
+    record?.SourceType,
+    record?.sourceType,
+    record?.source_type,
+    record?.Source,
+    record?.source
+  ];
+  for (const value of candidates) {
+    const text = String(value ?? '').trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function isCloudManagedUser(record){
+  if (!record || typeof record !== 'object') return false;
+  const source = userSourceValue(record).toLowerCase().replace(/[\s_-]+/g, '');
+  if (source === 'cloud' || source.includes('cloud') || source === 'smartplus') return true;
+  return [record.cloud, record.Cloud, record.isCloud, record.is_cloud].some(value =>
+    value === true || value === 1 || ['true', '1', 'yes'].includes(String(value ?? '').trim().toLowerCase())
+  );
+}
+
 function userSourceBadge(user){
-  const cloud = !!user?.isCloud;
+  const cloud = isCloudManagedUser(user);
   const label = cloud ? 'Cloud' : 'Local';
   const kind = cloud ? 'badge-cloud' : 'badge-local';
   return `<span class="badge user-source-badge ${kind}">${label}</span>`;
@@ -1020,7 +1044,7 @@ function userMatchesSearch(user, term){
     user?.access_schedule,
     user?.schedule_name,
     user?.access_level,
-    user?.isCloud ? 'cloud' : 'local',
+    isCloudManagedUser(user) ? 'cloud' : 'local',
     ...(Array.isArray(user?.groups) ? user.groups : [])
   ]
     .map(normalizeSearchText)
@@ -1040,7 +1064,7 @@ function setUserSort(value){
 
 function deviceUserKey(record){
   if (!record || typeof record !== 'object') return '';
-  const source = canonicalString(record.Source || record.source).toLowerCase();
+  const cloud = isCloudManagedUser(record);
   const userIdRaw = canonicalString(record.UserID || record.UserId || record.user_id);
   const normalizedUserId = normalizeHaUserId(userIdRaw);
   if (normalizedUserId) return normalizedUserId;
@@ -1051,7 +1075,7 @@ function deviceUserKey(record){
   const card = canonicalString(record.CardCode || record.card_code);
   const name = canonicalString(record.Name || record.name);
 
-  if (source === 'cloud') {
+  if (cloud) {
     if (contactId) return `cloud:${contactId}`;
     if (phone) return `cloud:phone:${phone}`;
     if (card) return `cloud:card:${card}`;
@@ -1780,7 +1804,7 @@ function renderUsers(devs, registryUsers, kpis){
     (d._users || d.users || []).forEach(u => {
       const key = deviceUserKey(u);
       if (!key) return;
-      const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
+      const isCloud = isCloudManagedUser(u);
       const accessEnabled = u.AccessEnabled !== false;
       const userGroups = normalizeGroupsList(u.Groups || u.groups || deviceGroups);
       const hasGroupAccess = userGroups.some(g => String(g).trim().toLowerCase() !== 'no access');

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -1002,9 +1002,33 @@ function canonicalString(value){
   }
 }
 
+function userSourceValue(record){
+  const candidates = [
+    record?.SourceType,
+    record?.sourceType,
+    record?.source_type,
+    record?.Source,
+    record?.source
+  ];
+  for (const value of candidates) {
+    const text = String(value ?? '').trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function isCloudManagedUser(record){
+  if (!record || typeof record !== 'object') return false;
+  const source = userSourceValue(record).toLowerCase().replace(/[\s_-]+/g, '');
+  if (source === 'cloud' || source.includes('cloud') || source === 'smartplus') return true;
+  return [record.cloud, record.Cloud, record.isCloud, record.is_cloud].some(value =>
+    value === true || value === 1 || ['true', '1', 'yes'].includes(String(value ?? '').trim().toLowerCase())
+  );
+}
+
 function deviceUserKey(record){
   if (!record || typeof record !== 'object') return '';
-  const source = canonicalString(record.Source || record.source).toLowerCase();
+  const cloud = isCloudManagedUser(record);
   const userId = canonicalString(record.UserID || record.UserId || record.user_id);
   if (userId) return userId;
 
@@ -1013,7 +1037,7 @@ function deviceUserKey(record){
   const card = canonicalString(record.CardCode || record.card_code);
   const name = canonicalString(record.Name || record.name);
 
-  if (source === 'cloud') {
+  if (cloud) {
     if (contactId) return `cloud:${contactId}`;
     if (phone) return `cloud:phone:${phone}`;
     if (card) return `cloud:card:${card}`;
@@ -1238,7 +1262,7 @@ function compileUsers(devices, registryUsers, kpis){
     (d._users || d.users || []).forEach(u => {
       const key = deviceUserKey(u);
       if (!key) return;
-      const isCloud = String(u.Source || '').toLowerCase() === 'cloud' || !!u.cloud;
+      const isCloud = isCloudManagedUser(u);
       const accessEnabled = u.AccessEnabled !== false;
       const userGroups = normalizeGroupsList(u.Groups || u.groups || deviceGroups);
       const hasGroupAccess = userGroups.some(g => String(g).trim().toLowerCase() !== 'no access');


### PR DESCRIPTION
## What changed
- Normalize Akuvox user ownership from the firmware `SourceType` field into the existing `Source` field used by dashboard snapshots.
- Prefer `SourceType` when both fields exist and conflict.
- Use one cloud-managed detector across the desktop dashboard, mobile dashboard, and mobile user overview.
- Recognize `Cloud`, cloud-labelled variants, SmartPlus, and existing boolean cloud flags.
- Bump the integration version from `3.12.6` to `3.12.7`.

## Root cause
Akuvox user-list responses expose ownership as `SourceType`, for example `SourceType: "Local"` in the captured support bundle. The dashboard only checked `Source`, so cloud-managed records using `SourceType: "Cloud"` fell through to the Local badge. Some of those users still had no edit actions because their IDs did not match the local-user ID filter, which hid the classification error.

## User impact
Cloud-provisioned users now show a **Cloud** source badge and remain read-only. Locally managed users continue to show **Local** and retain their existing actions.

## Validation
- `154 passed, 2 deselected`
- Existing three async test-stub warnings only
- `git diff --check` passed
- Regression coverage verifies that `SourceType: "Cloud"` overrides a stale `Source: "Local"` value