### PR TITLE
Restore menu-first mobile dashboard navigation

### DIFF
--- a/custom_components/akuvox_ac/tests/test_device_models.py
+++ b/custom_components/akuvox_ac/tests/test_device_models.py
@@ -158,12 +158,16 @@ def test_dashboard_branding_events_and_update_controls():
     assert "? 'bi-telephone-fill'" in dashboard
     assert "? 'Access Granted'" in dashboard
 
-    for shell_name in ("head.html", "head-mob.html"):
-        shell = (WWW / shell_name).read_text(encoding="utf-8")
-        assert "header.app-header," in shell
-        assert ".mobile-launcher," in shell
-        assert "display: none !important;" in shell
-        assert "padding: 0 !important;" in shell
+    desktop_shell = (WWW / "head.html").read_text(encoding="utf-8")
+    assert "header.app-header," in desktop_shell
+    assert ".mobile-launcher," in desktop_shell
+    assert "display: none !important;" in desktop_shell
+    assert "padding: 0 !important;" in desktop_shell
+
+    mobile_shell = (WWW / "head-mob.html").read_text(encoding="utf-8")
+    assert "body.mobile-stage-nav .mobile-launcher { display: grid; }" in mobile_shell
+    assert "body.mobile-stage-content .mobile-launcher { display: none; }" in mobile_shell
+    assert "body.mobile-stage-content header.app-header { display: flex; }" in mobile_shell
 
 
 def test_dashboard_user_actions_are_not_clipped():

--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -40,6 +40,20 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
 
     assert 'id="mobileBackBtn"' in shell
     assert 'id="mobileMenuBtn"' in shell
+    assert 'class="mobile-launcher-title">Access Control<' in shell
+    assert '<button class="mobile-tile" type="button" data-view="index">' in shell
+    for view in (
+        "user-overview",
+        "users",
+        "temp-user",
+        "event-history",
+        "device-management",
+        "settings",
+    ):
+        assert f'data-view="{view}"' in shell
+    assert "body.mobile-stage-nav .mobile-launcher { display: grid; }" in shell
+    assert "body.mobile-stage-content header.app-header { display: flex; }" in shell
+    assert "header.app-header .logo-mark { display: none; }" in shell
     assert "const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';" in shell
     assert "const APP_HISTORY_SESSION_KEY = 'akuvoxHistorySession';" in shell
     assert "const APP_HISTORY_SESSION_ID = (() => {" in shell
@@ -54,6 +68,7 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
     assert "setMobileStage('content', { syncHistory: false });" in shell
     assert "const mobileMenuBtn = document.getElementById('mobileMenuBtn');" in shell
     assert "setMobileStage('nav');" in shell
+    assert "mobileStage = explicitDestination ? 'content' : 'nav';" in shell
 
     for name in ("device_edit-mob.html", "diagnostics-mob.html", "schedules-mob.html"):
         page = read_page(name)
@@ -73,10 +88,19 @@ def test_mobile_global_actions_include_update_check():
         '<button class="mobile-tile sub" type="button" data-action="hacs_update_check">'
         in shell
     )
-    assert '<span class="tile-title">Check for updates</span>' in shell
+    assert '<span class="tile-title">System update</span>' in shell
     assert '<span>Check for updates</span>' in shell
     assert "steps.push(() => postJson(API_ACTION, { action: 'hacs_update_check' }));" in shell
     assert "steps.push(() => callService('akuvox_ac', 'hacs_update_check', {}));" in shell
+
+
+def test_mobile_global_actions_include_access_event_refresh():
+    shell = read_page("head-mob.html")
+
+    assert 'data-action="refresh_events"' in shell
+    assert '<span class="tile-title">Update access events</span>' in shell
+    assert "steps.push(() => postJson(API_ACTION, { action: 'refresh_events' }));" in shell
+    assert "steps.push(() => callService('akuvox_ac', 'refresh_events', {}));" in shell
 
 
 def test_dashboards_start_only_one_state_polling_loop():

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -9,9 +9,8 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <style>
     :root {
-      --bg:#0b1320; --panel:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#a5b5cc;
-      --accent:#2ff0c4; --accent-dark:#1ba987;
-      --mint:#2ff0c4; --mint-soft:rgba(47,240,196,.18); --mint-glow:rgba(47,240,196,.35);
+      --bg:#020b18; --panel:#0b192b; --panel-2:#0e1f35; --border:#203650;
+      --text:#f3f7fb; --muted:#91a4ba; --accent:#1686ff; --accent-soft:#0e315f;
     }
     html, body { height: 100%; }
     body {
@@ -134,20 +133,40 @@
     }
     .mobile-launcher {
       display: none;
-      background: var(--panel);
-      border-bottom: 1px solid var(--border);
-      padding: 0 1.5rem 1rem;
-      gap: 0.75rem;
+      padding: 0.75rem;
+      gap: 0.7rem;
+      overflow-y: auto;
+      align-content: start;
+      background:
+        radial-gradient(circle at 55% -15%,rgba(24,112,213,.2),transparent 42%),
+        linear-gradient(180deg,#020b18 0%,#061222 100%);
+    }
+    .mobile-launcher-intro {
+      grid-column: 1 / -1;
+      padding: 0.35rem 0.15rem 0.45rem;
+    }
+    .mobile-launcher-title {
+      display: block;
+      font-size: 1.2rem;
+      font-weight: 750;
+      letter-spacing: -.02em;
+    }
+    .mobile-launcher-subtitle {
+      display: block;
+      margin-top: 0.2rem;
+      color: var(--muted);
+      font-size: 0.84rem;
     }
     .mobile-group {
       display: flex;
       flex-direction: column;
       gap: 0.6rem;
+      min-width: 0;
     }
-    .mobile-group + .mobile-group { margin-top: 0.5rem; }
+    .mobile-group.expanded { grid-column: 1 / -1; }
     .mobile-launcher .mobile-subgrid {
       display: none;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.6rem;
     }
     .mobile-group.expanded .mobile-subgrid[data-subgrid="users-primary"] { display: grid; }
@@ -155,68 +174,87 @@
     .mobile-group.show-add-options .mobile-subgrid[data-subgrid="users-primary"] { display: none; }
     .mobile-group.show-add-options .mobile-subgrid[data-subgrid="users-add"] { display: grid; }
     .mobile-group [data-group-toggle] {
-      border: 1px solid rgba(47,240,196,.25);
+      height: 100%;
     }
     .mobile-group.expanded [data-group-toggle] {
-      border-color: rgba(47,240,196,.55);
-      box-shadow: 0 0.8rem 1.5rem rgba(3,20,32,.55);
+      border-color: #1686ff;
+      box-shadow: 0 0 0 .12rem rgba(22,134,255,.16);
     }
     .mobile-tile {
-      border: 1px solid rgba(13,202,240,.25);
-      border-radius: 0.9rem;
-      background: linear-gradient(135deg, rgba(13,202,240,.18), rgba(13,202,240,.05));
+      min-height: 132px;
+      border: 1px solid var(--border);
+      border-radius: 0.72rem;
+      background: linear-gradient(145deg,rgba(13,31,52,.98),rgba(8,23,40,.98));
       color: var(--text);
-      padding: 1rem 1.1rem;
+      padding: 0.9rem;
       display: flex;
+      flex-direction: column;
       align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
+      justify-content: flex-start;
+      gap: 0.7rem;
       width: 100%;
-      text-align: left;
+      text-align: center;
       cursor: pointer;
-      transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+      box-shadow: 0 12px 30px rgba(0,0,0,.16);
+      transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease, background .15s ease;
     }
     .mobile-tile .tile-text {
       display: flex;
       flex-direction: column;
       gap: 0.25rem;
+      align-items: center;
     }
     .mobile-tile .tile-title {
-      font-size: 1.05rem;
-      font-weight: 600;
+      font-size: 0.96rem;
+      font-weight: 700;
     }
     .mobile-tile small {
-      font-size: 0.85rem;
+      font-size: 0.74rem;
+      line-height: 1.3;
       color: var(--muted);
     }
     .mobile-tile .bi {
-      font-size: 1.5rem;
-      color: var(--accent);
+      order: -1;
+      display: grid;
+      place-items: center;
+      width: 45px;
+      height: 45px;
+      flex: 0 0 45px;
+      border-radius: 50%;
+      color: #dcecff;
+      background: linear-gradient(145deg,#153f75,#0d2850);
+      font-size: 1.25rem;
     }
     .mobile-tile:hover,
     .mobile-tile:focus {
       transform: translateY(-1px);
-      border-color: var(--accent);
-      box-shadow: 0 0.5rem 1.2rem rgba(3, 20, 32, 0.45);
+      border-color: #1686ff;
+      background: linear-gradient(145deg,rgba(17,43,72,.98),rgba(9,27,47,.98));
+      box-shadow: 0 0 0 .12rem rgba(22,134,255,.16),0 12px 30px rgba(0,0,0,.2);
       outline: none;
     }
     .mobile-tile.sub {
-      background: #10243d;
-      border-color: #1f3a5f;
-      padding: 0.85rem 1rem;
+      min-height: 112px;
+      background: linear-gradient(145deg,#10243d,#0a1a2c);
+      border-color: #274665;
+      padding: 0.75rem;
     }
-    .mobile-tile.sub .tile-title { font-size: 0.95rem; }
+    .mobile-tile.sub .tile-title { font-size: 0.88rem; }
+    .mobile-tile.sub .bi { width: 38px;height: 38px;flex-basis:38px;font-size:1rem; }
     .mobile-tile.sub.back {
       grid-column: 1 / -1;
+      min-height: 42px;
+      flex-direction: row;
       background: transparent;
-      border: 1px solid rgba(148,163,184,.5);
+      border: 1px solid #38516d;
       padding: 0.55rem 0.85rem;
       justify-content: center;
     }
+    .mobile-tile.sub.back .bi { display:none; }
     .mobile-tile.sub.back .tile-title { font-size: 0.9rem; }
     .mobile-tile.active {
       border-color: var(--accent);
-      box-shadow: 0 0 0 0.15rem rgba(13,202,240,.3);
+      box-shadow: 0 0 0 0.15rem rgba(22,134,255,.22);
     }
     .frame-wrap {
       flex: 1;
@@ -278,41 +316,46 @@
     }
     @media (max-width: 720px) {
       header.app-header {
+        display: none;
         flex-direction: column;
         align-items: flex-start;
+        position: sticky;
+        top: 0;
+        z-index: 5;
+        padding: 0.5rem 0.75rem;
+        background: rgba(2,11,24,.97);
+        border-bottom-color: var(--border);
       }
       header.app-header .brand-bar {
         width: 100%;
         justify-content: space-between;
       }
+      header.app-header .brand { gap: 0; }
+      header.app-header .logo-mark { display: none; }
       header.app-header h1 { font-size: 1.25rem; }
       nav.nav-buttons { width: 100%; justify-content: flex-start; display: none; }
       .nav-quick-actions { display: none !important; }
-      .mobile-launcher { display: grid; }
-      .frame-wrap { padding: 0.5rem 0.75rem 1rem; }
-      footer.app-footer { padding: 0.5rem 0.75rem 1rem; text-align: left; }
+      .mobile-launcher { grid-template-columns:repeat(2,minmax(0,1fr)); }
+      .frame-wrap { padding: 0; }
+      .frame-wrap iframe { border:0;border-radius:0;display:block; }
+      footer.app-footer { display:none; }
+      body.mobile-stage-nav header.app-header,
       body.mobile-stage-nav .frame-wrap,
       body.mobile-stage-nav footer.app-footer { display: none; }
       body.mobile-stage-nav .mobile-launcher { display: grid; }
       body.mobile-stage-content .mobile-launcher { display: none; }
+      body.mobile-stage-content header.app-header { display: flex; }
       body.mobile-stage-content .frame-wrap,
       body.mobile-stage-content footer.app-footer { display: block; }
       body.mobile-stage-content .mobile-menu-btn,
       body.mobile-stage-content .mobile-back-btn { display: inline-flex; }
     }
-    header.app-header,
-    .mobile-launcher,
-    footer.app-footer {
-      display: none !important;
-    }
-    .frame-wrap {
-      display: block !important;
-      padding: 0 !important;
-    }
-    .frame-wrap iframe {
-      display: block;
-      border: 0;
-      border-radius: 0;
+    @media (min-width: 721px) {
+      header.app-header,
+      .mobile-launcher,
+      footer.app-footer { display:none!important; }
+      .frame-wrap { display:block!important;padding:0!important; }
+      .frame-wrap iframe { display:block;border:0;border-radius:0; }
     }
   </style>
 </head>
@@ -383,6 +426,17 @@
     </div>
   </header>
   <section class="mobile-launcher" id="mobileLauncher" aria-label="Quick actions">
+    <div class="mobile-launcher-intro">
+      <span class="mobile-launcher-title">Access Control</span>
+      <span class="mobile-launcher-subtitle">Choose an area to manage</span>
+    </div>
+    <button class="mobile-tile" type="button" data-view="index">
+      <div class="tile-text">
+        <span class="tile-title">Overview</span>
+        <small>Live events, device status and system health</small>
+      </div>
+      <i class="bi bi-speedometer2"></i>
+    </button>
     <div class="mobile-group" data-group="users">
       <button class="mobile-tile" type="button" data-group-toggle="users" aria-expanded="false">
         <div class="tile-text">
@@ -466,9 +520,16 @@
           </div>
           <i class="bi bi-lightning-charge-fill"></i>
         </button>
+        <button class="mobile-tile sub" type="button" data-action="refresh_events">
+          <div class="tile-text">
+            <span class="tile-title">Update access events</span>
+            <small>Pull the latest access history from every panel</small>
+          </div>
+          <i class="bi bi-journal-arrow-down"></i>
+        </button>
         <button class="mobile-tile sub" type="button" data-action="hacs_update_check">
           <div class="tile-text">
-            <span class="tile-title">Check for updates</span>
+            <span class="tile-title">System update</span>
             <small>Check HACS for a newer integration version</small>
           </div>
           <i class="bi bi-cloud-arrow-down-fill"></i>
@@ -1334,6 +1395,7 @@ function describeAction(action){
   const normalized = String(action || '').toLowerCase();
   if (normalized.includes('reboot')) return 'reboot all devices';
   if (normalized.includes('sync')) return 'force a full sync';
+  if (normalized.includes('event')) return 'update access events';
   if (normalized.includes('update')) return 'check for updates';
   return 'run the requested action';
 }
@@ -1380,6 +1442,12 @@ async function runDashboardAction(action){
     steps.push(() => postJson(API_ACTION, { action: 'force_full_sync' }));
     steps.push(() => callService('akuvox_ac', 'force_full_sync', {}));
     steps.push(() => callService('akuvox_ac', 'sync_now', {}));
+  } else if (
+    normalized === 'refresh_events'
+    || normalized === 'update_access_events'
+  ) {
+    steps.push(() => postJson(API_ACTION, { action: 'refresh_events' }));
+    steps.push(() => callService('akuvox_ac', 'refresh_events', {}));
   } else if (
     normalized === 'hacs_update_check'
     || normalized === 'hacs_auto_update'
@@ -1593,6 +1661,12 @@ window.addEventListener('popstate', (event) => {
   const searchParams = new URLSearchParams(location.search);
   const initialView = normalizeView(searchParams.get('view') || DEFAULT_VIEW);
   const params = paramsFromSearch(location.search);
+  if (isMobileMode) {
+    const explicitDestination = searchParams.has('view')
+      || ['section', 'mode', 'id', 'user', 'extend'].some(key => searchParams.has(key));
+    mobileStage = explicitDestination ? 'content' : 'nav';
+    applyMobileFlags();
+  }
   updateHistory(initialView, params, { replaceState: true });
   await ensureDashboardSignedPaths();
   loadView(initialView, params, { replaceState: true });


### PR DESCRIPTION
## Summary
- restore the mobile launcher as the default phone screen
- restyle the older menu hierarchy to match the new blue dashboard design
- retain dedicated screens for overview, current users, permanent users, temporary users, event history, devices, and settings
- provide a compact Menu/Back bar on subscreens without restoring the duplicate project logo
- bring Global Actions up to date with force sync, access-event refresh, system update, and reboot controls
- open explicit deep links directly in their requested subscreen while ordinary mobile entry opens the menu

## Root cause
The mobile launcher and navigation logic were still present, but a blanket CSS rule hid the launcher, header controls, and footer. Phones therefore opened directly into the long responsive overview instead of the menu-first workflow.

## Verification
- browser verified at 390x844: menu opens by default with no horizontal overflow
- verified User Management and Add User nested menus, including Add Temporary User
- verified content mode displays Menu/Back controls and keeps the duplicate logo hidden
- verified explicit mobile deep links start in content mode
- desktop dashboard remains 1280x800 with no document-level scroll
- focused tests: `17 passed`
- full suite: `171 passed, 1 failed`; the existing unrelated failure is the Europe/London DST timestamp assertion in `test_process_door_events_updates_state_with_newer_events`

## Release impact
Patch-level mobile navigation and presentation fix.