### PR TITLE
Fix cloud event labels and mobile menu rows

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -54,7 +54,15 @@ def test_mobile_shell_owns_page_back_navigation_and_has_menu_button():
     assert "body.mobile-stage-nav .mobile-launcher { display: grid; }" in shell
     assert "body.mobile-stage-content header.app-header { display: flex; }" in shell
     assert "header.app-header .logo-mark { display: none; }" in shell
-    assert ".mobile-group.expanded { display: contents; }" in shell
+    assert ".mobile-group {" in shell
+    assert "display: contents;" in shell
+    assert '.mobile-group[data-group="users"] [data-group-toggle="users"] { order: 10; }' in shell
+    assert '.mobile-launcher [data-view="event-history"] { order: 20; }' in shell
+    assert '.mobile-group[data-group="users"] .mobile-subgrid { order: 25; }' in shell
+    assert '.mobile-launcher [data-view="device-management"] { order: 30; }' in shell
+    assert '.mobile-group[data-group="global"] [data-group-toggle="global"] { order: 40; }' in shell
+    assert '.mobile-group[data-group="global"] .mobile-subgrid { order: 45; }' in shell
+    assert '.mobile-launcher [data-view="settings"] { order: 50; }' in shell
     assert 'class="mobile-subgrid-heading"' in shell
     assert "const APP_HISTORY_INDEX_KEY = 'akuvoxHistoryIndex';" in shell
     assert "const APP_HISTORY_SESSION_KEY = 'akuvoxHistorySession';" in shell
@@ -141,3 +149,16 @@ def test_dashboards_start_only_one_state_polling_loop():
         page = read_page(name)
         assert page.count("setInterval(refresh, 5000);") == 1
         assert page.count("// initial + poll") == 1
+
+
+def test_cloud_open_events_use_akuvox_app_label():
+    for name in (
+        "index.html",
+        "index-mob.html",
+        "event_history.html",
+        "event_history-mob.html",
+    ):
+        page = read_page(name)
+        assert "Opened with Akuvox App" in page
+        assert "function isCloudEvent(" in page
+        assert " - Cloud - " not in page

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -664,6 +664,13 @@ function getEventTypeLabel(evt){
   return text ? text : '';
 }
 
+function isCloudEvent(evt, typeLabel){
+  if (!evt || typeof evt !== 'object') return false;
+  const source = String(evt.Source || evt.source || evt._source || '').toLowerCase();
+  if (source.includes('cloud')) return true;
+  return String(typeLabel || '').toLowerCase().includes('cloud');
+}
+
 function getEventPinLabel(evt){
   if (!evt || typeof evt !== 'object') return '';
   const value = pickEventValue(evt, ['Pin','PIN','Passcode','Password','Credential','CardNo','CardNumber','digits']);
@@ -689,9 +696,10 @@ function getEventTitle(evt){
   const typeLabel = getEventTypeLabel(evt);
   if (category === 'call') {
     const caller = getEventUserLabel(evt);
-    const typeLower = typeLabel.toLowerCase();
-    const callLabel = typeLower.includes('cloud') ? 'Cloud' : 'Call';
-    return `${deviceName} - ${callLabel} - ${caller}`;
+    if (isCloudEvent(evt, typeLabel)) {
+      return `${deviceName} - Opened with Akuvox App`;
+    }
+    return `${deviceName} - Call - ${caller}`;
   }
   if (category === 'access' && typeLabel) {
     const typeLower = typeLabel.toLowerCase();

--- a/custom_components/akuvox_ac/www/event_history.html
+++ b/custom_components/akuvox_ac/www/event_history.html
@@ -578,6 +578,13 @@ function getEventTypeLabel(evt){
   return text ? text : '';
 }
 
+function isCloudEvent(evt, typeLabel){
+  if (!evt || typeof evt !== 'object') return false;
+  const source = String(evt.Source || evt.source || evt._source || '').toLowerCase();
+  if (source.includes('cloud')) return true;
+  return String(typeLabel || '').toLowerCase().includes('cloud');
+}
+
 function getEventPinLabel(evt){
   if (!evt || typeof evt !== 'object') return '';
   const value = pickEventValue(evt, ['Pin','PIN','Passcode','Password','Credential','CardNo','CardNumber','digits']);
@@ -603,9 +610,10 @@ function getEventTitle(evt){
   const typeLabel = getEventTypeLabel(evt);
   if (category === 'call') {
     const caller = getEventUserLabel(evt);
-    const typeLower = typeLabel.toLowerCase();
-    const callLabel = typeLower.includes('cloud') ? 'Cloud' : 'Call';
-    return `${deviceName} - ${callLabel} - ${caller}`;
+    if (isCloudEvent(evt, typeLabel)) {
+      return `${deviceName} - Opened with Akuvox App`;
+    }
+    return `${deviceName} - Call - ${caller}`;
   }
   if (category === 'access' && typeLabel) {
     const typeLower = typeLabel.toLowerCase();

--- a/custom_components/akuvox_ac/www/head-mob.html
+++ b/custom_components/akuvox_ac/www/head-mob.html
@@ -159,12 +159,16 @@
       font-size: 0.84rem;
     }
     .mobile-group {
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      min-width: 0;
+      display: contents;
     }
-    .mobile-group.expanded { display: contents; }
+    .mobile-launcher-intro { order: 0; }
+    .mobile-group[data-group="users"] [data-group-toggle="users"] { order: 10; }
+    .mobile-launcher [data-view="event-history"] { order: 20; }
+    .mobile-group[data-group="users"] .mobile-subgrid { order: 25; }
+    .mobile-launcher [data-view="device-management"] { order: 30; }
+    .mobile-group[data-group="global"] [data-group-toggle="global"] { order: 40; }
+    .mobile-group[data-group="global"] .mobile-subgrid { order: 45; }
+    .mobile-launcher [data-view="settings"] { order: 50; }
     .mobile-launcher .mobile-subgrid {
       display: none;
       grid-column: 1 / -1;

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1309,10 +1309,16 @@ function describeEventForDisplay(event){
   if (normalizedCategory === 'call') {
     const caller = pickFirstEventText(event, EVENT_CALL_USER_KEYS) || 'Unknown';
     const fallbackMessage = pickFirstEventText(event, EVENT_DETAIL_KEYS.default) || 'call';
-    const callLabel = isCloudEvent(event, typeLabel) ? 'Cloud' : 'Call';
+    if (isCloudEvent(event, typeLabel)) {
+      return {
+        category: normalizedCategory,
+        title: `${deviceLabel} - Opened with Akuvox App`,
+        highlight: fallbackMessage || typeLabel || label,
+      };
+    }
     return {
       category: normalizedCategory,
-      title: `${deviceLabel} - ${callLabel} - ${caller}`,
+      title: `${deviceLabel} - Call - ${caller}`,
       highlight: caller || fallbackMessage || typeLabel || label,
     };
   }

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1626,10 +1626,16 @@ function describeEventForDisplay(event){
   if (normalizedCategory === 'call') {
     const caller = pickFirstEventText(event, EVENT_CALL_USER_KEYS) || 'Unknown';
     const fallbackMessage = pickFirstEventText(event, EVENT_DETAIL_KEYS.default) || 'call';
-    const callLabel = isCloudEvent(event, typeLabel) ? 'Cloud' : 'Call';
+    if (isCloudEvent(event, typeLabel)) {
+      return {
+        category: normalizedCategory,
+        title: `${deviceLabel} - Opened with Akuvox App`,
+        highlight: fallbackMessage || typeLabel || label,
+      };
+    }
     return {
       category: normalizedCategory,
-      title: `${deviceLabel} - ${callLabel} - ${caller}`,
+      title: `${deviceLabel} - Call - ${caller}`,
       highlight: caller || fallbackMessage || typeLabel || label,
     };
   }


### PR DESCRIPTION
## Summary
- rename cloud-open events to `Gate - Opened with Akuvox App` across desktop and mobile dashboard/history views
- keep the mobile launcher rows fixed while User Management or Global Actions expands below its parent row
- add regression coverage for the menu ordering and cloud-event label

## Verification
- browser-checked at 390x844 with no horizontal overflow
- confirmed both mobile dashboard and event history render the new cloud event label
- focused tests: 20 passed
- full suite: 174 passed, 1 existing DST-sensitive timestamp failure in `test_process_door_events_updates_state_with_newer_events`