### PR TITLE
Preserve device artwork aspect ratio

### DIFF
--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -117,9 +117,19 @@ def test_model_selectors_and_artwork_are_bundled():
         "access-keypad.svg",
         "controller.svg",
     ):
-        assert (artwork / filename).is_file()
+        asset = artwork / filename
+        assert asset.is_file()
+        assert 'preserveAspectRatio="xMidYMid meet"' in asset.read_text(
+            encoding="utf-8"
+        )
 
     assert "X912:'x912'" in dashboard
+    assert (
+        ".device-visual img{display:block;width:auto;height:auto;"
+        "max-width:100%;max-height:158px;aspect-ratio:auto;"
+        "object-fit:contain;"
+    ) in dashboard
+    assert "width:100%;height:100%;object-fit:contain" not in dashboard
     assert 'src="/api/AK_AC/project-icon.svg"' in dashboard
     assert (WWW / "project-icon.svg").is_file()
 

--- a/custom_components/akuvox_ac/www/device-models/access-keypad.svg
+++ b/custom_components/akuvox_ac/www/device-models/access-keypad.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Akuvox access keypad</title>
   <defs>
     <linearGradient id="body" x1="0" x2="1">

--- a/custom_components/akuvox_ac/www/device-models/compact-door.svg
+++ b/custom_components/akuvox_ac/www/device-models/compact-door.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Akuvox compact door phone</title>
   <defs>
     <linearGradient id="body" x1="0" x2="1">

--- a/custom_components/akuvox_ac/www/device-models/controller.svg
+++ b/custom_components/akuvox_ac/www/device-models/controller.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Akuvox access controller</title>
   <defs>
     <linearGradient id="case" x1="0" x2="1">

--- a/custom_components/akuvox_ac/www/device-models/face-slim.svg
+++ b/custom_components/akuvox_ac/www/device-models/face-slim.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Akuvox slim face recognition terminal</title>
   <defs>
     <linearGradient id="glass" y1="0" y2="1">

--- a/custom_components/akuvox_ac/www/device-models/generic.svg
+++ b/custom_components/akuvox_ac/www/device-models/generic.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Generic Akuvox device</title>
   <defs>
     <linearGradient id="body" x1="0" x2="1">

--- a/custom_components/akuvox_ac/www/device-models/keypad-door.svg
+++ b/custom_components/akuvox_ac/www/device-models/keypad-door.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Akuvox keypad door phone</title>
   <defs>
     <linearGradient id="metal" x1="0" x2="1">

--- a/custom_components/akuvox_ac/www/device-models/screen-tall.svg
+++ b/custom_components/akuvox_ac/www/device-models/screen-tall.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title">
   <title id="title">Akuvox touchscreen intercom</title>
   <defs>
     <linearGradient id="frame" x1="0" x2="1">

--- a/custom_components/akuvox_ac/www/device-models/x912.svg
+++ b/custom_components/akuvox_ac/www/device-models/x912.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="title desc">
   <title id="title">Akuvox X912 door phone</title>
   <desc id="desc">Graphite X912 door phone with dual cameras, touchscreen, touch keypad and card reader.</desc>
   <defs>

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -136,7 +136,7 @@
       border-radius:8px;background:linear-gradient(145deg,#12263d,#0a1a2c);display:flex;
       align-items:center;justify-content:center;min-height:168px;padding:10px;position:relative;
     }
-    .device-visual img{display:block;max-width:88px;max-height:158px;width:100%;height:100%;object-fit:contain;filter:drop-shadow(0 12px 14px rgba(0,0,0,.4))}
+    .device-visual img{display:block;width:auto;height:auto;max-width:100%;max-height:158px;aspect-ratio:auto;object-fit:contain;filter:drop-shadow(0 12px 14px rgba(0,0,0,.4))}
     .device-copy{display:flex;flex-direction:column;min-width:0}
     .device-title-line{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
     .device-title{font-size:1rem;font-weight:750;margin:0}


### PR DESCRIPTION
## Summary
- stop device overview artwork from being forced to fill both width and height
- preserve each bundled device SVG's intrinsic proportions with uniform `meet` scaling
- add regression coverage for the dashboard CSS and all device model assets

## Verification
- `15 passed` in focused device/dashboard tests
- browser verified at 803x775 and 1280x800: X912 renders at its native 1:2 ratio
- desktop preview remains contained in an 800px viewport without document-level vertical scrolling
- full suite: `169 passed, 1 failed`; the existing unrelated failure is `test_process_door_events_updates_state_with_newer_events`, a Europe/London timestamp assertion

## Release impact
Patch-level dashboard presentation fix.