### PR TITLE
Remove duplicate dashboard menu

### DIFF
--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -110,7 +110,22 @@ def test_dashboard_branding_events_and_update_controls():
 
     for shell_name in ("head.html", "head-mob.html"):
         shell = (WWW / shell_name).read_text(encoding="utf-8")
-        assert 'src="/api/AK_AC/project-icon.svg"' in shell
+        assert "header.app-header," in shell
+        assert ".mobile-launcher," in shell
+        assert "display: none !important;" in shell
+        assert "padding: 0 !important;" in shell
+
+
+def test_dashboard_user_actions_are_not_clipped():
+    dashboard = (WWW / "index.html").read_text(encoding="utf-8")
+
+    assert "#sectionUsers{display:flex;flex-direction:column}" in dashboard
+    assert "#sectionUsers .user-panel-header{flex:0 0 auto;overflow:visible}" in dashboard
+    assert "#sectionUsers .card-body{flex:1 1 auto;min-height:0}" in dashboard
+    assert (
+        ".user-heading .btn{display:inline-flex;align-items:center;"
+        "min-height:31px;white-space:nowrap}"
+    ) in dashboard
 
 
 def test_device_overview_uses_persisted_last_checked_time():

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -300,6 +300,20 @@
       body.mobile-stage-content .mobile-menu-btn,
       body.mobile-stage-content .mobile-back-btn { display: inline-flex; }
     }
+    header.app-header,
+    .mobile-launcher,
+    footer.app-footer {
+      display: none !important;
+    }
+    .frame-wrap {
+      display: block !important;
+      padding: 0 !important;
+    }
+    .frame-wrap iframe {
+      display: block;
+      border: 0;
+      border-radius: 0;
+    }
   </style>
 </head>
 <body>

--- a/custom_components/akuvox_ac/www/head.html
+++ b/custom_components/akuvox_ac/www/head.html
@@ -280,6 +280,20 @@
       body.mobile-stage-content footer.app-footer { display: block; }
       body.mobile-stage-content .mobile-back-btn { display: inline-flex; }
     }
+    header.app-header,
+    .mobile-launcher,
+    footer.app-footer {
+      display: none !important;
+    }
+    .frame-wrap {
+      display: block !important;
+      padding: 0 !important;
+    }
+    .frame-wrap iframe {
+      display: block;
+      border: 0;
+      border-radius: 0;
+    }
   </style>
 </head>
 <body>

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -163,6 +163,10 @@
     .user-panel-header{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap;padding:8px 16px}
     .user-heading{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
     .user-heading-title{font-size:.92rem;font-weight:720}
+    #sectionUsers{display:flex;flex-direction:column}
+    #sectionUsers .user-panel-header{flex:0 0 auto;overflow:visible}
+    #sectionUsers .card-body{flex:1 1 auto;min-height:0}
+    .user-heading .btn{display:inline-flex;align-items:center;min-height:31px;white-space:nowrap}
     .user-toolbar{display:flex;align-items:center;gap:10px;flex:0 1 440px;flex-wrap:nowrap}
     .user-toolbar .form-control,.user-toolbar .form-select{background:#0a1a2c;color:var(--text);border-color:#29445f}
     .user-toolbar .form-control::placeholder{color:#8798aa}


### PR DESCRIPTION
## Summary
- hide the redundant outer dashboard navigation and logo in both shell variants
- let the dashboard iframe fill the complete panel without outer padding or border
- prevent the Add User and Add Temporary User controls from being clipped

## Verification
- focused dashboard tests: 12 passed
- browser checked at 1280x800: one custom header, no outer-page vertical scroll, both user buttons fully visible
- full integration suite: 165 passed, 1 unrelated existing timezone-sensitive event test failed

## Release impact
Patch release: user-facing dashboard layout fix with no configuration or API changes.