### PR TITLE
Show next dashboard health check

### DIFF
--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -182,6 +182,7 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             "sync_status": "in_sync",
             "last_sync": None,
             "last_checked": persisted_last_checked,
+            "last_health_check": None,
             "last_error": None,
             "last_ping": None,
         }
@@ -415,6 +416,11 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         finally:
             self.health["last_error"] = last_error
             self.health["last_ping"] = last_ping
+            self.health["last_health_check"] = (
+                dt.datetime.now(dt.timezone.utc)
+                .replace(microsecond=0)
+                .isoformat()
+            )
 
         if alerts_dirty and not alerts_saved:
             try:

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -54,6 +54,7 @@ from .const import (
     MIN_ACCESS_HISTORY_LIMIT,
     MAX_ACCESS_HISTORY_LIMIT,
     DEFAULT_DEVICE_MODEL,
+    DEFAULT_POLL_INTERVAL,
     AKUVOX_DEVICE_MODELS,
 )
 
@@ -3055,6 +3056,49 @@ def _serialize_devices(root: Dict[str, Any]) -> tuple[List[Dict[str, Any]], bool
     return devices, any_alarm
 
 
+def _next_health_check_eta(
+    root: Dict[str, Any],
+    *,
+    now: Optional[dt.datetime] = None,
+) -> Optional[str]:
+    """Return the earliest estimated coordinator health-check time."""
+    current = now or dt.datetime.now(dt.timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=dt.timezone.utc)
+    else:
+        current = current.astimezone(dt.timezone.utc)
+
+    next_checks: List[dt.datetime] = []
+    for _, _, coord, _ in _iter_device_buckets(root):
+        interval = getattr(coord, "update_interval", None)
+        try:
+            interval_seconds = max(10.0, float(interval.total_seconds()))
+        except Exception:
+            interval_seconds = float(DEFAULT_POLL_INTERVAL)
+
+        health = getattr(coord, "health", {}) or {}
+        checked_at = _parse_datetime_value(health.get("last_health_check"))
+        if checked_at is None:
+            candidate = current + dt.timedelta(seconds=interval_seconds)
+        else:
+            if checked_at.tzinfo is None:
+                checked_at = checked_at.replace(tzinfo=dt.timezone.utc)
+            else:
+                checked_at = checked_at.astimezone(dt.timezone.utc)
+            candidate = checked_at + dt.timedelta(seconds=interval_seconds)
+            if candidate <= current:
+                overdue_seconds = (current - candidate).total_seconds()
+                intervals_due = int(overdue_seconds // interval_seconds) + 1
+                candidate += dt.timedelta(
+                    seconds=interval_seconds * intervals_due
+                )
+        next_checks.append(candidate)
+
+    if not next_checks:
+        return None
+    return min(next_checks).replace(microsecond=0).isoformat()
+
+
 def _apply_face_error_sync_overrides(
     devices: List[Dict[str, Any]],
     registry_users: List[Dict[str, Any]],
@@ -3224,6 +3268,7 @@ class AkuvoxUIView(HomeAssistantView):
                 "events_last_sync": None,
                 "auto_sync_time": None,
                 "next_sync_eta": None,
+                "next_health_check_eta": None,
                 "version": INTEGRATION_VERSION_LABEL,
                 "version_raw": INTEGRATION_VERSION,
             },
@@ -3254,6 +3299,7 @@ class AkuvoxUIView(HomeAssistantView):
             devices = devices_serialized
 
             kpis["devices"] = len(devices)
+            kpis["next_health_check_eta"] = _next_health_check_eta(root)
             queue_active = bool(getattr(root.get("sync_queue"), "_active", False))
             kpis["pending"] = sum(
                 1

--- a/custom_components/akuvox_ac/tests/test_api_call_efficiency.py
+++ b/custom_components/akuvox_ac/tests/test_api_call_efficiency.py
@@ -220,3 +220,29 @@ def test_completed_integrity_check_is_persisted_for_dashboard_restart():
     assert coordinator.health["last_checked"] == checked_at
     assert coordinator.storage.data["last_checked"] == checked_at
     assert coordinator.storage.saved is True
+
+
+def test_device_poll_records_completed_health_check():
+    class _Api:
+        async def ping_info(self):
+            return {"ok": False}
+
+    class _Storage:
+        def __init__(self):
+            self.data = {"alerts_state": {}}
+
+        async def async_save(self):
+            return None
+
+    coordinator = object.__new__(AkuvoxCoordinator)
+    coordinator.api = _Api()
+    coordinator.device_name = "Gate"
+    coordinator.health = {"name": "Gate"}
+    coordinator.storage = _Storage()
+    coordinator._was_online = False
+    coordinator._append_event = lambda _message: None
+
+    asyncio.run(coordinator._async_update_data())
+
+    assert coordinator.health["last_health_check"]
+    assert coordinator.health["last_health_check"].endswith("+00:00")

--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -6,7 +7,10 @@ from custom_components.akuvox_ac.const import (
     CONF_DEVICE_MODEL,
     DEFAULT_DEVICE_MODEL,
 )
-from custom_components.akuvox_ac.http import _serialize_devices
+from custom_components.akuvox_ac.http import (
+    _next_health_check_eta,
+    _serialize_devices,
+)
 
 
 WWW = Path(__file__).resolve().parents[1] / "www"
@@ -50,6 +54,42 @@ def test_device_model_falls_back_for_existing_entries():
     )
 
     assert devices[0]["model"] == DEFAULT_DEVICE_MODEL
+
+
+def test_next_health_check_uses_earliest_device_interval():
+    first = SimpleNamespace(
+        health={"last_health_check": "2026-06-14T09:30:00+00:00"},
+        update_interval=timedelta(seconds=30),
+    )
+    second = SimpleNamespace(
+        health={"last_health_check": "2026-06-14T09:29:40+00:00"},
+        update_interval=timedelta(seconds=60),
+    )
+    root = {
+        "entry-1": {"coordinator": first, "options": {}},
+        "entry-2": {"coordinator": second, "options": {}},
+    }
+
+    eta = _next_health_check_eta(
+        root,
+        now=datetime(2026, 6, 14, 9, 30, 10, tzinfo=timezone.utc),
+    )
+
+    assert eta == "2026-06-14T09:30:30+00:00"
+
+
+def test_next_health_check_rolls_over_missed_intervals():
+    coordinator = SimpleNamespace(
+        health={"last_health_check": "2026-06-14T09:30:00+00:00"},
+        update_interval=timedelta(seconds=30),
+    )
+
+    eta = _next_health_check_eta(
+        {"entry-1": {"coordinator": coordinator, "options": {}}},
+        now=datetime(2026, 6, 14, 9, 31, 5, tzinfo=timezone.utc),
+    )
+
+    assert eta == "2026-06-14T09:31:30+00:00"
 
 
 def test_model_selectors_and_artwork_are_bundled():
@@ -126,6 +166,17 @@ def test_dashboard_user_actions_are_not_clipped():
         ".user-heading .btn{display:inline-flex;align-items:center;"
         "min-height:31px;white-space:nowrap}"
     ) in dashboard
+
+
+def test_dashboard_switches_between_sync_and_health_check_kpi():
+    dashboard = (WWW / "index.html").read_text(encoding="utf-8")
+    mobile = (WWW / "index-mob.html").read_text(encoding="utf-8")
+
+    for page in (dashboard, mobile):
+        assert 'id="kpiNextLabel">Next Health Check<' in page
+        assert "const syncScheduled = syncActive" in page
+        assert "syncScheduled ? 'Next Sync' : 'Next Health Check'" in page
+        assert "k.next_health_check_eta" in page
 
 
 def test_device_overview_uses_persisted_last_checked_time():

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -839,20 +839,30 @@ function userSourceBadge(user){
 
 function renderKPIs(k){
   const nextEl = document.getElementById('kpiNext');
+  const nextLabel = document.getElementById('kpiNextLabel');
   const eventsLastEl = document.getElementById('kpiEventsLast');
   if (eventsLastEl) {
     const lastSync = k?.events_last_sync;
     eventsLastEl.textContent = lastSync ? formatWhen(lastSync) : '—';
   }
   const syncActive = !!k.sync_active;
+  const nextSyncText = String(k.next_sync || '').trim();
+  const syncScheduled = syncActive
+    || !!k.next_sync_eta
+    || (nextSyncText && nextSyncText !== '—');
+  if (nextLabel) nextLabel.textContent = syncScheduled ? 'Next Sync' : 'Next Health Check';
   if (syncActive) {
     clearNextSyncCountdown();
     if (nextEl) nextEl.textContent = k.next_sync || 'Syncing…';
   } else if (k.next_sync_eta) {
     startNextSyncCountdown(k.next_sync_eta, k.next_sync);
-  } else if (nextEl) {
+  } else if (syncScheduled && nextEl) {
     clearNextSyncCountdown();
     nextEl.textContent = k.next_sync || '—';
+  } else if (nextEl) {
+    clearNextSyncCountdown();
+    const healthCheck = formatWhen(k.next_health_check_eta);
+    nextEl.textContent = healthCheck === '—' ? '—' : healthCheck.split(' ')[0];
   }
   $('#kpiDevices').textContent = k.devices ?? '0';
   $('#kpiUsers').textContent   = k.users ?? '0';
@@ -2708,7 +2718,7 @@ function startNextSyncCountdown(iso, fallbackTime){
         <div class="box text-end"><div>Devices</div><div id="kpiDevices">—</div></div>
         <div class="box text-end"><div>Pending Sync</div><div id="kpiPending">—</div></div>
         <div class="box text-end"><div>Events Last Sync</div><div id="kpiEventsLast">—</div></div>
-        <div class="box text-end"><div>Next Sync</div><div id="kpiNext">—</div></div>
+        <div class="box text-end"><div id="kpiNextLabel">Next Health Check</div><div id="kpiNext">—</div></div>
       </div>
     </div>
 

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1054,22 +1054,34 @@ function setKpiTimestamp(value, valueId, subId, fallback = '—'){
 
 function renderKPIs(k){
   const nextEl = document.getElementById('kpiNext');
+  const nextLabel = document.getElementById('kpiNextLabel');
+  const nextSub = document.getElementById('kpiNextSub');
   setKpiTimestamp(k?.events_last_sync, 'kpiEventsLast', 'kpiEventsDate');
   const syncActive = !!k.sync_active;
+  const nextSyncText = String(k.next_sync || '').trim();
+  const syncScheduled = syncActive
+    || !!k.next_sync_eta
+    || (nextSyncText && nextSyncText !== '—');
+  if (nextLabel) nextLabel.textContent = syncScheduled ? 'Next Sync' : 'Next Health Check';
   if (syncActive) {
     clearNextSyncCountdown();
     if (nextEl) nextEl.textContent = k.next_sync || 'Syncing…';
-    const nextSub = document.getElementById('kpiNextSub');
     if (nextSub) nextSub.textContent = 'Sync in progress';
   } else if (k.next_sync_eta) {
     startNextSyncCountdown(k.next_sync_eta, k.next_sync);
-    const nextSub = document.getElementById('kpiNextSub');
     if (nextSub) nextSub.textContent = 'Scheduled';
-  } else if (nextEl) {
+  } else if (syncScheduled && nextEl) {
     clearNextSyncCountdown();
     nextEl.textContent = k.next_sync || '—';
-    const nextSub = document.getElementById('kpiNextSub');
-    if (nextSub) nextSub.textContent = k.next_sync && k.next_sync !== '—' ? 'Scheduled' : 'Not Scheduled';
+    if (nextSub) nextSub.textContent = 'Scheduled';
+  } else {
+    clearNextSyncCountdown();
+    setKpiTimestamp(
+      k.next_health_check_eta,
+      'kpiNext',
+      'kpiNextSub',
+      '—'
+    );
   }
   $('#kpiDevices').textContent = k.devices ?? '0';
   $('#kpiUsers').textContent   = k.users ?? '0';
@@ -3185,7 +3197,7 @@ function startNextSyncCountdown(iso, fallbackTime){
       </article>
       <article class="summary-card">
         <span class="summary-icon"><i class="bi bi-calendar2-check"></i></span>
-        <div><div class="summary-label">Next Sync</div><div class="summary-value" id="kpiNext">—</div><div class="summary-sub" id="kpiNextSub">Not Scheduled</div></div>
+        <div><div class="summary-label" id="kpiNextLabel">Next Health Check</div><div class="summary-value" id="kpiNext">—</div><div class="summary-sub" id="kpiNextSub">—</div></div>
       </article>
       <span id="kpiPending" class="visually-held">—</span>
     </section>


### PR DESCRIPTION
## Summary
- record the completion time of each regular device health poll
- calculate the earliest upcoming health check from each coordinator's configured interval
- show `Next Health Check` when no sync is scheduled
- automatically switch the KPI back to `Next Sync` for active, queued, or configured automatic syncs
- apply the behavior to desktop and mobile dashboards

## Verification
- focused coordinator/dashboard tests: 22 passed before the final regression addition
- full integration suite: 169 passed, with the existing unrelated timezone-sensitive door-event test still failing
- browser verified at 1280x800:
  - no scheduled sync: `Next Health Check` with a clock time
  - queued sync: `Next Sync` with the countdown

## Release impact
Patch release: dashboard state and display correction with no configuration migration.