### PR TITLE
Repair responsive mobile dashboard

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1740,6 +1740,11 @@ def _resolve_dashboard_asset(name: str, request: Optional[web.Request]) -> Path:
     if base.endswith(".html"):
         base = base[:-5]
 
+    # The main dashboard is responsive. Keep mobile requests on the same
+    # implementation so the phone view cannot drift back to the legacy tables.
+    if base in {"index", "index-mob"}:
+        return _static_asset("index.html")
+
     explicit_mobile = base.endswith("-mob")
     prefer_mobile = _request_prefers_mobile(request) if not explicit_mobile else True
     candidates: List[str] = []
@@ -3225,7 +3230,8 @@ class AkuvoxDashboardView(HomeAssistantView):
             target = "unauthorized-mob" if target.endswith("-mob") else "unauthorized"
 
         asset = _resolve_dashboard_asset(target, request)
-        variant = "mobile" if asset.name.endswith("-mob.html") else "desktop"
+        requested_mobile = target.endswith("-mob") or _request_prefers_mobile(request)
+        variant = "mobile" if requested_mobile else "desktop"
         if asset.suffix.lower() == ".html":
             signed = _signed_paths_for_request(hass, request)
             try:

--- a/custom_components/akuvox_ac/tests/test_dashboard_auth.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_auth.py
@@ -1,10 +1,36 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
 
 ensure_homeassistant_stubs()
 
 from custom_components.akuvox_ac import http as http_module  # noqa: E402
+
+
+def _dashboard_request(query=None, user_agent=""):
+    return SimpleNamespace(
+        rel_url=SimpleNamespace(query=query or {}),
+        headers={"User-Agent": user_agent},
+    )
+
+
+def test_mobile_dashboard_uses_the_responsive_web_dashboard():
+    mobile_query = _dashboard_request({"variant": "mobile"})
+    mobile_agent = _dashboard_request(
+        user_agent=(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) "
+            "AppleWebKit/605.1.15 Mobile/15E148"
+        )
+    )
+
+    assert http_module._resolve_dashboard_asset("index", mobile_query).name == "index.html"
+    assert http_module._resolve_dashboard_asset("index", mobile_agent).name == "index.html"
+    assert http_module._resolve_dashboard_asset("index-mob", mobile_query).name == "index.html"
+    assert (
+        http_module._resolve_dashboard_asset("user_overview", mobile_query).name
+        == "user_overview-mob.html"
+    )
 
 
 def test_dashboard_injects_signing_helper_without_initial_signed_paths():

--- a/custom_components/akuvox_ac/tests/test_dashboard_user_source.py
+++ b/custom_components/akuvox_ac/tests/test_dashboard_user_source.py
@@ -18,7 +18,7 @@ def test_dashboard_templates_show_cloud_and_local_user_sources():
         assert ".badge-local{" in html
         assert "isCloudManagedUser(user) ? 'cloud' : 'local'" in html
         assert "const isCloud = isCloudManagedUser(u)" in html
-        assert "<td>${userSourceBadge(u)}</td>" in html
+        assert "userSourceBadge(u)}</td>" in html
 
     desktop = (www / "index.html").read_text(encoding="utf-8")
     mobile = (www / "index-mob.html").read_text(encoding="utf-8")

--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -178,6 +178,17 @@ def test_dashboard_user_actions_are_not_clipped():
     ) in dashboard
 
 
+def test_dashboard_uses_mobile_cards_instead_of_squeezed_user_columns():
+    dashboard = (WWW / "index.html").read_text(encoding="utf-8")
+
+    assert "@media (max-width:600px)" in dashboard
+    assert "#sectionUsers .table thead{display:none}" in dashboard
+    assert 'data-label="Face Recognition"' in dashboard
+    assert 'class="user-actions-cell" data-label="Actions"' in dashboard
+    assert ".brand{display:none}" in dashboard
+    assert ".top-actions{display:grid;grid-template-columns:1fr;gap:8px}" in dashboard
+
+
 def test_dashboard_switches_between_sync_and_health_check_kpi():
     dashboard = (WWW / "index.html").read_text(encoding="utf-8")
     mobile = (WWW / "index-mob.html").read_text(encoding="utf-8")

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -265,6 +265,57 @@
       .device-overview-card{grid-template-columns:90px minmax(0,1fr)}
       .user-toolbar{width:100%}
     }
+    @media (max-width:600px){
+      .workspace{width:calc(100vw - 16px);padding:8px 0 12px;gap:10px}
+      .brand{display:none}
+      .topbar,.top-actions{width:100%}
+      .top-actions{display:grid;grid-template-columns:1fr;gap:8px}
+      .top-actions .btn{width:100%;min-height:40px}
+      .summary-grid{gap:8px}
+      .summary-card{min-height:112px;padding:12px;gap:10px}
+      .summary-icon{width:46px;height:46px;flex-basis:46px;font-size:1.2rem}
+      .summary-value{font-size:1.25rem}
+      .card-header{padding:11px 12px}
+      .event-item{grid-template-columns:30px 58px minmax(0,1fr);gap:7px;padding:8px 10px}
+      .event-result{grid-column:3;justify-self:start}
+      .device-overview-list{padding:10px}
+      .device-overview-card{grid-template-columns:92px minmax(0,1fr);padding:12px;gap:12px}
+      .device-actions{display:grid;grid-template-columns:1fr;gap:7px}
+      .device-actions .btn{width:100%;min-width:0}
+      .system-alerts{padding:0 12px}
+      .user-panel-header{align-items:stretch;padding:10px}
+      .user-heading{display:grid;grid-template-columns:1fr;gap:8px;width:100%}
+      .user-heading .btn{width:100%;justify-content:center}
+      .user-toolbar{flex-direction:column;align-items:stretch;gap:8px}
+      .user-toolbar .user-search,
+      .user-toolbar .form-control,
+      .user-toolbar .form-select{width:100%;min-width:0;max-width:none}
+      .user-toolbar .user-search{flex:0 0 auto}
+      #sectionUsers .table-responsive-shell{padding:10px;overflow:visible}
+      #sectionUsers .table,
+      #sectionUsers .table tbody,
+      #sectionUsers .table tr,
+      #sectionUsers .table td{display:block;width:100%}
+      #sectionUsers .table thead{display:none}
+      #sectionUsers .table tbody{display:grid;gap:10px}
+      #sectionUsers .table tbody tr{
+        padding:8px 10px;border:1px solid #203b58;border-radius:8px;
+        background:rgba(5,19,34,.72);
+      }
+      #sectionUsers .table tbody td{
+        display:grid;grid-template-columns:minmax(96px,.45fr) minmax(0,1fr);
+        align-items:start;gap:10px;padding:7px 0;text-align:left;border:0;
+      }
+      #sectionUsers .table tbody td+td{border-top:1px solid rgba(42,63,87,.5)}
+      #sectionUsers .table tbody td::before{
+        content:attr(data-label);color:#91a4ba;font-size:.69rem;font-weight:700;
+        letter-spacing:.035em;text-transform:uppercase;
+      }
+      #sectionUsers .table tbody td[colspan]{display:block;text-align:center}
+      #sectionUsers .table tbody td[colspan]::before{content:none}
+      #sectionUsers .table .user-actions-cell>div{display:flex;flex-wrap:wrap;gap:6px}
+      #sectionUsers .table .user-actions-cell .btn{margin:0!important;flex:1 1 calc(50% - 6px)}
+    }
   </style>
 </head>
 <body>
@@ -2427,17 +2478,17 @@ function renderUsers(devs, registryUsers, kpis){
     }
 
     const pinCell = renderPinCell(u.pin, u.name);
-    const pinColumn = showPinColumn ? `<td>${pinCell}</td>` : '';
+    const pinColumn = showPinColumn ? `<td data-label="PIN">${pinCell}</td>` : '';
 
     return `<tr>
-      <td>${escapeHtml(u.name)}</td>
-      <td>${userSourceBadge(u)}</td>
+      <td data-label="Name">${escapeHtml(u.name)}</td>
+      <td data-label="Source">${userSourceBadge(u)}</td>
       ${pinColumn}
-      <td>${faceBadge}</td>
-      <td>${accessBadge}</td>
-      <td>${escapeHtml(formatLastAccess(u.last))}</td>
-      <td>${scheduleChip}</td>
-      <td>${actions}</td>
+      <td data-label="Face Recognition">${faceBadge}</td>
+      <td data-label="Access">${accessBadge}</td>
+      <td data-label="Last Access">${escapeHtml(formatLastAccess(u.last))}</td>
+      <td data-label="Access Schedule">${scheduleChip}</td>
+      <td class="user-actions-cell" data-label="Actions"><div>${actions}</div></td>
     </tr>`;
   }).join('');
 


### PR DESCRIPTION
## Summary
- route mobile overview requests to the maintained responsive web dashboard instead of the legacy compressed table page
- preserve the mobile response variant while sharing one dashboard implementation across phone and desktop
- add phone-specific action sizing, device layout adjustments, and semantic user cards
- retain the compact desktop table and one-viewport desktop layout

## Root cause
Mobile requests were intentionally selecting `index-mob.html`, but that older page still rendered the device and user areas as wide desktop tables. The phone viewport squeezed and clipped those columns, producing the broken pages shown in Home Assistant.

## Verification
- browser checked through the mobile shell at 375x844: no horizontal overflow; actions, KPIs, event feed, device overview, and user cards render correctly
- browser checked at 1280x800: desktop table remains active and the dashboard fits exactly within the viewport
- full suite: `171 passed, 1 failed`; the existing unrelated failure is `test_process_door_events_updates_state_with_newer_events`, a Europe/London daylight-saving timestamp assertion
- `git diff --check` passed

## Release impact
Patch-level dashboard routing and responsive layout fix.