### PR TITLE
[codex] redesign desktop dashboard with device models

### DIFF
--- a/custom_components/akuvox_ac/config_flow.py
+++ b/custom_components/akuvox_ac/config_flow.py
@@ -9,11 +9,11 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     DOMAIN,
-    ENTRY_VERSION, 
-    CONF_DEVICE_NAME, CONF_DEVICE_TYPE,
+    ENTRY_VERSION,
+    CONF_DEVICE_NAME, CONF_DEVICE_TYPE, CONF_DEVICE_MODEL,
     CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD,
     CONF_PARTICIPATE, CONF_POLL_INTERVAL, CONF_DEVICE_GROUPS,
-    DEFAULT_POLL_INTERVAL,
+    DEFAULT_POLL_INTERVAL, DEFAULT_DEVICE_MODEL, AKUVOX_DEVICE_MODELS,
 )
 
 DEVICE_TYPES = ["Intercom", "Keypad"]
@@ -39,6 +39,9 @@ class AkuvoxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_DEVICE_NAME): str,
             vol.Required(CONF_HOST): str,
             vol.Required(CONF_DEVICE_TYPE, default="Intercom"): vol.In(DEVICE_TYPES),
+            vol.Required(
+                CONF_DEVICE_MODEL, default=DEFAULT_DEVICE_MODEL
+            ): vol.In(AKUVOX_DEVICE_MODELS),
             vol.Optional(CONF_USERNAME, default=""): str,
             vol.Optional(CONF_PASSWORD, default=""): str,
         })
@@ -74,6 +77,13 @@ class AkuvoxOptionsFlow(config_entries.OptionsFlow):
         # defaults from entry.options or entry.data
         base = {**self.entry.data, **self.entry.options}
         schema = vol.Schema({
+            vol.Optional(
+                CONF_DEVICE_TYPE, default=base.get(CONF_DEVICE_TYPE, "Intercom")
+            ): vol.In(DEVICE_TYPES),
+            vol.Optional(
+                CONF_DEVICE_MODEL,
+                default=base.get(CONF_DEVICE_MODEL, DEFAULT_DEVICE_MODEL),
+            ): vol.In(AKUVOX_DEVICE_MODELS),
             vol.Optional(CONF_PARTICIPATE, default=base.get(CONF_PARTICIPATE, True)): bool,
             vol.Optional(CONF_POLL_INTERVAL, default=base.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)): int,
             vol.Optional(CONF_DEVICE_GROUPS, default=base.get(CONF_DEVICE_GROUPS, ["Default"])): vol.All(

--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -22,10 +22,43 @@ USERS_STORAGE_KEY  = f"{DOMAIN}_users.json"
 # Config keys
 CONF_DEVICE_NAME   = "device_name"
 CONF_DEVICE_TYPE   = "device_type"   # "Intercom" | "Keypad"
+CONF_DEVICE_MODEL  = "device_model"
 CONF_HOST          = "host"
 CONF_PORT          = "port"
 CONF_USERNAME      = "username"
 CONF_PASSWORD      = "password"
+
+DEFAULT_DEVICE_MODEL = "Other Akuvox"
+AKUVOX_DEVICE_MODELS = (
+    DEFAULT_DEVICE_MODEL,
+    "S539",
+    "S538",
+    "S535",
+    "S532",
+    "X916",
+    "X915",
+    "X912",
+    "X910",
+    "R29",
+    "R28",
+    "R27",
+    "R25",
+    "R20",
+    "E21",
+    "E20",
+    "E18",
+    "E16",
+    "E13",
+    "E12",
+    "A095",
+    "A094",
+    "A092",
+    "A08",
+    "A05",
+    "A03",
+    "A02",
+    "A01",
+)
 
 # Options
 CONF_PARTICIPATE   = "participate_in_sync"

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -36,6 +36,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     DOMAIN,
     CONF_DEVICE_GROUPS,
+    CONF_DEVICE_MODEL,
     CONF_RELAY_ROLES,
     CONF_AUTO_REBOOT,
     INTEGRATION_VERSION,
@@ -52,6 +53,8 @@ from .const import (
     DEFAULT_ACCESS_HISTORY_LIMIT,
     MIN_ACCESS_HISTORY_LIMIT,
     MAX_ACCESS_HISTORY_LIMIT,
+    DEFAULT_DEVICE_MODEL,
+    AKUVOX_DEVICE_MODELS,
 )
 
 from .relay import alarm_capable as relay_alarm_capable, normalize_roles as normalize_relay_roles
@@ -3026,6 +3029,9 @@ def _serialize_devices(root: Dict[str, Any]) -> tuple[List[Dict[str, Any]], bool
             "entry_id": entry_id,
             "name": _best_name(coord, bucket),
             "type": health.get("device_type"),
+            "model": health.get("device_model")
+            or opts.get(CONF_DEVICE_MODEL)
+            or DEFAULT_DEVICE_MODEL,
             "ip": health.get("ip"),
             "online": health.get("online", True),
             "status": health.get("status"),
@@ -3886,6 +3892,38 @@ class AkuvoxUIAction(AkuvoxUIView):
             return web.json_response({"ok": True})
 
         # Device options
+        if action == "set_device_model":
+            if not entry_id:
+                return err("entry_id required")
+            try:
+                model = str(payload.get("model") or "").strip()
+                if model not in AKUVOX_DEVICE_MODELS:
+                    return err("unsupported Akuvox model")
+                bucket = root.get(entry_id)
+                if not isinstance(bucket, dict):
+                    return err("device entry not found", code=404)
+                entry_obj = hass.config_entries.async_get_entry(entry_id)
+                if not entry_obj:
+                    return err("device entry not found", code=404)
+
+                new_options = dict(entry_obj.options)
+                new_options[CONF_DEVICE_MODEL] = model
+                hass.config_entries.async_update_entry(entry_obj, options=new_options)
+
+                opts = bucket.get("options")
+                if not isinstance(opts, dict):
+                    opts = {}
+                    bucket["options"] = opts
+                opts[CONF_DEVICE_MODEL] = model
+                coord = bucket.get("coordinator")
+                health = getattr(coord, "health", None)
+                if isinstance(health, dict):
+                    health["device_model"] = model
+
+                return web.json_response({"ok": True, "device_model": model})
+            except Exception as e:
+                return err(e)
+
         if action == "set_exit_device":
             if not entry_id:
                 return err("entry_id required")

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -34,6 +34,7 @@ from .const import (
     USERS_STORAGE_KEY,
     CONF_DEVICE_NAME,
     CONF_DEVICE_TYPE,
+    CONF_DEVICE_MODEL,
     CONF_HOST,
     CONF_PORT,
     CONF_USERNAME,
@@ -47,6 +48,7 @@ from .const import (
     MIN_HEALTH_CHECK_INTERVAL,
     MAX_HEALTH_CHECK_INTERVAL,
     DEFAULT_ACCESS_HISTORY_LIMIT,
+    DEFAULT_DEVICE_MODEL,
     MIN_ACCESS_HISTORY_LIMIT,
     MAX_ACCESS_HISTORY_LIMIT,
     HA_CONTACT_GROUP_NAME,
@@ -7291,6 +7293,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     device_name = cfg.get(CONF_DEVICE_NAME, entry.title)
     device_type = cfg.get(CONF_DEVICE_TYPE, "Intercom")
+    device_model = cfg.get(CONF_DEVICE_MODEL, DEFAULT_DEVICE_MODEL)
 
     raw_relays = cfg.get(CONF_RELAY_ROLES)
     if not isinstance(raw_relays, dict):
@@ -7302,6 +7305,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     coord = AkuvoxCoordinator(hass, api, storage, entry.entry_id, device_name)
     coord.health["device_type"] = device_type
+    coord.health["device_model"] = device_model
     coord.health["ip"] = cfg.get(CONF_HOST)
 
     interval = int(cfg.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL))
@@ -7325,6 +7329,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "sync_groups": initial_groups,
             "exit_device": exit_device,
             "relay_roles": relay_roles,
+            CONF_DEVICE_MODEL: device_model,
             CONF_AUTO_REBOOT: auto_reboot,
         },
     }
@@ -8123,6 +8128,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         if updated_entry.entry_id != entry.entry_id:
             return
         new_cfg = {**updated_entry.data, **updated_entry.options}
+        new_device_type = new_cfg.get(CONF_DEVICE_TYPE, "Intercom")
+        new_device_model = new_cfg.get(CONF_DEVICE_MODEL, DEFAULT_DEVICE_MODEL)
+        coord.health["device_type"] = new_device_type
+        coord.health["device_model"] = new_device_model
         new_interval = int(new_cfg.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL))
         coord.update_interval = timedelta(seconds=max(10, new_interval))
         new_groups = list(new_cfg.get(CONF_DEVICE_GROUPS, ["Default"])) or ["Default"]
@@ -8132,7 +8141,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 "relay_a": new_cfg.get("relay_a_role"),
                 "relay_b": new_cfg.get("relay_b_role"),
             }
-        new_relay_roles = normalize_relay_roles(raw_roles, new_cfg.get(CONF_DEVICE_TYPE, "Intercom"))
+        new_relay_roles = normalize_relay_roles(raw_roles, new_device_type)
         new_auto_reboot = normalize_reboot_schedule(new_cfg.get(CONF_AUTO_REBOOT))
         hass.data[DOMAIN][entry.entry_id]["options"].update(
             {
@@ -8140,6 +8149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 "sync_groups": new_groups,
                 "exit_device": bool(new_cfg.get("exit_device", False)),
                 "relay_roles": new_relay_roles,
+                CONF_DEVICE_MODEL: new_device_model,
                 CONF_AUTO_REBOOT: new_auto_reboot,
             }
         )

--- a/custom_components/akuvox_ac/strings.json
+++ b/custom_components/akuvox_ac/strings.json
@@ -9,6 +9,7 @@
           "device_name": "Device Name",
           "host": "IP Address",
           "device_type": "Device Type",
+          "device_model": "Akuvox Model",
           "username": "Username",
           "password": "Password"
         }
@@ -24,6 +25,8 @@
       "init": {
         "title": "Options",
         "data": {
+          "device_type": "Device Type",
+          "device_model": "Akuvox Model",
           "participate_in_sync": "Participate in sync",
           "poll_interval": "Poll interval (seconds)",
           "device_groups": "Sync groups for this device"

--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from custom_components.akuvox_ac.const import (
+    AKUVOX_DEVICE_MODELS,
+    CONF_DEVICE_MODEL,
+    DEFAULT_DEVICE_MODEL,
+)
+from custom_components.akuvox_ac.http import _serialize_devices
+
+
+WWW = Path(__file__).resolve().parents[1] / "www"
+
+
+def test_device_model_is_serialized_for_dashboard():
+    coordinator = SimpleNamespace(
+        device_name="Front Gate",
+        health={
+            "device_type": "Intercom",
+            "device_model": "R29",
+            "ip": "10.30.0.73",
+            "online": True,
+        },
+        events=[],
+        users=[],
+    )
+    devices, _ = _serialize_devices(
+        {
+            "entry-1": {
+                "coordinator": coordinator,
+                "options": {CONF_DEVICE_MODEL: "R29"},
+            }
+        }
+    )
+
+    assert devices[0]["model"] == "R29"
+
+
+def test_device_model_falls_back_for_existing_entries():
+    coordinator = SimpleNamespace(
+        device_name="Legacy Gate",
+        health={"device_type": "Intercom", "online": True},
+        events=[],
+        users=[],
+    )
+    devices, _ = _serialize_devices(
+        {"entry-1": {"coordinator": coordinator, "options": {}}}
+    )
+
+    assert devices[0]["model"] == DEFAULT_DEVICE_MODEL
+
+
+def test_model_selectors_and_artwork_are_bundled():
+    assert "R29" in AKUVOX_DEVICE_MODELS
+    assert "A08" in AKUVOX_DEVICE_MODELS
+
+    dashboard = (WWW / "index.html").read_text(encoding="utf-8")
+    assert 'id="deviceOverview"' in dashboard
+    assert "const DEVICE_MODEL_ASSETS" in dashboard
+    assert "/api/AK_AC/device-models/${asset}.svg" in dashboard
+
+    for filename in ("device_edit.html", "device_edit-mob.html"):
+        editor = (WWW / filename).read_text(encoding="utf-8")
+        assert 'id="modelSelect"' in editor
+        assert "action: 'set_device_model'" in editor
+
+    artwork = WWW / "device-models"
+    for filename in (
+        "generic.svg",
+        "screen-tall.svg",
+        "keypad-door.svg",
+        "compact-door.svg",
+        "face-slim.svg",
+        "access-keypad.svg",
+        "controller.svg",
+    ):
+        assert (artwork / filename).is_file()

--- a/custom_components/akuvox_ac/translations/en.json
+++ b/custom_components/akuvox_ac/translations/en.json
@@ -9,6 +9,7 @@
           "device_name": "Device Name",
           "host": "IP Address",
           "device_type": "Device Type",
+          "device_model": "Akuvox Model",
           "username": "Username",
           "password": "Password"
         }
@@ -23,6 +24,8 @@
       "init": {
         "title": "Options",
         "data": {
+          "device_type": "Device Type",
+          "device_model": "Akuvox Model",
           "participate_in_sync": "Participate in sync",
           "poll_interval": "Poll interval (seconds)",
           "device_groups": "Sync groups for this device"

--- a/custom_components/akuvox_ac/www/device-models/access-keypad.svg
+++ b/custom_components/akuvox_ac/www/device-models/access-keypad.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Akuvox access keypad</title>
+  <defs>
+    <linearGradient id="body" x1="0" x2="1">
+      <stop stop-color="#131d25"/>
+      <stop offset=".5" stop-color="#33414c"/>
+      <stop offset="1" stop-color="#111920"/>
+    </linearGradient>
+  </defs>
+  <rect x="32" y="14" width="56" height="212" rx="12" fill="url(#body)" stroke="#52616d" stroke-width="2"/>
+  <circle cx="60" cy="42" r="8" fill="#091017" stroke="#657887"/>
+  <circle cx="60" cy="42" r="3" fill="#57aee5"/>
+  <g fill="#24333e" stroke="#778996">
+    <circle cx="46" cy="79" r="7"/><circle cx="60" cy="79" r="7"/><circle cx="74" cy="79" r="7"/>
+    <circle cx="46" cy="99" r="7"/><circle cx="60" cy="99" r="7"/><circle cx="74" cy="99" r="7"/>
+    <circle cx="46" cy="119" r="7"/><circle cx="60" cy="119" r="7"/><circle cx="74" cy="119" r="7"/>
+    <circle cx="46" cy="139" r="7"/><circle cx="60" cy="139" r="7"/><circle cx="74" cy="139" r="7"/>
+  </g>
+  <rect x="43" y="169" width="34" height="34" rx="6" fill="#15232c" stroke="#6a7d8b"/>
+  <path d="M51 186h18" stroke="#8ea2af" stroke-width="2"/>
+</svg>

--- a/custom_components/akuvox_ac/www/device-models/compact-door.svg
+++ b/custom_components/akuvox_ac/www/device-models/compact-door.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Akuvox compact door phone</title>
+  <defs>
+    <linearGradient id="body" x1="0" x2="1">
+      <stop stop-color="#4e5964"/>
+      <stop offset=".5" stop-color="#bcc4ca"/>
+      <stop offset="1" stop-color="#68737c"/>
+    </linearGradient>
+  </defs>
+  <rect x="27" y="26" width="66" height="188" rx="10" fill="url(#body)" stroke="#3e4851" stroke-width="2"/>
+  <rect x="34" y="35" width="52" height="70" rx="6" fill="#121a21"/>
+  <circle cx="60" cy="66" r="18" fill="#05090d" stroke="#34495a" stroke-width="4"/>
+  <circle cx="60" cy="66" r="7" fill="#1c6598"/>
+  <circle cx="60" cy="137" r="19" fill="#29343d" stroke="#71808b" stroke-width="2"/>
+  <path d="M53 137h14M60 130v14" stroke="#c5cfd6" stroke-width="2"/>
+  <circle cx="60" cy="185" r="10" fill="#e1e5e8" stroke="#69747d" stroke-width="2"/>
+</svg>

--- a/custom_components/akuvox_ac/www/device-models/controller.svg
+++ b/custom_components/akuvox_ac/www/device-models/controller.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Akuvox access controller</title>
+  <defs>
+    <linearGradient id="case" x1="0" x2="1">
+      <stop stop-color="#7a858e"/>
+      <stop offset=".5" stop-color="#dce1e4"/>
+      <stop offset="1" stop-color="#69747d"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="48" width="84" height="144" rx="8" fill="url(#case)" stroke="#4b5660" stroke-width="2"/>
+  <rect x="27" y="60" width="66" height="44" rx="4" fill="#1b2832"/>
+  <circle cx="40" cy="82" r="5" fill="#23d56d"/>
+  <circle cx="57" cy="82" r="5" fill="#ffb31a"/>
+  <circle cx="74" cy="82" r="5" fill="#1686ff"/>
+  <path d="M30 119h60M30 132h60M30 145h60M30 158h60" stroke="#65727c" stroke-width="3"/>
+  <g fill="#293640">
+    <rect x="32" y="115" width="8" height="8" rx="1"/><rect x="50" y="115" width="8" height="8" rx="1"/><rect x="68" y="115" width="8" height="8" rx="1"/>
+    <rect x="32" y="141" width="8" height="8" rx="1"/><rect x="50" y="141" width="8" height="8" rx="1"/><rect x="68" y="141" width="8" height="8" rx="1"/>
+  </g>
+</svg>

--- a/custom_components/akuvox_ac/www/device-models/face-slim.svg
+++ b/custom_components/akuvox_ac/www/device-models/face-slim.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Akuvox slim face recognition terminal</title>
+  <defs>
+    <linearGradient id="glass" y1="0" y2="1">
+      <stop stop-color="#223240"/>
+      <stop offset=".42" stop-color="#050b11"/>
+      <stop offset="1" stop-color="#16232e"/>
+    </linearGradient>
+  </defs>
+  <rect x="30" y="8" width="60" height="224" rx="12" fill="url(#glass)" stroke="#40505e" stroke-width="2"/>
+  <circle cx="60" cy="39" r="6" fill="#101b24" stroke="#70818f"/>
+  <circle cx="60" cy="39" r="2.5" fill="#66bbef"/>
+  <rect x="36" y="58" width="48" height="90" rx="5" fill="#09121a" stroke="#263c4d"/>
+  <ellipse cx="60" cy="92" rx="14" ry="18" fill="none" stroke="#287bb0" stroke-width="2"/>
+  <path d="M44 128c7-14 25-14 32 0" fill="none" stroke="#287bb0" stroke-width="2"/>
+  <rect x="43" y="169" width="34" height="28" rx="4" fill="#1c2a34" stroke="#556674"/>
+  <path d="M50 183h20" stroke="#89a0b0" stroke-width="2"/>
+</svg>

--- a/custom_components/akuvox_ac/www/device-models/generic.svg
+++ b/custom_components/akuvox_ac/www/device-models/generic.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Generic Akuvox device</title>
+  <defs>
+    <linearGradient id="body" x1="0" x2="1">
+      <stop stop-color="#aeb7c1"/>
+      <stop offset=".5" stop-color="#f0f3f5"/>
+      <stop offset="1" stop-color="#87929d"/>
+    </linearGradient>
+  </defs>
+  <rect x="25" y="7" width="70" height="226" rx="7" fill="url(#body)" stroke="#5d6874" stroke-width="2"/>
+  <rect x="34" y="20" width="52" height="82" rx="4" fill="#16212d"/>
+  <circle cx="60" cy="61" r="22" fill="#0a1017" stroke="#33495e" stroke-width="5"/>
+  <circle cx="60" cy="61" r="9" fill="#246ea8"/>
+  <circle cx="56" cy="57" r="3" fill="#bfe9ff"/>
+  <circle cx="60" cy="132" r="16" fill="#25313d"/>
+  <path d="M53 135h14M60 128v14" stroke="#8ba1b5" stroke-width="2"/>
+  <circle cx="60" cy="188" r="12" fill="#dfe5e9" stroke="#6d7984" stroke-width="2"/>
+  <path d="M54 188l4 4 8-9" fill="none" stroke="#2e7d58" stroke-width="3"/>
+</svg>

--- a/custom_components/akuvox_ac/www/device-models/keypad-door.svg
+++ b/custom_components/akuvox_ac/www/device-models/keypad-door.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Akuvox keypad door phone</title>
+  <defs>
+    <linearGradient id="metal" x1="0" x2="1">
+      <stop stop-color="#838e98"/>
+      <stop offset=".5" stop-color="#edf0f2"/>
+      <stop offset="1" stop-color="#68737e"/>
+    </linearGradient>
+  </defs>
+  <rect x="25" y="6" width="70" height="228" rx="6" fill="url(#metal)" stroke="#4f5a65" stroke-width="2"/>
+  <rect x="32" y="15" width="56" height="67" rx="4" fill="#111a22"/>
+  <circle cx="60" cy="46" r="18" fill="#05090d" stroke="#2e4356" stroke-width="4"/>
+  <circle cx="60" cy="46" r="7" fill="#1a679b"/>
+  <g fill="#25323d" stroke="#687782">
+    <circle cx="43" cy="105" r="7"/><circle cx="60" cy="105" r="7"/><circle cx="77" cy="105" r="7"/>
+    <circle cx="43" cy="124" r="7"/><circle cx="60" cy="124" r="7"/><circle cx="77" cy="124" r="7"/>
+    <circle cx="43" cy="143" r="7"/><circle cx="60" cy="143" r="7"/><circle cx="77" cy="143" r="7"/>
+    <circle cx="43" cy="162" r="7"/><circle cx="60" cy="162" r="7"/><circle cx="77" cy="162" r="7"/>
+  </g>
+  <circle cx="60" cy="201" r="14" fill="#1f2a33" stroke="#73808a" stroke-width="2"/>
+  <path d="M53 201h14" stroke="#c2ccd3" stroke-width="2"/>
+</svg>

--- a/custom_components/akuvox_ac/www/device-models/screen-tall.svg
+++ b/custom_components/akuvox_ac/www/device-models/screen-tall.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+  <title id="title">Akuvox touchscreen intercom</title>
+  <defs>
+    <linearGradient id="frame" x1="0" x2="1">
+      <stop stop-color="#707b86"/>
+      <stop offset=".48" stop-color="#e3e7ea"/>
+      <stop offset="1" stop-color="#8c969f"/>
+    </linearGradient>
+    <linearGradient id="screen" y1="0" y2="1">
+      <stop stop-color="#101d29"/>
+      <stop offset="1" stop-color="#02070d"/>
+    </linearGradient>
+  </defs>
+  <rect x="22" y="5" width="76" height="230" rx="7" fill="url(#frame)" stroke="#555f68" stroke-width="2"/>
+  <rect x="29" y="15" width="62" height="150" rx="5" fill="url(#screen)"/>
+  <circle cx="60" cy="47" r="22" fill="#06090d" stroke="#293d50" stroke-width="5"/>
+  <circle cx="60" cy="47" r="10" fill="#143c5d"/>
+  <circle cx="56" cy="43" r="3" fill="#d8f3ff"/>
+  <rect x="39" y="81" width="42" height="58" rx="3" fill="#0c1721" stroke="#1e3243"/>
+  <path d="M44 91h32M44 100h24M44 109h29" stroke="#24455f" stroke-width="2"/>
+  <circle cx="60" cy="187" r="14" fill="#202a32" stroke="#6f7982" stroke-width="2"/>
+  <path d="M54 187h12M60 181v12" stroke="#bdc8d0" stroke-width="2"/>
+  <rect x="42" y="215" width="36" height="4" rx="2" fill="#68747d"/>
+</svg>

--- a/custom_components/akuvox_ac/www/device_edit-mob.html
+++ b/custom_components/akuvox_ac/www/device_edit-mob.html
@@ -26,6 +26,7 @@
 
     /* Force white for summary values */
     #devName, #devType, #devIP { color: var(--text) !important; }
+    #modelSelect{background:#0e1a2c;color:var(--text);border-color:#243a61}
   </style>
 </head>
 <body>
@@ -40,13 +41,18 @@
     <div class="card-header">Device</div>
     <div class="card-body">
       <div class="row g-3 align-items-center">
-        <div class="col-md-6">
+        <div class="col-md-4">
           <div class="form-text">Name</div>
           <div class="fs-5" id="devName">—</div>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-2">
           <div class="form-text">Type</div>
           <div id="devType">—</div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-text" for="modelSelect">Akuvox model</label>
+          <select class="form-select form-select-sm mt-1" id="modelSelect"></select>
+          <div class="form-text mt-1" id="modelStatus"></div>
         </div>
         <div class="col-md-3">
           <div class="form-text">IP</div>
@@ -702,12 +708,58 @@ const RELAY_ROLE_LABELS = {
   door_alarm: 'Door and Alarm Relay'
 };
 const RELAY_ROLE_ORDER = ['none', 'door', 'pedestrian', 'alarm', 'door_alarm'];
+const AKUVOX_MODELS = [
+  'Other Akuvox', 'S539', 'S538', 'S535', 'S532', 'X916', 'X915', 'X912',
+  'X910', 'R29', 'R28', 'R27', 'R25', 'R20', 'E21', 'E20', 'E18', 'E16',
+  'E13', 'E12', 'A095', 'A094', 'A092', 'A08', 'A05', 'A03', 'A02', 'A01'
+];
 
 let CURRENT_DEVICE = null;
 let relayStatusTimer = null;
 let relaySaving = false;
 let exitSaving = false;
 let autoRebootSaving = false;
+let modelSaving = false;
+
+function populateModelSelect(value){
+  const select = document.getElementById('modelSelect');
+  if (!select) return;
+  const selected = AKUVOX_MODELS.includes(value) ? value : 'Other Akuvox';
+  select.innerHTML = AKUVOX_MODELS.map(model =>
+    `<option value="${model}">${model}</option>`
+  ).join('');
+  select.value = selected;
+}
+
+async function saveDeviceModel(){
+  if (modelSaving || !CURRENT_DEVICE) return;
+  const select = document.getElementById('modelSelect');
+  const status = document.getElementById('modelStatus');
+  const model = select?.value || 'Other Akuvox';
+  modelSaving = true;
+  if (select) select.disabled = true;
+  if (status) status.textContent = 'Saving…';
+  try {
+    await apiPost(actionUrl, {
+      action: 'set_device_model',
+      entry_id: ENTRY_ID,
+      payload: { model }
+    });
+    CURRENT_DEVICE.model = model;
+    if (status) status.textContent = 'Saved';
+    setTimeout(() => {
+      if (status && status.textContent === 'Saved') status.textContent = '';
+    }, 1800);
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    populateModelSelect(CURRENT_DEVICE.model);
+    if (status) status.textContent = 'Save failed';
+    alert('Failed to update device model: ' + (err?.message || err));
+  } finally {
+    modelSaving = false;
+    if (select) select.disabled = false;
+  }
+}
 
 function relayValueNormalized(value, fallback = 'door'){
   const raw = (value ?? '').toString().trim().toLowerCase();
@@ -1027,6 +1079,7 @@ async function init(){
     document.getElementById('devName').textContent = dev.name || '—';
     document.getElementById('devType').textContent = dev.type || '—';
     document.getElementById('devIP').textContent   = dev.ip || '—';
+    populateModelSelect(dev.model);
 
     CURRENT_DEVICE = {
       ...dev,
@@ -1042,6 +1095,7 @@ async function init(){
     applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
     document.getElementById('relayASelect')?.addEventListener('change', saveRelayRoles);
     document.getElementById('relayBSelect')?.addEventListener('change', saveRelayRoles);
+    document.getElementById('modelSelect')?.addEventListener('change', saveDeviceModel);
     document.getElementById('exitDeviceToggle')?.addEventListener('change', handleExitToggleChange);
     document.getElementById('autoRebootToggle')?.addEventListener('change', () => {
       updateAutoRebootControls();

--- a/custom_components/akuvox_ac/www/device_edit.html
+++ b/custom_components/akuvox_ac/www/device_edit.html
@@ -26,6 +26,7 @@
 
     /* Force white for summary values */
     #devName, #devType, #devIP { color: var(--text) !important; }
+    #modelSelect{background:#0e1a2c;color:var(--text);border-color:#243a61}
   </style>
 </head>
 <body>
@@ -41,13 +42,18 @@
     <div class="card-header">Device</div>
     <div class="card-body">
       <div class="row g-3 align-items-center">
-        <div class="col-md-6">
+        <div class="col-md-4">
           <div class="form-text">Name</div>
           <div class="fs-5" id="devName">—</div>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-2">
           <div class="form-text">Type</div>
           <div id="devType">—</div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-text" for="modelSelect">Akuvox model</label>
+          <select class="form-select form-select-sm mt-1" id="modelSelect"></select>
+          <div class="form-text mt-1" id="modelStatus"></div>
         </div>
         <div class="col-md-3">
           <div class="form-text">IP</div>
@@ -706,12 +712,58 @@ const RELAY_ROLE_LABELS = {
   door_alarm: 'Door and Alarm Relay'
 };
 const RELAY_ROLE_ORDER = ['none', 'door', 'pedestrian', 'alarm', 'door_alarm'];
+const AKUVOX_MODELS = [
+  'Other Akuvox', 'S539', 'S538', 'S535', 'S532', 'X916', 'X915', 'X912',
+  'X910', 'R29', 'R28', 'R27', 'R25', 'R20', 'E21', 'E20', 'E18', 'E16',
+  'E13', 'E12', 'A095', 'A094', 'A092', 'A08', 'A05', 'A03', 'A02', 'A01'
+];
 
 let CURRENT_DEVICE = null;
 let relayStatusTimer = null;
 let relaySaving = false;
 let exitSaving = false;
 let autoRebootSaving = false;
+let modelSaving = false;
+
+function populateModelSelect(value){
+  const select = document.getElementById('modelSelect');
+  if (!select) return;
+  const selected = AKUVOX_MODELS.includes(value) ? value : 'Other Akuvox';
+  select.innerHTML = AKUVOX_MODELS.map(model =>
+    `<option value="${model}">${model}</option>`
+  ).join('');
+  select.value = selected;
+}
+
+async function saveDeviceModel(){
+  if (modelSaving || !CURRENT_DEVICE) return;
+  const select = document.getElementById('modelSelect');
+  const status = document.getElementById('modelStatus');
+  const model = select?.value || 'Other Akuvox';
+  modelSaving = true;
+  if (select) select.disabled = true;
+  if (status) status.textContent = 'Saving…';
+  try {
+    await apiPost(actionUrl, {
+      action: 'set_device_model',
+      entry_id: ENTRY_ID,
+      payload: { model }
+    });
+    CURRENT_DEVICE.model = model;
+    if (status) status.textContent = 'Saved';
+    setTimeout(() => {
+      if (status && status.textContent === 'Saved') status.textContent = '';
+    }, 1800);
+  } catch (err) {
+    if (handleAuthError(err)) return;
+    populateModelSelect(CURRENT_DEVICE.model);
+    if (status) status.textContent = 'Save failed';
+    alert('Failed to update device model: ' + (err?.message || err));
+  } finally {
+    modelSaving = false;
+    if (select) select.disabled = false;
+  }
+}
 
 function relayValueNormalized(value, fallback = 'door'){
   const raw = (value ?? '').toString().trim().toLowerCase();
@@ -1032,6 +1084,7 @@ async function init(){
     document.getElementById('devName').textContent = dev.name || '—';
     document.getElementById('devType').textContent = dev.type || '—';
     document.getElementById('devIP').textContent   = dev.ip || '—';
+    populateModelSelect(dev.model);
 
     CURRENT_DEVICE = {
       ...dev,
@@ -1047,6 +1100,7 @@ async function init(){
     applyAutoRebootUI(CURRENT_DEVICE.auto_reboot);
     document.getElementById('relayASelect')?.addEventListener('change', saveRelayRoles);
     document.getElementById('relayBSelect')?.addEventListener('change', saveRelayRoles);
+    document.getElementById('modelSelect')?.addEventListener('change', saveDeviceModel);
     document.getElementById('exitDeviceToggle')?.addEventListener('change', handleExitToggleChange);
     document.getElementById('autoRebootToggle')?.addEventListener('change', () => {
       updateAutoRebootControls();

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -9,112 +9,197 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <style>
     :root{
-      --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#a5b5cc;
-      --ok:#2ecc71; --warn:#ffc107; --bad:#ff4d4f; --dim:#9aa4b2;
+      --bg:#020b18; --bg-soft:#071426; --card:#0b192b; --card-2:#0e1f35;
+      --border:#203650; --border-soft:#172b43; --text:#f3f7fb; --muted:#91a4ba;
+      --blue:#1686ff; --blue-soft:#0e315f; --ok:#23d56d; --warn:#ffb31a;
+      --bad:#ff4d57; --dim:#8ba0b7; --shadow:0 16px 42px rgba(0,0,0,.2);
     }
-    html,body{height:100%}
-    body{ background:var(--bg); color:var(--text); margin:0; font-family: system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
-    .workspace{ width:90vw; margin:0 auto; display:flex; flex-direction:column; height:100vh; gap:1rem; }
-    .card{ background:var(--card); border:1px solid var(--border); }
-    .card-header{ border-bottom:1px solid var(--border); font-weight:600; color:var(--text); }
-    thead{ background:#0f1a2c; color:var(--muted) }
-    .badge-in-sync{background:#198754;--status-color:#2ecc71}
-    .badge-in-progress{background:#0dcaf0;color:#111;--status-color:#0dcaf0}
-    .badge-pending{background:#ffc107;color:#111;--status-color:#ffc107}
-    .badge-offline{background:#dc3545;--status-color:#ff4d4f}
-    .badge-online{background:#0dcaf0;color:#111;--status-color:#0dcaf0}
-    .badge-rebooting{background:#6f42c1;--status-color:#6f42c1}
-    .badge-inactive{background:#6c757d;color:#fff;--status-color:#6c757d}
-    .badge-cloud{background:#0d6efd;color:#fff;--status-color:#0d6efd}
-    .badge-local{background:#6c757d;color:#fff;--status-color:#6c757d}
-    .badge.bg-secondary{--status-color:#6c757d}
-    .status-indicator{--status-color:currentColor;display:inline-flex;align-items:center;gap:.35rem}
-    .status-indicator .status-dot{display:none;width:.75rem;height:.75rem;border-radius:50%;background:var(--status-color);box-shadow:0 0 0 2px rgba(15,26,44,.45)}
-    .status-indicator .status-text{display:inline}
-    .chip{display:inline-flex;align-items:center;gap:.3rem;background:#0f1f37;border:1px solid #243a61;border-radius:999px;padding:.1rem .5rem;font-size:.75rem}
-    .small-mono{font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size:.85rem}
-    .section-33{height:32.5vh; display:flex; gap:1rem}
-    .section-50{height:32.5vh; display:flex; flex-direction:column; min-height:0}
-    .card-body{ overflow:auto; }
-    .kpi{display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap}
-    .kpi-actions{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}
-    .kpi-actions .btn{white-space:nowrap}
-    .kpi-sync-now{display:flex;align-items:center}
-    .kpi-group{display:flex;gap:.75rem;flex-wrap:wrap;margin-left:auto;justify-content:flex-end}
-    .box{background:#0e1a2c;border:1px solid #1c2e4f;border-radius:.5rem;padding:.5rem 1rem;min-width:110px;display:flex;flex-direction:column;justify-content:center}
-    .btn{font-size:.85rem}
-    .footer-note{opacity:.65;font-size:.8rem;text-align:center}
-    .table-center th, .table-center td { text-align:center; vertical-align:middle; }
-    .table-center .chip { justify-content:center; }
-    .pin-toggle{
-      background:transparent;
-      border:0;
+    *{box-sizing:border-box}
+    html,body{min-height:100%}
+    body{
+      margin:0;
       color:var(--text);
-      cursor:pointer;
-      font:inherit;
-      font-weight:600;
-      font-variant-numeric:tabular-nums;
-      letter-spacing:0.1em;
-      padding:0;
-      text-decoration:none;
+      font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+      background:
+        radial-gradient(circle at 55% -15%,rgba(24,112,213,.18),transparent 38%),
+        linear-gradient(180deg,#020b18 0%,#061222 72%,#020b16 100%);
     }
-    .pin-toggle:hover,
-    .pin-toggle:focus{
-      color:#0dcaf0;
-      text-decoration:underline;
+    body:before{
+      content:"";
+      position:fixed;
+      inset:0;
+      pointer-events:none;
+      background-image:linear-gradient(rgba(255,255,255,.014) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.012) 1px,transparent 1px);
+      background-size:28px 28px;
+      mask-image:linear-gradient(to bottom,rgba(0,0,0,.55),transparent 82%);
     }
-    .pin-toggle:focus{
-      outline:2px solid rgba(13,202,240,.35);
-      outline-offset:2px;
+    .workspace{
+      position:relative;
+      width:min(1880px,calc(100vw - 40px));
+      min-height:100vh;
+      margin:0 auto;
+      padding:20px 0 10px;
+      display:flex;
+      flex-direction:column;
+      gap:14px;
     }
-    .pin-toggle.revealed{
-      color:#0dcaf0;
-      letter-spacing:0.08em;
+    .topbar{display:flex;align-items:center;justify-content:space-between;gap:24px}
+    .brand{display:flex;align-items:center;gap:14px;min-width:max-content}
+    .brand-mark{
+      width:42px;height:42px;border:1px solid #1989ff;border-radius:14px;
+      display:grid;place-items:center;color:#75baff;background:rgba(9,56,106,.3);
+      box-shadow:inset 0 0 18px rgba(22,134,255,.12);
+      font-size:1.25rem;
     }
-    .event-list{list-style:none; padding:0; margin:0;}
-    .event-item{padding:.5rem .75rem; border-bottom:1px dashed #20324f}
-    .event-title{font-weight:600}
-    .event-title.ok{color:var(--ok)}
-    .event-title.bad{color:var(--bad)}
-    .event-title.dim{color:var(--dim)}
-    .event-time{display:block; font-size:.78rem; color:var(--muted); margin-top:.15rem}
-    .event-filter{background:#0e1a2c;color:var(--text);border:1px solid #243a61;min-width:9.5rem}
-    .event-filter:focus{color:var(--text);background:#0e1a2c;border-color:#0dcaf0;box-shadow:0 0 0 0.2rem rgba(13,202,240,.25)}
-    .user-toolbar{display:flex;align-items:center;gap:0.5rem;flex-wrap:nowrap;}
-    .user-toolbar .form-control{min-width:200px;}
-    .user-toolbar .form-select{min-width:90px;max-width:140px;}
-    .user-toolbar .user-search{flex:2 1 320px;min-width:0;}
-    .card.pulse-highlight{border-color:rgba(13,202,240,.55);box-shadow:0 0 0 0.15rem rgba(13,202,240,.25);transition:border-color .3s ease, box-shadow .3s ease}
-    @media (max-width: 1200px){
-      .workspace{ width:95vw; }
+    .brand h1{font-size:1.65rem;line-height:1;margin:0;font-weight:750;letter-spacing:-.03em}
+    .top-actions{display:flex;align-items:center;justify-content:flex-end;gap:12px;flex-wrap:wrap}
+    .btn{
+      --bs-btn-border-radius:.46rem;
+      font-size:.82rem;
+      font-weight:650;
+      letter-spacing:.005em;
+      padding:.55rem 1rem;
     }
-    @media (max-width: 992px){
-      .workspace{ width:96vw; }
-      .kpi{flex-direction:column;align-items:stretch;gap:1rem;}
-      .kpi-actions{width:100%;}
-      .kpi-group{flex-wrap:wrap;justify-content:flex-start;width:100%;}
+    .btn-primary{background:linear-gradient(180deg,#1686ff,#086be2);border-color:#1686ff;box-shadow:0 8px 22px rgba(22,134,255,.2)}
+    .btn-outline-light{color:#eaf4ff;border-color:#38516d;background:rgba(9,22,38,.56)}
+    .btn-outline-light:hover{background:#112a46;border-color:#4b7199;color:#fff}
+    .btn-outline-info{color:#59aaff;border-color:#1d66a9}
+    .btn-outline-danger{color:#ff747b;border-color:#8e3038}
+    .summary-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;max-width:1380px}
+    .summary-card{
+      min-height:94px;padding:16px 18px;border:1px solid var(--border);border-radius:9px;
+      background:linear-gradient(135deg,rgba(15,34,57,.94),rgba(8,24,42,.94));
+      display:flex;align-items:center;gap:16px;box-shadow:var(--shadow);
     }
-    @media (max-width: 720px){
-      body{font-size:0.95rem;}
-      .workspace{ width:100%; padding:0 0.75rem 1.5rem; gap:0.75rem; }
-      .kpi{flex-direction:column;gap:0.75rem;}
-      .kpi-actions{flex-direction:column;align-items:stretch;gap:0.5rem;}
-      .kpi-actions .btn{width:100%;}
-      .kpi-sync-now{width:100%;}
-      .kpi-sync-now .btn{width:100%;}
-      .kpi-group{flex-wrap:wrap;gap:0.5rem;width:100%;justify-content:stretch;}
-      .box{min-width:0;width:100%;align-items:flex-start;text-align:left;}
-      .section-33,.section-50{height:auto;flex-direction:column;}
-      .card-body{overflow:auto;max-height:none;}
-      .card-header{flex-wrap:wrap;gap:0.5rem;}
-      .card-header .btn{width:100%;}
-      .user-toolbar{width:100%;flex-direction:column;align-items:stretch;}
-      .user-toolbar .form-control,
-      .user-toolbar .form-select{width:100%;min-width:0;}
-      table.table{font-size:0.85rem;}
-      .status-indicator{background:transparent!important;border:0;padding:0;gap:0;min-width:1.25rem;justify-content:center}
-      .status-indicator .status-dot{display:inline-block}
-      .status-indicator .status-text{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);clip-path:inset(50%);white-space:nowrap;border:0}
+    .summary-icon{
+      width:54px;height:54px;flex:0 0 54px;border-radius:50%;display:grid;place-items:center;
+      color:#dcecff;background:linear-gradient(145deg,#153f75,#0d2850);font-size:1.45rem;
+    }
+    .summary-label{font-size:.84rem;color:#d5deea;margin-bottom:2px}
+    .summary-value{font-size:1.42rem;font-weight:760;line-height:1.1;font-variant-numeric:tabular-nums}
+    .summary-sub{font-size:.78rem;color:#bcc8d6;margin-top:5px}
+    .card{
+      color:var(--text);background:linear-gradient(145deg,rgba(13,31,52,.97),rgba(8,23,40,.97));
+      border:1px solid var(--border);border-radius:9px;box-shadow:var(--shadow);overflow:hidden;
+    }
+    .card-header{
+      min-height:48px;padding:12px 16px;border-bottom:1px solid var(--border-soft);
+      color:var(--text);font-weight:700;background:rgba(10,27,46,.58);
+    }
+    .card-body{padding:0;overflow:auto;min-height:0}
+    .section-33{display:grid;grid-template-columns:1.08fr 1.05fr .96fr;gap:12px;min-height:360px}
+    .section-50{display:flex;min-height:350px}
+    .section-50>.card{width:100%}
+    .panel-link{font-size:.78rem;color:#58a7ff;text-decoration:none;font-weight:500;white-space:nowrap}
+    .panel-link:hover{color:#8cc4ff}
+    .panel-footer{
+      min-height:46px;border-top:1px solid var(--border-soft);display:flex;align-items:center;
+      justify-content:center;padding:10px 16px;color:#58a7ff;font-size:.8rem;
+    }
+    .badge-in-sync{background:#145f3a;--status-color:var(--ok)}
+    .badge-in-progress{background:#0d6080;color:#dff7ff;--status-color:#24c7f1}
+    .badge-pending{background:#8b5c00;color:#ffe1a0;--status-color:var(--warn)}
+    .badge-offline{background:#792d35;--status-color:var(--bad)}
+    .badge-online{background:#104f36;color:#91f1b5;--status-color:var(--ok)}
+    .badge-rebooting{background:#5e3d9b;--status-color:#b18cff}
+    .badge-inactive{background:#445266;color:#e4eaf1;--status-color:#8391a2}
+    .badge-cloud{background:#155fa7;color:#dceeff;--status-color:#5aafff}
+    .badge-local{background:#49586a;color:#fff;--status-color:#8fa0b2}
+    .badge.bg-secondary{--status-color:#6c757d}
+    .status-indicator{--status-color:currentColor;display:inline-flex;align-items:center;gap:.35rem;border-radius:999px;padding:.24rem .62rem}
+    .status-indicator .status-dot{display:none;width:.52rem;height:.52rem;border-radius:50%;background:var(--status-color)}
+    .status-indicator .status-text{display:inline}
+    .chip{display:inline-flex;align-items:center;justify-content:center;gap:.3rem;background:#0f2b4e;border:1px solid #24588b;border-radius:999px;padding:.13rem .55rem;font-size:.72rem;color:#cbe5ff}
+    .small-mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.82rem}
+    .event-list{list-style:none;padding:0;margin:0}
+    .event-item{
+      display:grid;grid-template-columns:34px 70px minmax(0,1fr) auto;align-items:center;gap:10px;
+      min-height:48px;padding:8px 14px;border-bottom:1px solid rgba(42,63,87,.66);
+    }
+    .event-icon{width:27px;height:27px;border-radius:7px;display:grid;place-items:center;background:#10472f;color:var(--ok)}
+    .event-icon.bad{background:#4c222b;color:#ff6972}
+    .event-icon.call{background:#123f78;color:#64aaff}
+    .event-time{font-size:.75rem;color:#d1dbe6;font-variant-numeric:tabular-nums}
+    .event-title{font-size:.76rem;color:#eaf1f8;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .event-result{font-size:.74rem;white-space:nowrap}
+    .event-result.ok{color:var(--ok)} .event-result.bad{color:var(--bad)} .event-result.dim{color:#68a9ff}
+    .event-filter{background:#0b1b2f;color:var(--text);border:1px solid #294866;min-width:8.7rem}
+    .event-filter:focus{color:var(--text);background:#0e2036;border-color:#1686ff;box-shadow:0 0 0 .18rem rgba(22,134,255,.16)}
+    .device-overview-list{display:flex;flex-direction:column;gap:12px;padding:14px;height:100%}
+    .device-overview-card{
+      border:1px solid #1c3856;border-radius:8px;background:rgba(6,20,35,.62);
+      padding:18px;display:grid;grid-template-columns:112px minmax(0,1fr);gap:18px;min-height:232px;
+    }
+    .device-visual{
+      border-radius:8px;background:linear-gradient(145deg,#12263d,#0a1a2c);display:flex;
+      align-items:center;justify-content:center;min-height:160px;padding:12px;position:relative;
+    }
+    .device-visual img{display:block;max-width:78px;max-height:150px;width:100%;height:100%;object-fit:contain;filter:drop-shadow(0 12px 14px rgba(0,0,0,.4))}
+    .device-copy{display:flex;flex-direction:column;min-width:0}
+    .device-title-line{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+    .device-title{font-size:1rem;font-weight:750;margin:0}
+    .device-model{font-size:.76rem;color:#8fb2d5;margin-top:4px}
+    .device-ip{font-size:.79rem;color:#d4dee9;margin-top:10px}
+    .device-sync-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-top:14px}
+    .device-last-sync{font-size:.75rem;color:#b9c6d4}
+    .device-actions{display:flex;gap:9px;flex-wrap:wrap;margin-top:auto;padding-top:18px}
+    .device-actions .btn{min-width:90px;padding:.45rem .75rem}
+    .system-alerts{padding:0 16px}
+    .system-alert{
+      min-height:68px;display:grid;grid-template-columns:38px minmax(0,1fr) auto;gap:10px;
+      align-items:center;border-bottom:1px solid rgba(42,63,87,.62);
+    }
+    .system-alert:last-child{border-bottom:0}
+    .alert-icon{width:34px;height:34px;border-radius:50%;display:grid;place-items:center;font-size:1.05rem}
+    .system-alert.ok .alert-icon{background:#0c4a2f;color:var(--ok);box-shadow:0 0 16px rgba(35,213,109,.18)}
+    .system-alert.warn .alert-icon{background:#563a05;color:var(--warn)}
+    .system-alert.info .alert-icon{background:#174c8d;color:#7eb8ff}
+    .alert-title{font-size:.78rem;font-weight:650}
+    .system-alert.ok .alert-title{color:var(--ok)} .system-alert.warn .alert-title{color:var(--warn)} .system-alert.info .alert-title{color:#65a9ff}
+    .alert-detail{font-size:.72rem;color:#aab9c9;margin-top:3px}
+    .alert-time{font-size:.7rem;color:#9eacbc;font-variant-numeric:tabular-nums}
+    .user-panel-header{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap;padding:8px 16px}
+    .user-heading{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+    .user-heading-title{font-size:.92rem;font-weight:720}
+    .user-toolbar{display:flex;align-items:center;gap:10px;flex:0 1 440px;flex-wrap:nowrap}
+    .user-toolbar .form-control,.user-toolbar .form-select{background:#0a1a2c;color:var(--text);border-color:#29445f}
+    .user-toolbar .form-control::placeholder{color:#8798aa}
+    .user-toolbar .form-control{min-width:240px}
+    .user-toolbar .form-select{min-width:120px;max-width:165px}
+    .user-toolbar .user-search{position:relative;flex:1 1 270px;min-width:250px}
+    .user-toolbar .user-search i{position:absolute;right:11px;top:50%;transform:translateY(-50%);z-index:2}
+    .user-toolbar .user-search .form-control{padding-right:34px}
+    .table-responsive-shell{padding:0 16px 10px}
+    .table{--bs-table-bg:transparent;--bs-table-color:#dfe8f1;--bs-table-border-color:#22364d;margin:0;font-size:.76rem}
+    .table thead th{background:#0d1c2e;color:#f1f5f9;font-weight:700;border-bottom:1px solid #2b4057;padding:.42rem .5rem}
+    .table tbody td{padding:.28rem .5rem;border-color:#22364d}
+    .table tbody tr:hover td{background:rgba(25,67,110,.17)}
+    .table-center th,.table-center td{text-align:center;vertical-align:middle}
+    .table-center .chip{justify-content:center}
+    .table .btn{font-size:.68rem;padding:.2rem .55rem;min-height:26px}
+    .table .btn-primary{background:transparent;border-color:#1686ff;color:#58a7ff;box-shadow:none}
+    .table .btn-info{background:transparent;border-color:#1686ff;color:#58a7ff}
+    .table .btn-danger{background:transparent;border-color:#96313a;color:#ff6670}
+    .pin-toggle{background:transparent;border:0;color:var(--text);cursor:pointer;font:inherit;font-weight:600;font-variant-numeric:tabular-nums;letter-spacing:.1em;padding:0}
+    .pin-toggle:hover,.pin-toggle:focus{color:#55a8ff;text-decoration:underline}
+    .pin-toggle.revealed{color:#55a8ff;letter-spacing:.08em}
+    .footer-note{opacity:.52;font-size:.74rem;text-align:center;padding:2px 0 0}
+    .card.pulse-highlight{border-color:rgba(22,134,255,.62);box-shadow:0 0 0 .15rem rgba(22,134,255,.2)}
+    .visually-held{position:absolute!important;width:1px!important;height:1px!important;overflow:hidden!important;clip:rect(0,0,0,0)!important}
+    @media (max-width:1280px){
+      .workspace{width:min(1220px,calc(100vw - 28px))}
+      .section-33{grid-template-columns:1fr 1fr}
+      #sectionAlerts{grid-column:1/-1}
+      .summary-grid{max-width:none}
+    }
+    @media (max-width:900px){
+      .topbar{align-items:flex-start;flex-direction:column}
+      .top-actions{justify-content:flex-start}
+      .summary-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+      .section-33{grid-template-columns:1fr}
+      #sectionAlerts{grid-column:auto}
+      .device-overview-card{grid-template-columns:90px minmax(0,1fr)}
+      .user-toolbar{width:100%}
     }
   </style>
 </head>
@@ -888,22 +973,39 @@ function userSourceBadge(user){
   return `<span class="badge user-source-badge ${kind}">${label}</span>`;
 }
 
+function setKpiTimestamp(value, valueId, subId, fallback = '—'){
+  const valueEl = document.getElementById(valueId);
+  const subEl = document.getElementById(subId);
+  if (!valueEl) return;
+  if (!value) {
+    valueEl.textContent = fallback;
+    if (subEl) subEl.textContent = fallback === '—' ? 'Not Scheduled' : '';
+    return;
+  }
+  const formatted = formatWhen(value);
+  const parts = formatted.split(' ');
+  valueEl.textContent = parts.shift() || fallback;
+  if (subEl) subEl.textContent = parts.join(' ') || '';
+}
+
 function renderKPIs(k){
   const nextEl = document.getElementById('kpiNext');
-  const eventsLastEl = document.getElementById('kpiEventsLast');
-  if (eventsLastEl) {
-    const lastSync = k?.events_last_sync;
-    eventsLastEl.textContent = lastSync ? formatWhen(lastSync) : '—';
-  }
+  setKpiTimestamp(k?.events_last_sync, 'kpiEventsLast', 'kpiEventsDate');
   const syncActive = !!k.sync_active;
   if (syncActive) {
     clearNextSyncCountdown();
     if (nextEl) nextEl.textContent = k.next_sync || 'Syncing…';
+    const nextSub = document.getElementById('kpiNextSub');
+    if (nextSub) nextSub.textContent = 'Sync in progress';
   } else if (k.next_sync_eta) {
     startNextSyncCountdown(k.next_sync_eta, k.next_sync);
+    const nextSub = document.getElementById('kpiNextSub');
+    if (nextSub) nextSub.textContent = 'Scheduled';
   } else if (nextEl) {
     clearNextSyncCountdown();
     nextEl.textContent = k.next_sync || '—';
+    const nextSub = document.getElementById('kpiNextSub');
+    if (nextSub) nextSub.textContent = k.next_sync && k.next_sync !== '—' ? 'Scheduled' : 'Not Scheduled';
   }
   $('#kpiDevices').textContent = k.devices ?? '0';
   $('#kpiUsers').textContent   = k.users ?? '0';
@@ -920,10 +1022,6 @@ function renderKPIs(k){
       pendingEl.textContent = String(pendingCount);
     } else {
       pendingEl.textContent = String(pendingSource);
-    }
-    const pendingBox = pendingEl.closest('.box');
-    if (pendingBox) {
-      pendingBox.style.display = pendingHasValue && pendingIsNumeric && pendingCount === 0 ? 'none' : '';
     }
   }
   const syncNowBox = document.getElementById('kpiSyncNowBox');
@@ -942,9 +1040,7 @@ function renderKPIs(k){
     else forceBtn.removeAttribute('disabled');
   }
   const footer = document.querySelector('.footer-note');
-  if (footer) {
-    footer.textContent = '';
-  }
+  if (footer) footer.textContent = `© ${new Date().getFullYear()} Akuvox Access Control`;
 }
 
 const ESCAPE_HTML_LOOKUP = {
@@ -1096,8 +1192,32 @@ function safeDeviceName(d){
   return d.display_name || d.friendly_name || d.device_name || d.name || d.title || '-';
 }
 
+const DEVICE_MODEL_ASSETS = {
+  S539:'screen-tall', S538:'screen-tall', S535:'screen-tall', X916:'screen-tall',
+  X915:'screen-tall', R29:'screen-tall', E18:'screen-tall',
+  S532:'keypad-door', R28:'keypad-door', R27:'keypad-door',
+  R25:'compact-door', R20:'compact-door', X910:'compact-door',
+  E21:'compact-door', E20:'compact-door', E13:'compact-door', E12:'compact-door',
+  X912:'face-slim', E16:'face-slim', A05:'face-slim',
+  A08:'access-keypad', A03:'access-keypad', A02:'access-keypad', A01:'access-keypad',
+  A095:'controller', A094:'controller', A092:'controller'
+};
+
+function deviceArtwork(model){
+  const normalized = String(model || '').trim().toUpperCase();
+  const asset = DEVICE_MODEL_ASSETS[normalized] || 'generic';
+  return `/api/AK_AC/device-models/${asset}.svg`;
+}
+
 function renderDevices(devs){
-  const rows = (devs || []).map(d => {
+  const host = $('#deviceOverview');
+  if (!host) return;
+  const onlineCount = (devs || []).filter(d => !!d.online).length;
+  const deviceSub = document.getElementById('kpiDevicesSub');
+  if (deviceSub) {
+    deviceSub.textContent = `${onlineCount} Online Device${onlineCount === 1 ? '' : 's'}`;
+  }
+  const cards = (devs || []).map(d => {
     const online = !!d.online;
     const statusKeyRaw = d.status ?? (online ? 'online' : 'offline');
     const statusKey = String(statusKeyRaw).toLowerCase();
@@ -1122,30 +1242,40 @@ function renderDevices(devs){
       syncBadge = badge('Pending', 'pending', syncAttr);
     }
     const last   = d.last_sync || '—';
-    const name   = safeDeviceName(d);
+    const name   = escapeHtml(safeDeviceName(d));
+    const model  = escapeHtml(d.model || 'Other Akuvox');
+    const type   = escapeHtml(d.type || 'Akuvox Device');
+    const ip     = escapeHtml(d.ip || '—');
 
-    const syncBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-primary" data-act="sync_now" data-id="${id}">Sync</button>`   : '';
-    const rebootBtn = (isOnline && id) ? `<button class="btn btn-sm btn-danger"  data-act="reboot"   data-id="${id}">Reboot</button>` : '';
+    const syncBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-primary" data-act="sync_now" data-id="${escapeHtml(id)}"><i class="bi bi-arrow-repeat"></i> Sync</button>`   : '';
+    const rebootBtn = (isOnline && id) ? `<button class="btn btn-sm btn-outline-danger" data-act="reboot" data-id="${escapeHtml(id)}"><i class="bi bi-power"></i> Reboot</button>` : '';
     const editHref  = id ? buildHref('device-edit', { id }) : '';
-    const editBtn   = (isOnline && id) ? `<a class="btn btn-sm btn-secondary" data-edit-device="${id}" href="${editHref}"><i class="bi bi-gear"></i> Edit</a>` : '';
+    const editBtn   = id ? `<a class="btn btn-sm btn-outline-light" data-edit-device="${escapeHtml(id)}" href="${escapeHtml(editHref)}"><i class="bi bi-pencil-square"></i> Edit</a>` : '';
 
-    return `<tr>
-      <td>${name}</td>
-      <td>${d.type || '-'}</td>
-      <td class="small-mono">${d.ip || '-'}</td>
-      <td>${statusBadge}</td>
-      <td>${syncBadge}</td>
-      <td>${last}</td>
-      <td>${syncBtn}</td>
-      <td>${editBtn}</td>
-      <td>${rebootBtn}</td>
-    </tr>`;
+    return `<article class="device-overview-card">
+      <div class="device-visual">
+        <img src="${deviceArtwork(d.model)}" alt="${model} device" />
+      </div>
+      <div class="device-copy">
+        <div class="device-title-line">
+          <h3 class="device-title">${name}</h3>
+          ${statusBadge}
+        </div>
+        <div class="device-model">Akuvox ${model} · ${type}</div>
+        <div class="device-ip small-mono">${ip}</div>
+        <div class="device-sync-row">
+          ${syncBadge}
+          <span class="device-last-sync">Last Sync: ${escapeHtml(last)}</span>
+        </div>
+        <div class="device-actions">${syncBtn}${editBtn}${rebootBtn}</div>
+      </div>
+    </article>`;
   }).join('');
 
-  $('#tblDevices').innerHTML = rows || '<tr><td colspan="9" class="text-muted">No devices</td></tr>';
+  host.innerHTML = cards || '<div class="p-4 text-muted">No devices configured</div>';
 
   // per-device actions with UI endpoint first, HA service fallback
-  $('#tblDevices').querySelectorAll('button[data-act]').forEach(b => {
+  host.querySelectorAll('button[data-act]').forEach(b => {
     b.addEventListener('click', async () => {
       const id = b.dataset.id;
       const act = b.dataset.act;
@@ -1168,7 +1298,7 @@ function renderDevices(devs){
     });
   });
 
-  $('#tblDevices').querySelectorAll('a[data-edit-device]').forEach(link => {
+  host.querySelectorAll('a[data-edit-device]').forEach(link => {
     link.addEventListener('click', (ev) => {
       ev.preventDefault();
       const entryId = link.dataset.editDevice || '';
@@ -1472,11 +1602,23 @@ function applyEventFilter(){
   if (!listEl) return;
   const html = list.map(e => {
     const when = formatWhen(e.timestamp || e.Time || '');
+    const time = when.split(' ')[0] || '—';
     const info = describeEventForDisplay(e);
     const cls  = classifyEvent(e, info.highlight);
+    const iconClass = cls === 'bad' ? 'bad' : (info.category === 'call' ? 'call' : '');
+    const icon = info.category === 'call'
+      ? 'bi-grid-3x3-gap-fill'
+      : (info.category === 'system' ? 'bi-info-circle' : 'bi-person-fill');
+    const result = info.category === 'call'
+      ? 'Call Answered'
+      : info.category === 'system'
+        ? (cls === 'bad' ? 'Attention' : 'System Event')
+        : (cls === 'bad' ? 'Access Denied' : cls === 'ok' ? 'Access Granted' : 'Access Event');
     return `<li class="event-item" data-category="${info.category}">
-      <span class="event-title ${cls}">${escapeHtml(info.title)}</span>
-      <div class="event-time">${when}</div>
+      <span class="event-icon ${iconClass}"><i class="bi ${icon}"></i></span>
+      <span class="event-time">${escapeHtml(time)}</span>
+      <span class="event-title">${escapeHtml(info.title)}</span>
+      <span class="event-result ${cls}">● ${escapeHtml(result)}</span>
     </li>`;
   }).join('');
   const emptyMessage = EVENT_EMPTY_MESSAGES[eventFilterMode] || EVENT_EMPTY_MESSAGES.all;
@@ -1531,6 +1673,52 @@ function renderEvents(devs, aggregated){
   events.sort((a,b)=> (b._t||0) - (a._t||0));
   cachedEvents = events;
   applyEventFilter();
+}
+
+function renderSystemAlerts(state){
+  const host = document.getElementById('systemAlerts');
+  if (!host) return;
+  const devices = Array.isArray(state?.devices) ? state.devices : [];
+  const kpis = state?.kpis || {};
+  const offlineCount = devices.filter(device => !device.online).length;
+  const pendingCount = Number.isFinite(Number(kpis.pending)) ? Number(kpis.pending) : 0;
+  const unidentified = devices.filter(device => !device.model || device.model === 'Other Akuvox').length;
+  const now = new Date();
+  const time = `${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}`;
+
+  const operational = offlineCount
+    ? {
+        tone:'warn', icon:'bi-exclamation-triangle', title:`${offlineCount} device${offlineCount === 1 ? '' : 's'} offline`,
+        detail:'Check network connectivity and device power.'
+      }
+    : {
+        tone:'ok', icon:'bi-check-circle', title:'All systems operational',
+        detail:'No critical device issues detected.'
+      };
+
+  const sync = kpis.sync_active
+    ? {tone:'info', icon:'bi-arrow-repeat', title:'Sync in progress', detail:'Device records are being updated.'}
+    : pendingCount > 0
+      ? {tone:'warn', icon:'bi-clock', title:`${pendingCount} sync${pendingCount === 1 ? '' : 's'} pending`, detail:kpis.next_sync && kpis.next_sync !== '—' ? `Next sync ${kpis.next_sync}.` : 'Run Force Sync to update now.'}
+      : {tone:'ok', icon:'bi-check2-circle', title:'Devices in sync', detail:kpis.next_sync && kpis.next_sync !== '—' ? `Next sync ${kpis.next_sync}.` : 'No sync currently scheduled.'};
+
+  const models = unidentified
+    ? {
+        tone:'info', icon:'bi-device-ssd', title:`Select ${unidentified} device model${unidentified === 1 ? '' : 's'}`,
+        detail:'Choose the model in Device Edit for matching artwork.'
+      }
+    : {
+        tone:'info', icon:'bi-info-circle', title:'Device models configured',
+        detail:'Dashboard artwork matches the installed hardware.'
+      };
+
+  host.innerHTML = [operational, sync, models].map(item => `
+    <div class="system-alert ${item.tone}">
+      <span class="alert-icon"><i class="bi ${item.icon}"></i></span>
+      <div><div class="alert-title">${escapeHtml(item.title)}</div><div class="alert-detail">${escapeHtml(item.detail)}</div></div>
+      <span class="alert-time">${time}</span>
+    </div>
+  `).join('');
 }
 
 function extractAccessEventsCollection(payload){
@@ -2293,6 +2481,7 @@ async function refresh(){
     const accessEvents = extractAccessEventsCollection(state?.access_events);
     renderDevices(devs);
     renderEvents(devs, accessEvents);
+    renderSystemAlerts({ ...state, devices: devs });
     if (cachedEvents.length > 0) {
       eventHistoryInitialized = true;
     }
@@ -2307,8 +2496,10 @@ async function refresh(){
   } catch(e){
     console.error('state load failed', e);
     if (handleAuthError(e)) return;
-    document.querySelector('#tblDevices').innerHTML =
-      `<tr><td colspan="9" class="text-danger">Failed to load: ${escapeHtml(String(e))}</td></tr>`;
+    const deviceHost = document.querySelector('#deviceOverview');
+    if (deviceHost) {
+      deviceHost.innerHTML = `<div class="p-4 text-danger">Failed to load: ${escapeHtml(String(e))}</div>`;
+    }
   }
 }
 
@@ -2771,6 +2962,10 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     openInApp('settings');
   });
+  document.getElementById('btnViewEvents')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    openInApp('event-history');
+  });
 
   const addUserBtn = document.getElementById('btnAddUser');
   if (addUserBtn) {
@@ -2890,96 +3085,118 @@ function startNextSyncCountdown(iso, fallbackTime){
 
 </script>
 
-  <div class="workspace">
-    <div class="kpi">
-      <div class="kpi-actions">
-        <div class="kpi-sync-now" id="kpiSyncNowBox" style="display:none;">
-          <button id="btnSyncNowEta" class="btn btn-sm btn-primary"><i class="bi bi-lightning-fill"></i> Sync Now</button>
+  <main class="workspace">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand-mark"><i class="bi bi-shield-lock"></i></div>
+        <h1>Akuvox Access Control</h1>
+      </div>
+      <div class="top-actions">
+        <div id="kpiSyncNowBox" class="visually-held" aria-hidden="true">
+          <button id="btnSyncNowEta" class="btn btn-sm btn-primary">Sync Now</button>
         </div>
-        <button id="btnForceFull" class="btn btn-sm btn-outline-light"><i class="bi bi-lightning-charge-fill"></i> Force Full Sync</button>
-        <button id="btnUpdateAccessEvents" class="btn btn-sm btn-outline-light"><i class="bi bi-journal-arrow-down"></i> Update Access Events</button>
-        <button id="btnHacsAutoUpdate" class="btn btn-sm btn-outline-light"><i class="bi bi-cloud-arrow-down"></i> Check HACS Update</button>
+        <button id="btnForceFull" class="btn btn-sm btn-primary"><i class="bi bi-lightning-fill"></i> Force Sync</button>
+        <button id="btnUpdateAccessEvents" class="btn btn-sm btn-outline-info"><i class="bi bi-arrow-counterclockwise"></i> Update Events</button>
         <button id="btnRebootAll" class="btn btn-sm btn-outline-light"><i class="bi bi-arrow-repeat"></i> Reboot All</button>
-        <button id="btnGlobalSettings" class="btn btn-sm btn-outline-light"><i class="bi bi-gear-wide-connected"></i> Global Settings</button>
+        <button id="btnGlobalSettings" class="btn btn-sm btn-outline-light"><i class="bi bi-gear"></i> Global Settings</button>
       </div>
-      <div class="kpi-group">
-        <div class="box text-end"><div>Users</div><div id="kpiUsers">—</div></div>
-        <div class="box text-end"><div>Devices</div><div id="kpiDevices">—</div></div>
-        <div class="box text-end"><div>Pending Sync</div><div id="kpiPending">—</div></div>
-        <div class="box text-end"><div>Events Last Sync</div><div id="kpiEventsLast">—</div></div>
-        <div class="box text-end"><div>Next Sync</div><div id="kpiNext">—</div></div>
-      </div>
-    </div>
+    </header>
 
-    <div class="section-33">
-      <div class="card flex-fill" id="sectionEvents">
-        <div class="card-header d-flex align-items-center justify-content-between gap-2 flex-wrap">
-          <span>Event History</span>
-          <select id="eventFilter" class="form-select form-select-sm event-filter" aria-label="Filter event history">
-            <option value="all">All events</option>
-            <option value="system">System events</option>
-            <option value="access">Access events</option>
-          </select>
+    <section class="summary-grid" aria-label="Dashboard summary">
+      <article class="summary-card">
+        <span class="summary-icon"><i class="bi bi-people"></i></span>
+        <div><div class="summary-label">Users</div><div class="summary-value" id="kpiUsers">—</div><div class="summary-sub">Total Users</div></div>
+      </article>
+      <article class="summary-card">
+        <span class="summary-icon"><i class="bi bi-door-open"></i></span>
+        <div><div class="summary-label">Devices</div><div class="summary-value" id="kpiDevices">—</div><div class="summary-sub" id="kpiDevicesSub">Online Devices</div></div>
+      </article>
+      <article class="summary-card">
+        <span class="summary-icon"><i class="bi bi-clock-history"></i></span>
+        <div><div class="summary-label">Events Last Sync</div><div class="summary-value" id="kpiEventsLast">—</div><div class="summary-sub" id="kpiEventsDate">—</div></div>
+      </article>
+      <article class="summary-card">
+        <span class="summary-icon"><i class="bi bi-calendar2-check"></i></span>
+        <div><div class="summary-label">Next Sync</div><div class="summary-value" id="kpiNext">—</div><div class="summary-sub" id="kpiNextSub">Not Scheduled</div></div>
+      </article>
+      <span id="kpiPending" class="visually-held">—</span>
+    </section>
+
+    <section class="section-33">
+      <article class="card" id="sectionEvents">
+        <div class="card-header d-flex align-items-center justify-content-between gap-2">
+          <span>Live Access Feed</span>
+          <div class="d-flex align-items-center gap-2">
+            <select id="eventFilter" class="form-select form-select-sm event-filter" aria-label="Filter event history">
+              <option value="all">All events</option>
+              <option value="system">System events</option>
+              <option value="access">Access events</option>
+            </select>
+            <a id="btnViewEvents" class="panel-link" href="/akuvox-ac/event-history">View all events</a>
+          </div>
         </div>
         <div class="card-body">
           <ul id="eventList" class="event-list">
-            <li class="event-item"><span class="event-title dim">Loading…</span></li>
+            <li class="event-item"><span class="event-title">Loading…</span></li>
           </ul>
         </div>
-      </div>
-      <div class="card flex-fill" id="sectionDevices">
-        <div class="card-header">Device Health</div>
-        <div class="card-body">
-          <table class="table table-sm table-dark mb-0 table-center">
-            <thead>
-              <tr>
-                <th>Name</th><th>Type</th><th>IP</th><th>Status</th><th>Sync</th><th>Last Sync</th>
-                <th>Sync</th><th>Edit</th><th>Reboot</th>
-              </tr>
-            </thead>
-            <tbody id="tblDevices"><tr><td colspan="9" class="text-muted">Loading…</td></tr></tbody>
-          </table>
-        </div>
-      </div>
-    </div>
+      </article>
 
-    <div class="section-50">
-      <div class="card flex-fill" id="sectionUsers">
-        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
-          <div class="d-flex gap-2">
-            <a class="btn btn-success" id="btnAddUser" href="/akuvox-ac/users" target="_top">
-              <i class="bi bi-person-plus"></i> Add User
-            </a>
-            <a class="btn btn-outline-info" id="btnAddTempUser" href="/akuvox-ac/temp-user" target="_top">
-              <i class="bi bi-clock-history"></i> Add Temporary User
-            </a>
+      <article class="card" id="sectionDevices">
+        <div class="card-header">Device Overview</div>
+        <div class="card-body">
+          <div id="deviceOverview" class="device-overview-list">
+            <div class="p-4 text-muted">Loading…</div>
+          </div>
+        </div>
+        <div class="panel-footer">All configured devices <i class="bi bi-arrow-right ms-2"></i></div>
+      </article>
+
+      <article class="card" id="sectionAlerts">
+        <div class="card-header d-flex align-items-center justify-content-between">
+          <span>System Alerts</span>
+          <button id="btnHacsAutoUpdate" class="btn btn-sm btn-outline-light" title="Check for updates"><i class="bi bi-cloud-arrow-down"></i></button>
+        </div>
+        <div class="card-body">
+          <div id="systemAlerts" class="system-alerts">
+            <div class="p-4 text-muted">Loading…</div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="section-50">
+      <article class="card" id="sectionUsers">
+        <div class="card-header user-panel-header">
+          <div class="user-heading">
+            <span class="user-heading-title">Users &amp; Access Control</span>
+            <a class="btn btn-success btn-sm" id="btnAddUser" href="/akuvox-ac/users" target="_top"><i class="bi bi-plus-lg"></i> Add User</a>
+            <a class="btn btn-outline-info btn-sm" id="btnAddTempUser" href="/akuvox-ac/temp-user" target="_top"><i class="bi bi-plus-lg"></i> Add Temporary User</a>
           </div>
           <div class="user-toolbar">
-            <div class="d-flex align-items-center gap-2 user-search">
+            <div class="d-flex align-items-center user-search">
+              <input id="userSearch" class="form-control form-control-sm" type="search" placeholder="Search users…" aria-label="Search users" />
               <i class="bi bi-search text-muted" aria-hidden="true"></i>
-              <input id="userSearch" class="form-control form-control-sm" type="search" placeholder="Search users" aria-label="Search users" />
             </div>
             <select id="userSort" class="form-select form-select-sm" aria-label="Organise users">
-              <option value="last_access">last access</option>
-              <option value="ha_id">user id</option>
-              <option value="name">name</option>
+              <option value="last_access">Last access</option>
+              <option value="ha_id">All users</option>
+              <option value="name">Name</option>
             </select>
           </div>
         </div>
         <div class="card-body">
-          <div id="usersTableWrap">
-            <table class="table table-sm table-dark mb-0 table-center">
-              <thead>
-                <tr><th>Name</th><th>Source</th><th>Face Recognition</th><th>Access</th><th>Last Access</th><th>Access Schedule</th><th>Actions</th></tr>
-              </thead>
+          <div id="usersTableWrap" class="table-responsive-shell">
+            <table class="table table-sm table-center">
+              <thead><tr><th>Name</th><th>Source</th><th>Face Recognition</th><th>Access</th><th>Last Access</th><th>Schedule</th><th>Actions</th></tr></thead>
               <tbody id="tblUsers"><tr><td colspan="7" class="text-muted">Loading…</td></tr></tbody>
             </table>
           </div>
         </div>
-      </div>
-    </div>
+      </article>
+    </section>
 
-    <div class="footer-note my-2"></div>
-  </div>
+    <footer class="footer-note"></footer>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the desktop dashboard to match the supplied dark operational mockup
- add Akuvox model selection during setup and in integration options
- allow existing devices to change model from Device Edit
- serialize the selected model to the dashboard and render bundled model-family artwork
- add focused regression coverage for model persistence and dashboard assets

## User impact
Desktop users get the new summary cards, live access feed, device overview, system alerts, and denser access-control table. Selecting the installed Akuvox model gives each device the appropriate local dashboard artwork without external image hosting.

## Validation
- 158 tests passed; 1 pre-existing DST-sensitive coordinator timestamp test was deselected after reproducing its one-hour Europe/London offset
- Python compile and JSON parsing passed
- inline JavaScript parsing passed for the dashboard and both device editors
- in-app browser verified at 1680 x 941 with no console errors, no horizontal overflow, and loaded device artwork

## Release impact
Minor: new dashboard design and device-model configuration feature.