### PR TITLE
[codex] Show device integrity check time

### DIFF
--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -162,6 +162,9 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         if not isinstance(alerts_state, dict):
             self.storage.data["alerts_state"] = {}
         self._alerts_state = self.storage.data.get("alerts_state", {})
+        persisted_last_checked = str(
+            self.storage.data.get("last_checked") or ""
+        ).strip() or None
 
         # Friendly display name (persist and surface in multiple places for UI)
         self.device_name: str = device_name or "Akuvox Device"
@@ -178,6 +181,7 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             # checks move this state to pending when work is actually needed.
             "sync_status": "in_sync",
             "last_sync": None,
+            "last_checked": persisted_last_checked,
             "last_error": None,
             "last_ping": None,
         }
@@ -220,6 +224,29 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         """Store a fresh device user snapshot and record its fetch time."""
         self.users = list(users or [])
         self._last_user_refresh_monotonic = time.monotonic()
+
+    async def async_record_integrity_check(self, checked_at: Optional[str] = None) -> str:
+        """Persist when device data was last compared with Home Assistant."""
+        timestamp = str(checked_at or "").strip()
+        if not timestamp:
+            timestamp = (
+                dt.datetime.now(dt.timezone.utc)
+                .replace(microsecond=0)
+                .isoformat()
+            )
+
+        self.health["last_checked"] = timestamp
+        self.storage.data["last_checked"] = timestamp
+        try:
+            await self.storage.async_save()
+        except Exception as err:
+            _LOGGER.debug("Failed to persist integrity check time: %s", _safe_str(err))
+
+        try:
+            self.async_update_listeners()
+        except Exception:
+            pass
+        return timestamp
 
     async def async_refresh_users(self, *, force: bool = False) -> List[Dict[str, Any]]:
         """Refresh the full user list only when its slower cache is due."""

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -3037,6 +3037,7 @@ def _serialize_devices(root: Dict[str, Any]) -> tuple[List[Dict[str, Any]], bool
             "status": health.get("status"),
             "sync_status": health.get("sync_status", "pending"),
             "last_sync": health.get("last_sync", "—"),
+            "last_checked": health.get("last_checked"),
             "events": list(getattr(coord, "events", []) or []),
             "_users": list(getattr(coord, "users", []) or []),
             "users": list(getattr(coord, "users", []) or []),

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -7160,6 +7160,9 @@ class SyncManager:
                                 )
                                 break
 
+                checked_at = dt_util.now().replace(microsecond=0).isoformat()
+                await coord.async_record_integrity_check(checked_at)
+
                 if mismatch_reason is None:
                     try:
                         coord._append_event("Integrity check passed")  # type: ignore[attr-defined]

--- a/custom_components/akuvox_ac/tests/test_api_call_efficiency.py
+++ b/custom_components/akuvox_ac/tests/test_api_call_efficiency.py
@@ -6,6 +6,7 @@ from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
 ensure_homeassistant_stubs()
 
 from custom_components.akuvox_ac import http as http_module  # noqa: E402
+from custom_components.akuvox_ac.coordinator import AkuvoxCoordinator  # noqa: E402
 from custom_components.akuvox_ac.integration import SyncManager  # noqa: E402
 
 
@@ -146,3 +147,76 @@ def test_integrity_tick_refreshes_access_events_before_deferred_sync():
     asyncio.run(manager._integrity_check_cb(None))
 
     assert coordinator.refresh_calls == 1
+
+
+def test_integrity_tick_records_completed_device_comparison():
+    manager = object.__new__(SyncManager)
+
+    class _Api:
+        async def user_list(self):
+            return []
+
+        async def schedule_get(self):
+            return []
+
+    class _Coordinator:
+        def __init__(self):
+            self.health = {
+                "sync_status": "in_sync",
+                "device_type": "Intercom",
+            }
+            self.users = []
+            self.storage = None
+            self.checked_at = None
+
+        async def async_refresh_access_history(self):
+            return None
+
+        async def async_record_integrity_check(self, checked_at):
+            self.checked_at = checked_at
+
+        def _append_event(self, _message):
+            return None
+
+    coordinator = _Coordinator()
+    manager.hass = SimpleNamespace(
+        config=SimpleNamespace(internal_url=None, external_url=None)
+    )
+    manager._devices = lambda: [("entry-1", coordinator, _Api(), {})]
+    manager._root = lambda: {"sync_queue": None}
+    manager._settings_store = lambda: None
+    manager._users_store = lambda: None
+    manager._schedules_store = lambda: None
+
+    async def _device_schedule_map(_api, *, device_schedules=None):
+        return {"24/7 access": "1001", "no access": "1002"}
+
+    manager._device_schedule_map = _device_schedule_map
+
+    asyncio.run(manager._integrity_check_cb(None))
+
+    assert coordinator.checked_at
+    assert "T" in coordinator.checked_at
+
+
+def test_completed_integrity_check_is_persisted_for_dashboard_restart():
+    class _Storage:
+        def __init__(self):
+            self.data = {}
+            self.saved = False
+
+        async def async_save(self):
+            self.saved = True
+
+    coordinator = object.__new__(AkuvoxCoordinator)
+    coordinator.health = {}
+    coordinator.storage = _Storage()
+    coordinator.async_update_listeners = lambda: None
+
+    checked_at = "2026-06-14T09:30:00+01:00"
+    result = asyncio.run(coordinator.async_record_integrity_check(checked_at))
+
+    assert result == checked_at
+    assert coordinator.health["last_checked"] == checked_at
+    assert coordinator.storage.data["last_checked"] == checked_at
+    assert coordinator.storage.saved is True

--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -20,6 +20,7 @@ def test_device_model_is_serialized_for_dashboard():
             "device_model": "R29",
             "ip": "10.30.0.73",
             "online": True,
+            "last_checked": "2026-06-14T09:30:00+01:00",
         },
         events=[],
         users=[],
@@ -34,6 +35,7 @@ def test_device_model_is_serialized_for_dashboard():
     )
 
     assert devices[0]["model"] == "R29"
+    assert devices[0]["last_checked"] == "2026-06-14T09:30:00+01:00"
 
 
 def test_device_model_falls_back_for_existing_entries():
@@ -109,3 +111,14 @@ def test_dashboard_branding_events_and_update_controls():
     for shell_name in ("head.html", "head-mob.html"):
         shell = (WWW / shell_name).read_text(encoding="utf-8")
         assert 'src="/api/AK_AC/project-icon.svg"' in shell
+
+
+def test_device_overview_uses_persisted_last_checked_time():
+    dashboard = (WWW / "index.html").read_text(encoding="utf-8")
+    mobile = (WWW / "index-mob.html").read_text(encoding="utf-8")
+
+    assert "Last Checked: ${escapeHtml(lastChecked)}" in dashboard
+    assert "d.last_checked" in dashboard
+    assert "Awaiting first check" in dashboard
+    assert "<th>Last Checked</th>" in mobile
+    assert "d.last_checked" in mobile

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1064,7 +1064,9 @@ function renderDevices(devs){
     } else {
       syncBadge = badge('Pending', 'pending', syncAttr);
     }
-    const last   = d.last_sync || '—';
+    const lastChecked = d.last_checked
+      ? formatWhen(d.last_checked)
+      : 'Awaiting first check';
     const name   = safeDeviceName(d);
 
     const syncBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-primary" data-act="sync_now" data-id="${id}">Sync</button>`   : '';
@@ -1078,7 +1080,7 @@ function renderDevices(devs){
       <td class="small-mono">${d.ip || '-'}</td>
       <td>${statusBadge}</td>
       <td>${syncBadge}</td>
-      <td>${last}</td>
+      <td>${escapeHtml(lastChecked)}</td>
       <td>${syncBtn}</td>
       <td>${editBtn}</td>
       <td>${rebootBtn}</td>
@@ -2732,7 +2734,7 @@ function startNextSyncCountdown(iso, fallbackTime){
           <table class="table table-sm table-dark mb-0 table-center">
             <thead>
               <tr>
-                <th>Name</th><th>Type</th><th>IP</th><th>Status</th><th>Sync</th><th>Last Sync</th>
+                <th>Name</th><th>Type</th><th>IP</th><th>Status</th><th>Sync</th><th>Last Checked</th>
                 <th>Sync</th><th>Edit</th><th>Reboot</th>
               </tr>
             </thead>

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1301,7 +1301,9 @@ function renderDevices(devs){
     } else {
       syncBadge = badge('Pending', 'pending', syncAttr);
     }
-    const last   = d.last_sync || '—';
+    const lastChecked = d.last_checked
+      ? formatWhen(d.last_checked)
+      : 'Awaiting first check';
     const name   = escapeHtml(safeDeviceName(d));
     const model  = escapeHtml(d.model || 'Other Akuvox');
     const type   = escapeHtml(d.type || 'Akuvox Device');
@@ -1325,7 +1327,7 @@ function renderDevices(devs){
         <div class="device-ip small-mono">${ip}</div>
         <div class="device-sync-row">
           ${syncBadge}
-          <span class="device-last-sync">Last Sync: ${escapeHtml(last)}</span>
+          <span class="device-last-sync">Last Checked: ${escapeHtml(lastChecked)}</span>
         </div>
         <div class="device-actions">${syncBtn}${editBtn}${rebootBtn}</div>
       </div>


### PR DESCRIPTION
## Summary
- rename the Device Overview timestamp from Last Sync to Last Checked
- record the time each device is compared with Home Assistant during the integrity check
- persist the timestamp per device so it survives Home Assistant restarts
- show a clear Awaiting first check message before the first comparison completes
- expose the same value in the mobile dashboard

## Root cause
Device Overview used `last_sync`, which is only populated after a write/sync operation. Read-only integrity comparisons did not record a timestamp, leaving the dashboard blank for devices that were already in sync.

## Validation
- 13 focused dashboard and integrity-check tests pass
- browser preview displays `Last Checked: 00:18:42 14-06-2026`
- dashboard remains within the viewport with no page scroll
- full suite: 163 passed; one unchanged BST-sensitive coordinator event test differs by one hour on this Windows host

## Release impact
Patch release.