### PR TITLE
Refine mobile menu navigation

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -41,7 +41,7 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
     assert 'id="mobileBackBtn"' in shell
     assert 'id="mobileMenuBtn"' in shell
     assert 'class="mobile-launcher-title">Access Control<' in shell
-    assert '<button class="mobile-tile" type="button" data-view="index">' in shell
+    assert '<button class="mobile-tile" type="button" data-view="index">' not in shell
     for view in (
         "user-overview",
         "users",
@@ -54,6 +54,8 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
     assert "body.mobile-stage-nav .mobile-launcher { display: grid; }" in shell
     assert "body.mobile-stage-content header.app-header { display: flex; }" in shell
     assert "header.app-header .logo-mark { display: none; }" in shell
+    assert ".mobile-group.expanded { display: contents; }" in shell
+    assert 'class="mobile-subgrid-heading"' in shell
     assert "const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';" in shell
     assert "const APP_HISTORY_SESSION_KEY = 'akuvoxHistorySession';" in shell
     assert "const APP_HISTORY_SESSION_ID = (() => {" in shell
@@ -61,13 +63,20 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
     assert "state[APP_HISTORY_SESSION_KEY] !== APP_HISTORY_SESSION_ID" in shell
     assert "const nextIndex = replaceState ? currentIndex : currentIndex + 1;" in shell
     assert "[APP_HISTORY_SESSION_KEY]: APP_HISTORY_SESSION_ID" in shell
+    assert "mobileMenuEntry: isMobileMode && mobileMenuEntry" in shell
+    assert "mobileMenuGroup: isMobileMode ? mobileMenuGroup : null" in shell
     assert "updateHistory(initialView, params, { replaceState: true });\n  await ensureDashboardSignedPaths();" in shell
-    assert "if (getAppHistoryIndex() > 0)" in shell
-    assert "history.back();" in shell
+    assert "let mobileViewStack = [];" in shell
+    assert "function rememberMobileDestination(view, params = {}, options = {})" in shell
+    assert "if (mobileViewStack.length > 1)" in shell
+    assert "mobileViewStack.pop();" in shell
+    assert "loadView(previous.view, previous.params, {" in shell
+    assert "function returnToMobileMenu(group)" in shell
+    assert "mobileViewStack = [];" in shell
     assert "function setMobileStage(stage, { preserveGroups = false, syncHistory = true } = {})" in shell
-    assert "setMobileStage('content', { syncHistory: false });" in shell
+    assert "setMobileStage('content', { preserveGroups: true, syncHistory: false });" in shell
+    assert "replaceState: true,\n        mobileMenuEntry: true," in shell
     assert "const mobileMenuBtn = document.getElementById('mobileMenuBtn');" in shell
-    assert "setMobileStage('nav');" in shell
     assert "mobileStage = explicitDestination ? 'content' : 'nav';" in shell
 
     for name in ("device_edit-mob.html", "diagnostics-mob.html", "schedules-mob.html"):
@@ -101,6 +110,30 @@ def test_mobile_global_actions_include_access_event_refresh():
     assert '<span class="tile-title">Update access events</span>' in shell
     assert "steps.push(() => postJson(API_ACTION, { action: 'refresh_events' }));" in shell
     assert "steps.push(() => callService('akuvox_ac', 'refresh_events', {}));" in shell
+    assert 'id="mobileActionStatus"' in shell
+    assert "setMobileActionStatus(`Request sent: ${describeAction(normalized)}.`, 'success');" in shell
+    assert "loadView('index', { section: 'global-actions' });" not in shell
+    assert "runDashboardAction(action);\n    if (isMobileMode)" not in shell
+
+
+def test_mobile_user_overview_only_presents_the_user_list():
+    overview = read_page("user_overview-mob.html")
+
+    assert "<h1>Current users</h1>" in overview
+    assert 'id="userSearch"' in overview
+    assert 'id="userSort"' in overview
+    assert 'id="userList"' in overview
+    for removed_id in (
+        "summaryUsers",
+        "summaryPending",
+        "summaryFaces",
+        "lastUpdated",
+        "btnMobileAddUser",
+        "btnMobileAddTempUser",
+        "forceFullSyncBtn",
+        "syncNowBtn",
+    ):
+        assert f'id="{removed_id}"' not in overview
 
 
 def test_dashboards_start_only_one_state_polling_loop():

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -136,6 +136,7 @@
       padding: 0.75rem;
       gap: 0.7rem;
       overflow-y: auto;
+      scrollbar-gutter: stable;
       align-content: start;
       background:
         radial-gradient(circle at 55% -15%,rgba(24,112,213,.2),transparent 42%),
@@ -163,11 +164,17 @@
       gap: 0.6rem;
       min-width: 0;
     }
-    .mobile-group.expanded { grid-column: 1 / -1; }
+    .mobile-group.expanded { display: contents; }
     .mobile-launcher .mobile-subgrid {
       display: none;
+      grid-column: 1 / -1;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.6rem;
+      padding: 0.75rem;
+      border: 1px solid #274665;
+      border-radius: 0.8rem;
+      background: linear-gradient(145deg,rgba(11,29,49,.98),rgba(5,18,32,.98));
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.025),0 12px 28px rgba(0,0,0,.18);
     }
     .mobile-group.expanded .mobile-subgrid[data-subgrid="users-primary"] { display: grid; }
     .mobile-group.expanded .mobile-subgrid:not([data-subgrid]) { display: grid; }
@@ -180,8 +187,35 @@
       border-color: #1686ff;
       box-shadow: 0 0 0 .12rem rgba(22,134,255,.16);
     }
+    .mobile-subgrid-heading {
+      grid-column: 1 / -1;
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      color: #c8dcf4;
+      font-size: 0.76rem;
+      font-weight: 750;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .mobile-subgrid-heading .bi { color: #4aa3ff; }
+    .mobile-action-status {
+      display: none;
+      grid-column: 1 / -1;
+      padding: 0.65rem 0.75rem;
+      border: 1px solid #38516d;
+      border-radius: 0.55rem;
+      color: var(--muted);
+      background: rgba(4,16,29,.72);
+      font-size: 0.78rem;
+      line-height: 1.35;
+    }
+    .mobile-action-status.visible { display: block; }
+    .mobile-action-status.busy { color: #8fc5ff; border-color: #245f9d; }
+    .mobile-action-status.success { color: #5ef3a8; border-color: rgba(46,204,113,.45); }
+    .mobile-action-status.error { color: #ff8995; border-color: rgba(255,77,79,.5); }
     .mobile-tile {
-      min-height: 132px;
+      min-height: 156px;
       border: 1px solid var(--border);
       border-radius: 0.72rem;
       background: linear-gradient(145deg,rgba(13,31,52,.98),rgba(8,23,40,.98));
@@ -430,13 +464,6 @@
       <span class="mobile-launcher-title">Access Control</span>
       <span class="mobile-launcher-subtitle">Choose an area to manage</span>
     </div>
-    <button class="mobile-tile" type="button" data-view="index">
-      <div class="tile-text">
-        <span class="tile-title">Overview</span>
-        <small>Live events, device status and system health</small>
-      </div>
-      <i class="bi bi-speedometer2"></i>
-    </button>
     <div class="mobile-group" data-group="users">
       <button class="mobile-tile" type="button" data-group-toggle="users" aria-expanded="false">
         <div class="tile-text">
@@ -446,10 +473,11 @@
         <i class="bi bi-people-fill"></i>
       </button>
       <div class="mobile-subgrid" data-subgrid="users-primary">
+        <div class="mobile-subgrid-heading"><i class="bi bi-people-fill"></i> User management</div>
         <button class="mobile-tile sub" type="button" data-view="user-overview">
           <div class="tile-text">
             <span class="tile-title">User overview</span>
-            <small>Review sync status and assigned groups</small>
+            <small>View and manage users in the system</small>
           </div>
           <i class="bi bi-layout-text-window-reverse"></i>
         </button>
@@ -462,6 +490,7 @@
         </button>
       </div>
       <div class="mobile-subgrid" data-subgrid="users-add">
+        <div class="mobile-subgrid-heading"><i class="bi bi-person-plus-fill"></i> Add a user</div>
         <button class="mobile-tile sub" type="button" data-view="users" data-mode="add">
           <div class="tile-text">
             <span class="tile-title">Add user</span>
@@ -506,6 +535,7 @@
         <i class="bi bi-lightning-fill"></i>
       </button>
       <div class="mobile-subgrid">
+        <div class="mobile-subgrid-heading"><i class="bi bi-lightning-fill"></i> Global actions</div>
         <button class="mobile-tile sub" type="button" data-action="reboot_all">
           <div class="tile-text">
             <span class="tile-title">Reboot all</span>
@@ -534,6 +564,7 @@
           </div>
           <i class="bi bi-cloud-arrow-down-fill"></i>
         </button>
+        <div class="mobile-action-status" id="mobileActionStatus" role="status" aria-live="polite"></div>
       </div>
     </div>
     <button class="mobile-tile" type="button" data-view="settings">
@@ -580,6 +611,7 @@ const MOBILE_BREAKPOINT = '(max-width: 720px)';
 const mobileMedia = window.matchMedia(MOBILE_BREAKPOINT);
 let isMobileMode = mobileMedia.matches;
 let mobileStage = isMobileMode ? 'nav' : 'content';
+let mobileViewStack = [];
 let knownToken = null;
 let tokenRefreshScheduled = false;
 const REJECTED_TOKENS = new Set();
@@ -904,6 +936,84 @@ function setMobileStage(stage, { preserveGroups = false, syncHistory = true } = 
   applyMobileFlags();
   updateGroupExpansion();
   if (syncHistory) syncHistoryStage();
+}
+
+function mobileGroupForView(view){
+  const normalized = normalizeView(view);
+  if (['user-overview', 'users', 'temp-user', 'face-rec'].includes(normalized)) return 'users';
+  return null;
+}
+
+function mobileShellUrl(){
+  const search = new URLSearchParams();
+  const authSig = currentAuthSig();
+  if (authSig) search.set('authSig', authSig);
+  const query = search.toString();
+  return query ? `${location.pathname}?${query}` : location.pathname;
+}
+
+function mobileStackEntry(view, params = {}, menuGroup = null){
+  return {
+    view: normalizeView(view),
+    params: { ...(params || {}) },
+    menuGroup: menuGroup || mobileGroupForView(view)
+  };
+}
+
+function sameMobileDestination(left, right){
+  if (!left || !right || left.view !== right.view) return false;
+  try {
+    return JSON.stringify(left.params || {}) === JSON.stringify(right.params || {});
+  } catch (err) {
+    return false;
+  }
+}
+
+function rememberMobileDestination(view, params = {}, options = {}){
+  if (!isMobileMode) return;
+  const entry = mobileStackEntry(view, params, options.menuGroup);
+  if (options.reset || !mobileViewStack.length) {
+    mobileViewStack = [entry];
+    return;
+  }
+  if (options.replace) {
+    const previous = mobileViewStack[mobileViewStack.length - 2];
+    if (previous && sameMobileDestination(previous, entry)) {
+      mobileViewStack.pop();
+    } else {
+      mobileViewStack[mobileViewStack.length - 1] = entry;
+    }
+    return;
+  }
+  const current = mobileViewStack[mobileViewStack.length - 1];
+  if (sameMobileDestination(current, entry)) {
+    mobileViewStack[mobileViewStack.length - 1] = entry;
+    return;
+  }
+  mobileViewStack.push(entry);
+}
+
+function returnToMobileMenu(group){
+  if (!isMobileMode) return;
+  document.querySelectorAll('.mobile-group.show-add-options').forEach(item => {
+    item.classList.remove('show-add-options');
+  });
+  expandedGroup = group || null;
+  mobileViewStack = [];
+  mobileStage = 'nav';
+  applyMobileFlags();
+  updateGroupExpansion();
+  const current = history.state || {};
+  const state = {
+    ...current,
+    view: DEFAULT_VIEW,
+    params: {},
+    mobileStage: 'nav',
+    mobileMenuEntry: false,
+    mobileMenuGroup: expandedGroup,
+    [APP_HISTORY_SESSION_KEY]: APP_HISTORY_SESSION_ID
+  };
+  history.replaceState(state, '', mobileShellUrl());
 }
 
 function handleMobileMediaChange(ev){
@@ -1233,7 +1343,8 @@ function setActiveNav(view){
     else btn.classList.remove('active');
   });
 
-  const userActive = view === 'users' || (view === 'index' && sectionLower === 'users');
+  const userActive = ['user-overview', 'users', 'temp-user', 'face-rec'].includes(view)
+    || (view === 'index' && sectionLower === 'users');
   const globalActive = view === 'index' && sectionLower === 'global-actions';
 
   const allowAutoExpand = !(isMobileMode && mobileStage === 'nav');
@@ -1257,13 +1368,25 @@ function getAppHistoryIndex(state = history.state){
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0;
 }
 
-function updateHistory(view, params, { replaceState = false } = {}){
+function updateHistory(view, params, options = {}){
+  const replaceState = !!options.replaceState;
+  const currentState = history.state || {};
+  const sameSession = currentState[APP_HISTORY_SESSION_KEY] === APP_HISTORY_SESSION_ID;
   const currentIndex = getAppHistoryIndex();
   const nextIndex = replaceState ? currentIndex : currentIndex + 1;
+  const hasExplicitMenuGroup = Object.prototype.hasOwnProperty.call(options, 'mobileMenuGroup');
+  const mobileMenuGroup = hasExplicitMenuGroup
+    ? (options.mobileMenuGroup || null)
+    : (sameSession ? (currentState.mobileMenuGroup || null) : mobileGroupForView(view));
+  const mobileMenuEntry = typeof options.mobileMenuEntry === 'boolean'
+    ? options.mobileMenuEntry
+    : (replaceState && sameSession && currentState.mobileMenuEntry === true);
   const state = {
     view,
     params,
     mobileStage: isMobileMode ? mobileStage : 'content',
+    mobileMenuEntry: isMobileMode && mobileMenuEntry,
+    mobileMenuGroup: isMobileMode ? mobileMenuGroup : null,
     [APP_HISTORY_INDEX_KEY]: nextIndex,
     [APP_HISTORY_SESSION_KEY]: APP_HISTORY_SESSION_ID
   };
@@ -1304,7 +1427,14 @@ function loadView(view, params = {}, options = {}){
   }
   setActiveNav(normalized);
   if (options.updateHistory !== false) {
-    updateHistory(normalized, params, { replaceState: !!options.replaceState });
+    const historyOptions = { replaceState: !!options.replaceState };
+    if (Object.prototype.hasOwnProperty.call(options, 'mobileMenuEntry')) {
+      historyOptions.mobileMenuEntry = options.mobileMenuEntry;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'mobileMenuGroup')) {
+      historyOptions.mobileMenuGroup = options.mobileMenuGroup;
+    }
+    updateHistory(normalized, params, historyOptions);
   }
 }
 
@@ -1408,18 +1538,17 @@ function formatActionError(err){
   try { return String(err); } catch (convErr) { return ''; }
 }
 
+function setMobileActionStatus(message, tone = ''){
+  const status = document.getElementById('mobileActionStatus');
+  if (!status) return;
+  status.textContent = message || '';
+  status.className = `mobile-action-status${message ? ' visible' : ''}${tone ? ` ${tone}` : ''}`;
+}
+
 async function runDashboardAction(action){
   const normalized = String(action || '').toLowerCase();
-  if (!normalized) return;
-
-  const frame = document.getElementById('viewFrame');
-  const previousHref = frame?.dataset.currentHref || '';
-
-  if (isMobileMode) {
-    setMobileStage('content', { preserveGroups: true, syncHistory: false });
-  }
-  loadView('index', { section: 'global-actions' });
-  const changed = frame && frame.dataset.currentHref !== previousHref;
+  if (!normalized) return false;
+  setMobileActionStatus(`Requesting ${describeAction(normalized)}...`, 'busy');
 
   let success = false;
   let lastError = '';
@@ -1456,10 +1585,8 @@ async function runDashboardAction(action){
     steps.push(() => postJson(API_ACTION, { action: 'hacs_update_check' }));
     steps.push(() => callService('akuvox_ac', 'hacs_update_check', {}));
   } else {
-    if (!changed && frame) {
-      reloadActiveView({ updateHistory: false });
-    }
-    return;
+    setMobileActionStatus('That action is not available.', 'error');
+    return false;
   }
 
   for (const step of steps) {
@@ -1474,15 +1601,12 @@ async function runDashboardAction(action){
 
   if (!success) {
     const message = describeAction(normalized);
+    setMobileActionStatus(`Unable to ${message}${lastError ? `: ${lastError}` : ''}`, 'error');
     alert(`Unable to ${message}${lastError ? `: ${lastError}` : ''}`);
-    return;
+    return false;
   }
-
-  if (!changed && frame) {
-    setTimeout(() => {
-      try { reloadActiveView({ updateHistory: false }); } catch (err) {}
-    }, 150);
-  }
+  setMobileActionStatus(`Request sent: ${describeAction(normalized)}.`, 'success');
+  return true;
 }
 
 async function fetchVersion(){
@@ -1561,7 +1685,17 @@ document.querySelectorAll('.mobile-launcher [data-view], .mobile-launcher [data-
       updateGroupExpansion();
     }
     if (!hasView) return;
-    if (isMobileMode) setMobileStage('content', { syncHistory: false });
+    if (isMobileMode) {
+      const menuGroup = parentGroup || mobileGroupForView(view);
+      setMobileStage('content', { preserveGroups: true, syncHistory: false });
+      rememberMobileDestination(view, params, { reset: true, menuGroup });
+      loadView(view, params, {
+        replaceState: true,
+        mobileMenuEntry: true,
+        mobileMenuGroup: menuGroup
+      });
+      return;
+    }
     loadView(view, params, { replaceState: false });
   });
 });
@@ -1592,15 +1726,19 @@ document.querySelectorAll('#navQuickActions [data-view]').forEach(btn => {
 });
 
 document.querySelectorAll('#navQuickActions [data-action], .mobile-launcher [data-action]').forEach(btn => {
-  btn.addEventListener('click', (ev) => {
+  btn.addEventListener('click', async (ev) => {
     ev.preventDefault();
     const action = (btn.dataset.action || '').toLowerCase();
     if (!action) return;
     const group = btn.closest('[data-group]')?.dataset.group || null;
     if (group) expandedGroup = group;
     updateGroupExpansion();
-    runDashboardAction(action);
-    if (isMobileMode) setMobileStage('content', { preserveGroups: true });
+    btn.setAttribute('disabled', 'disabled');
+    try {
+      await runDashboardAction(action);
+    } finally {
+      btn.removeAttribute('disabled');
+    }
   });
 });
 
@@ -1609,11 +1747,23 @@ if (mobileBackBtn) {
   mobileBackBtn.addEventListener('click', (ev) => {
     ev.preventDefault();
     if (!isMobileMode) return;
-    if (getAppHistoryIndex() > 0) {
-      history.back();
+    if (mobileViewStack.length > 1) {
+      mobileViewStack.pop();
+      const previous = mobileViewStack[mobileViewStack.length - 1];
+      expandedGroup = previous.menuGroup || mobileGroupForView(previous.view);
+      setMobileStage('content', { preserveGroups: true, syncHistory: false });
+      loadView(previous.view, previous.params, {
+        replaceState: true,
+        mobileMenuEntry: mobileViewStack.length === 1,
+        mobileMenuGroup: expandedGroup
+      });
       return;
     }
-    setMobileStage('nav');
+    const state = history.state || {};
+    const current = mobileViewStack[0];
+    returnToMobileMenu(
+      current?.menuGroup || state.mobileMenuGroup || mobileGroupForView(current?.view || state.view)
+    );
   });
 }
 
@@ -1622,7 +1772,11 @@ if (mobileMenuBtn) {
   mobileMenuBtn.addEventListener('click', (ev) => {
     ev.preventDefault();
     if (!isMobileMode) return;
-    setMobileStage('nav');
+    const state = history.state || {};
+    const current = mobileViewStack[0];
+    returnToMobileMenu(
+      current?.menuGroup || state.mobileMenuGroup || mobileGroupForView(current?.view || state.view)
+    );
   });
 }
 
@@ -1634,15 +1788,23 @@ window.addEventListener('message', (event) => {
   if (data.type !== 'akuvox-nav') return;
   const view = normalizeView(data.view || data.slug || data.target || DEFAULT_VIEW);
   const params = data.params || {};
-  if (isMobileMode && data.mobileStage) {
+  const requestedMobileStage = data.mobileStage
+    ? (String(data.mobileStage).toLowerCase() === 'nav' ? 'nav' : 'content')
+    : null;
+  if (isMobileMode && requestedMobileStage) {
     const preserve = data.preserveMobileGroups === true || data.preserveGroups === true;
-    const stage = String(data.mobileStage).toLowerCase() === 'nav' ? 'nav' : 'content';
-    setMobileStage(stage, { preserveGroups: preserve });
+    setMobileStage(requestedMobileStage, { preserveGroups: preserve });
   }
   const opts = {
     updateHistory: data.updateHistory !== false,
     replaceState: !!data.replaceState
   };
+  if (isMobileMode && opts.updateHistory && requestedMobileStage !== 'nav') {
+    rememberMobileDestination(view, params, {
+      replace: opts.replaceState,
+      menuGroup: mobileViewStack[0]?.menuGroup || mobileGroupForView(view)
+    });
+  }
   loadView(view, params, opts);
 });
 
@@ -1652,7 +1814,8 @@ window.addEventListener('popstate', (event) => {
   const params = state.params || paramsFromSearch(location.search);
   if (isMobileMode) {
     const targetStage = state.mobileStage || 'content';
-    setMobileStage(targetStage, { preserveGroups: true });
+    expandedGroup = state.mobileMenuGroup || mobileGroupForView(view);
+    setMobileStage(targetStage, { preserveGroups: true, syncHistory: false });
   }
   loadView(view, params, { updateHistory: false });
 });
@@ -1665,6 +1828,9 @@ window.addEventListener('popstate', (event) => {
     const explicitDestination = searchParams.has('view')
       || ['section', 'mode', 'id', 'user', 'extend'].some(key => searchParams.has(key));
     mobileStage = explicitDestination ? 'content' : 'nav';
+    mobileViewStack = explicitDestination
+      ? [mobileStackEntry(initialView, params, mobileGroupForView(initialView))]
+      : [];
     applyMobileFlags();
   }
   updateHistory(initialView, params, { replaceState: true });

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -9,22 +9,15 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <style>
     :root{
-      --bg:#0b1320; --card:#111a2b; --border:#1b2942; --text:#e6edf3; --muted:#9aa4b2;
+      --bg:#020b18; --card:#0b192b; --border:#203650; --text:#f3f7fb; --muted:#91a4ba;
       --ok:#2ecc71; --warn:#ffc107; --bad:#ff4d4f; --dim:#6c7a92;
     }
     html,body{height:100%;}
     body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
-    .page{min-height:100vh;display:flex;flex-direction:column;padding:1rem;gap:1rem;max-width:960px;margin:0 auto;}
-    header.page-header{display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;}
-    header.page-header h1{flex:1;font-size:1.35rem;margin:0;}
-    header.page-header .header-actions{display:flex;flex-direction:column;gap:0.5rem;align-items:flex-end;flex:1 1 auto;}
-    header.page-header .action-row{display:flex;gap:0.5rem;flex-wrap:wrap;justify-content:flex-end;}
-    header.page-header .btn{white-space:nowrap;}
-    .summary-grid{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}
-    .summary-card{background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.85rem;display:flex;flex-direction:column;gap:0.4rem;}
-    .summary-card .label{color:var(--muted);font-size:0.85rem;text-transform:uppercase;letter-spacing:0.08em;}
-    .summary-card .value{font-size:1.5rem;font-weight:600;}
-    .summary-card small{color:var(--muted);}
+    .page{min-height:100vh;display:flex;flex-direction:column;padding:0.75rem;gap:0.75rem;max-width:960px;margin:0 auto;}
+    header.page-header{padding:0.2rem 0.15rem;}
+    header.page-header h1{font-size:1.3rem;margin:0;}
+    header.page-header p{margin:0.2rem 0 0;color:var(--muted);font-size:0.86rem;}
     .user-list{display:flex;flex-direction:column;gap:1rem;}
     .user-toolbar{display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;background:var(--card);border:1px solid var(--border);border-radius:0.75rem;padding:0.75rem;}
     .user-toolbar .user-search{display:flex;align-items:center;gap:0.4rem;flex:1 1 220px;min-width:0;}
@@ -34,7 +27,7 @@
     .user-toolbar .form-control:focus,
     .user-toolbar .form-select:focus{color:#fff;background:#0e1a2c;border-color:#0dcaf0;box-shadow:0 0 0 0.2rem rgba(13,202,240,.25);}
     .user-toolbar .form-select option{color:#fff;background:#0e1a2c;}
-    .user-card{background:var(--card);border:1px solid var(--border);border-radius:1rem;padding:1rem;display:flex;flex-direction:column;gap:0.75rem;}
+    .user-card{background:linear-gradient(145deg,#0d2036,#08182a);border:1px solid var(--border);border-radius:0.8rem;padding:0.9rem;display:flex;flex-direction:column;gap:0.75rem;box-shadow:0 10px 26px rgba(0,0,0,.16);}
     .user-header{display:flex;gap:0.75rem;align-items:flex-start;}
     .user-name{font-size:1.1rem;font-weight:600;}
     .user-id{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:0.85rem;color:var(--muted);}
@@ -78,14 +71,9 @@
       letter-spacing:0.08em;
     }
     .empty-state{background:var(--card);border:1px dashed var(--border);border-radius:0.75rem;padding:1.5rem;text-align:center;color:var(--muted);}
-    .last-updated{color:var(--muted);font-size:0.85rem;text-align:right;}
     @media (max-width:720px){
       .page{padding:0.75rem;}
-      header.page-header h1{flex-basis:100%;font-size:1.25rem;}
-      header.page-header .header-actions{width:100%;align-items:flex-start;}
-      header.page-header .action-row{width:100%;justify-content:flex-start;}
-      header.page-header .btn{flex:1 1 calc(50% - 0.5rem);}
-      .summary-card .value{font-size:1.35rem;}
+      header.page-header h1{font-size:1.25rem;}
       .status-stack{width:100%;flex-direction:row;justify-content:flex-start;gap:0.5rem;margin-left:0;}
       .user-header{flex-direction:column;}
     }
@@ -94,36 +82,9 @@
 <body>
 <div class="page">
   <header class="page-header">
-    <h1>User Management</h1>
-    <div class="header-actions">
-      <div class="action-row">
-        <a class="btn btn-primary btn-sm" id="btnMobileAddUser" href="#"><i class="bi bi-person-plus"></i> Add User</a>
-        <a class="btn btn-outline-info btn-sm" id="btnMobileAddTempUser" href="#"><i class="bi bi-clock-history"></i> Add Temp User</a>
-      </div>
-      <div class="action-row">
-        <button class="btn btn-outline-warning btn-sm" id="forceFullSyncBtn"><i class="bi bi-arrow-repeat"></i> Force Full Sync</button>
-        <button class="btn btn-outline-secondary btn-sm" id="syncNowBtn"><i class="bi bi-arrow-repeat"></i> Sync Now</button>
-      </div>
-    </div>
+    <h1>Current users</h1>
+    <p>Users currently held in the access control system.</p>
   </header>
-  <section class="summary-grid" aria-label="User summary">
-    <div class="summary-card">
-      <span class="label">Users</span>
-      <span class="value" id="summaryUsers">—</span>
-      <small>Total managed profiles</small>
-    </div>
-    <div class="summary-card">
-      <span class="label">Pending sync</span>
-      <span class="value" id="summaryPending">—</span>
-      <small>Awaiting device updates</small>
-    </div>
-    <div class="summary-card">
-      <span class="label">Face profiles</span>
-      <span class="value" id="summaryFaces">—</span>
-      <small>Active facial credentials</small>
-    </div>
-  </section>
-  <div class="last-updated" id="lastUpdated"></div>
   <div class="user-toolbar" aria-label="User search and sort">
     <div class="user-search">
       <i class="bi bi-search text-muted" aria-hidden="true"></i>
@@ -1497,16 +1458,6 @@ function compileUsers(devices, registryUsers, kpis){
     .filter(u => u.isCloud || idMatchesFilter(u.id));
 }
 
-function renderSummary(kpis, users){
-  const userCount = Array.isArray(users) ? users.length : Number(kpis?.users ?? 0);
-  const total = Number.isFinite(userCount) ? userCount : Number(kpis?.users ?? 0);
-  const pending = Number(kpis?.pending ?? 0);
-  const faces = users.reduce((acc, u) => acc + (u.face_active ? 1 : 0), 0);
-  document.getElementById('summaryUsers').textContent = Number.isFinite(total) ? String(total) : '—';
-  document.getElementById('summaryPending').textContent = Number.isFinite(pending) ? String(pending) : '—';
-  document.getElementById('summaryFaces').textContent = String(faces);
-}
-
 function applyUserFilters(list){
   const filtered = (list || []).filter(u => userMatchesSearch(u, USER_SEARCH));
   sortUsers(filtered);
@@ -1743,10 +1694,7 @@ async function refresh(){
     syncPausedUsersFromState(state.registry_users || []);
     const list = compileUsers(devices, state.registry_users || [], state.kpis || {});
     LAST_USERS = list;
-    renderSummary(state.kpis || {}, list);
     renderUsers(applyUserFilters(list));
-    const ts = new Date();
-    document.getElementById('lastUpdated').textContent = `Updated ${ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
   } catch (err) {
     console.error('Failed to load users', err);
     if (handleAuthError(err)) return;


### PR DESCRIPTION
## Summary
- keep expanded mobile menu tiles at their normal two-column size
- present submenu options inside clearly bordered containers
- remove the broken mobile Overview destination
- simplify User Overview to the current user list, search, sorting, and user actions
- keep Global Actions on the menu with inline status feedback instead of opening Overview
- add an in-app mobile destination stack so Back returns to the actual parent screen or originating menu group

## Root cause
Expanded groups spanned the full launcher grid, action execution deliberately navigated the hidden frame to the Overview route, and the shell Back button depended on browser history state that was ambiguous after nested iframe navigation.

## Verification
- browser verified at 390x844 with no horizontal overflow
- expanded Global Actions tile remains the same width as collapsed tiles
- submenu actions render inside a distinct full-width container
- Global Actions remain on the menu and show inline result status
- Device Management -> Back returns to the launcher
- User Overview -> Manage -> Back returns to Current Users, then Back returns to expanded User Management
- focused tests: `27 passed`
- full suite: `173 passed, 1 failed`; the existing unrelated failure is the Europe/London DST timestamp assertion in `test_process_door_events_updates_state_with_newer_events`
- modified inline scripts parse successfully

## Release impact
Patch-level mobile navigation and layout refinement. Desktop behavior is unchanged.