### PR TITLE
Add Home Assistant open gate events

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -666,6 +666,37 @@ class AkuvoxAPI:
         rels = (primary, *fallbacks)
         return await self._request_attempts("GET", rels, None)
 
+    async def trigger_relay(
+        self,
+        relay_number: Any = 1,
+        *,
+        delay: Any = 20,
+        mode: Any = 0,
+        level: Any = 0,
+    ) -> Dict[str, Any]:
+        """Trigger an Akuvox relay using the device's authenticated web API."""
+
+        try:
+            relay = int(str(relay_number).strip())
+        except Exception as err:
+            raise ValueError("relay number must be 1 or 2") from err
+        if relay not in (1, 2):
+            raise ValueError("relay number must be 1 or 2")
+
+        try:
+            delay_seconds = max(1, min(300, int(float(str(delay).strip()))))
+        except Exception:
+            delay_seconds = 20
+
+        path = (
+            "/api/relay/trig"
+            f"?mode={int(mode or 0)}"
+            f"&num={relay}"
+            f"&level={int(level or 0)}"
+            f"&delay={delay_seconds}"
+        )
+        return await self._get_api(path)
+
     # -------------------- payload normalization helpers --------------------
     def _map_schedule_fields(self, d: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -687,6 +687,9 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             "user_name",
             "Name",
             "name",
+            "HomeAssistantUserID",
+            "home_assistant_user_id",
+            "ha_user_id",
             "CardNo",
             "CardNumber",
             "ID",
@@ -765,11 +768,17 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
                             profile.get("UserID"),
                             profile.get("UserId"),
                             profile.get("ID"),
+                            profile.get("ha_user_id"),
+                            profile.get("home_assistant_user_id"),
+                            profile.get("HomeAssistantUserID"),
                             profile.get("device_id"),
                             profile.get("card_code"),
                             profile.get("CardCode"),
                         ]
                     )
+                    ha_user_ids = profile.get("ha_user_ids") or profile.get("home_assistant_user_ids")
+                    if isinstance(ha_user_ids, (list, tuple, set)):
+                        values.extend(ha_user_ids)
                     device_ids = profile.get("device_ids") or profile.get("device_user_ids")
                     if isinstance(device_ids, dict):
                         values.extend(device_ids.values())
@@ -1816,6 +1825,8 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
                 continue
             compact = re.sub(r"[^a-z0-9]+", "", text)
 
+            if "home assistant" in text or compact in {"homeassistant", "ha"}:
+                return "Home Assistant"
             if re.search(r"\bface\b|\bfacial\b", text):
                 return "Face"
             if (

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -58,7 +58,11 @@ from .const import (
     AKUVOX_DEVICE_MODELS,
 )
 
-from .relay import alarm_capable as relay_alarm_capable, normalize_roles as normalize_relay_roles
+from .relay import (
+    alarm_capable as relay_alarm_capable,
+    door_relays,
+    normalize_roles as normalize_relay_roles,
+)
 from .ha_id import ha_id_from_int, is_ha_id, normalize_ha_id, normalize_user_id
 from .access_history import AccessHistory, categorize_event
 from .reboot_schedule import normalize_reboot_schedule
@@ -642,6 +646,7 @@ SIGNED_API_PATHS: Dict[str, str] = {
     "service_force_full_sync": "/api/services/akuvox_ac/force_full_sync",
     "service_refresh_events": "/api/services/akuvox_ac/refresh_events",
     "service_reboot_device": "/api/services/akuvox_ac/reboot_device",
+    "service_open_gate": "/api/services/akuvox_ac/open_gate",
     "service_delete_user": "/api/services/akuvox_ac/delete_user",
     "service_reactivate_temporary_user": "/api/services/akuvox_ac/reactivate_temporary_user",
 }
@@ -656,6 +661,7 @@ ALLOWED_DASHBOARD_SERVICE_PROXY: Set[str] = {
     "force_full_sync",
     "hacs_update_check",
     "hacs_update_install",
+    "open_gate",
     "reactivate_temporary_user",
     "reboot_device",
     "refresh_events",
@@ -897,7 +903,7 @@ def _ingest_history_event(hass: HomeAssistant, event: Dict[str, Any]) -> None:
 
     root = hass.data.get(DOMAIN, {}) or {}
     history = root.get("access_history")
-    if not history or not hasattr(history, "ingest"):
+    if history is None or not hasattr(history, "ingest"):
         return
 
     settings = root.get("settings_store")
@@ -2536,6 +2542,250 @@ def _context_user_name(hass: HomeAssistant, context) -> str:
     return default
 
 
+def _context_user_identity(hass: HomeAssistant, context) -> Tuple[str, str]:
+    """Return the Home Assistant user id/name behind a service/http context."""
+
+    default = "HA User"
+    if context is None:
+        return "", default
+
+    user_id = str(getattr(context, "user_id", "") or "").strip()
+    if not user_id:
+        return "", default
+
+    try:
+        user = hass.auth.async_get_user(user_id)
+        if user:
+            name = str(
+                getattr(user, "name", "")
+                or getattr(user, "username", "")
+                or getattr(user, "email", "")
+                or ""
+            ).strip()
+            return user_id, name or str(getattr(user, "id", "") or user_id).strip() or default
+    except Exception:
+        pass
+
+    return user_id, user_id or default
+
+
+def _request_actor_identity(
+    hass: HomeAssistant,
+    request: web.Request,
+    context: Any = None,
+) -> Tuple[str, str]:
+    """Return the HA user id/name for a dashboard request or session token."""
+
+    user = _request_hass_user(request)
+    if user:
+        return _ha_user_id(user), _ha_user_name(user)
+
+    session = _request_dashboard_session(hass, request)
+    if session:
+        user_id = str(session.get("user_id") or "").strip()
+        user_name = str(session.get("user_name") or "").strip()
+        if user_id or user_name:
+            return user_id, user_name or user_id or "HA User"
+
+    return _context_user_identity(hass, context)
+
+
+async def _home_assistant_users_payload(hass: HomeAssistant) -> List[Dict[str, Any]]:
+    """Return Home Assistant users suitable for local-user linking."""
+
+    try:
+        ha_users = await hass.auth.async_get_users()
+    except Exception:
+        return []
+
+    users: List[Dict[str, Any]] = []
+    for item in ha_users or []:
+        item_id = _ha_user_id(item)
+        if not item_id:
+            continue
+        if bool(getattr(item, "system_generated", False)):
+            continue
+        users.append(
+            {
+                "id": item_id,
+                "name": _ha_user_name(item),
+                "is_admin": _ha_user_is_admin(item),
+                "is_active": bool(getattr(item, "is_active", True)),
+            }
+        )
+    users.sort(key=lambda item: str(item.get("name") or "").lower())
+    return users
+
+
+def _linked_registry_user_for_ha_actor(
+    root: Dict[str, Any],
+    *,
+    ha_user_id: str,
+    ha_user_name: str,
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Find the local Akuvox profile linked to a Home Assistant user."""
+
+    users_store = root.get("users_store") if isinstance(root, dict) else None
+    try:
+        registry = users_store.all() if users_store and hasattr(users_store, "all") else {}
+    except Exception:
+        registry = {}
+    if not isinstance(registry, dict):
+        return None, None
+
+    wanted_id = str(ha_user_id or "").strip()
+    wanted_name = str(ha_user_name or "").strip().casefold()
+
+    def _values_match(profile: Dict[str, Any]) -> bool:
+        ids: List[Any] = [
+            profile.get("ha_user_id"),
+            profile.get("home_assistant_user_id"),
+            profile.get("HomeAssistantUserID"),
+        ]
+        for key in ("ha_user_ids", "home_assistant_user_ids"):
+            raw = profile.get(key)
+            if isinstance(raw, (list, tuple, set)):
+                ids.extend(raw)
+        if wanted_id and any(str(value or "").strip() == wanted_id for value in ids):
+            return True
+
+        if wanted_name:
+            for key in ("ha_user_name", "home_assistant_user_name", "HomeAssistantUserName"):
+                value = str(profile.get(key) or "").strip().casefold()
+                if value and value == wanted_name:
+                    return True
+        return False
+
+    for key, profile in registry.items():
+        if not isinstance(profile, dict):
+            continue
+        if not _values_match(profile):
+            continue
+        canonical = normalize_user_id(key) or str(key or "").strip()
+        if canonical:
+            return canonical, profile
+
+    return None, None
+
+
+async def async_open_gate(
+    hass: HomeAssistant,
+    root: Dict[str, Any],
+    *,
+    entry_id: Any = None,
+    relay_number: Any = None,
+    delay: Any = None,
+    triggered_by_id: str = "",
+    triggered_by_name: str = "",
+) -> Dict[str, Any]:
+    """Trigger a configured Akuvox door relay and publish a local access event."""
+
+    if not isinstance(root, dict):
+        raise RuntimeError("Akuvox integration is not ready")
+
+    target_entry = str(entry_id or "").strip()
+    if target_entry:
+        bucket = root.get(target_entry)
+        if not isinstance(bucket, dict):
+            raise RuntimeError("device entry not found")
+        coord = bucket.get("coordinator")
+        opts = bucket.get("options") if isinstance(bucket.get("options"), dict) else {}
+    else:
+        buckets = list(_iter_device_buckets(root))
+        if not buckets:
+            raise RuntimeError("no Akuvox devices are configured")
+        if len(buckets) > 1:
+            raise RuntimeError("entry_id is required when more than one device is configured")
+        target_entry, bucket, coord, opts = buckets[0]
+
+    if not isinstance(bucket, dict):
+        raise RuntimeError("device entry not found")
+    api = bucket.get("api")
+    coord = bucket.get("coordinator")
+    if not api or not hasattr(api, "trigger_relay"):
+        raise RuntimeError("device API is not ready")
+    if not coord:
+        raise RuntimeError("device coordinator is not ready")
+
+    health = getattr(coord, "health", {}) or {}
+    device_type = str(health.get("device_type") or "").strip()
+    roles = _device_relay_roles(opts if isinstance(opts, dict) else {}, device_type)
+    if relay_number in (None, ""):
+        relay_digits = door_relays(roles)
+        relay_number = relay_digits[0] if relay_digits else "1"
+
+    try:
+        relay_digit = int(str(relay_number).strip())
+    except Exception as err:
+        raise RuntimeError("relay must be 1 or 2") from err
+    if relay_digit not in (1, 2):
+        raise RuntimeError("relay must be 1 or 2")
+
+    result = await api.trigger_relay(relay_digit, delay=delay if delay not in (None, "") else 20)
+
+    actor_id = str(triggered_by_id or "").strip()
+    actor_name = str(triggered_by_name or "").strip() or actor_id or "HA User"
+    linked_user_id, linked_profile = _linked_registry_user_for_ha_actor(
+        root,
+        ha_user_id=actor_id,
+        ha_user_name=actor_name,
+    )
+
+    now = dt_util.now().replace(microsecond=0)
+    timestamp = now.isoformat()
+    device_name = _best_name(coord, bucket)
+    title = f"Opened with Home Assistant by {actor_name}"
+    event: Dict[str, Any] = {
+        "_source": "home_assistant",
+        "_category": "access",
+        "_device": device_name,
+        "_device_id": target_entry,
+        "_key": f"home-assistant-open:{target_entry}:{actor_id or actor_name}:{now.timestamp()}",
+        "entry_id": target_entry,
+        "timestamp": timestamp,
+        "DateTime": timestamp,
+        "Device": device_name,
+        "DeviceName": device_name,
+        "Event": title,
+        "Description": title,
+        "Type": "Home Assistant",
+        "AccessMethod": "Home Assistant",
+        "AccessType": "Home Assistant",
+        "Result": "Access Granted",
+        "AccessResult": "Access Granted",
+        "Status": "Access Granted",
+        "Relay": str(relay_digit),
+        "HomeAssistantUserID": actor_id,
+        "HomeAssistantUserName": actor_name,
+        "UserName": actor_name,
+        "Name": actor_name,
+    }
+    if linked_user_id:
+        event["UserID"] = linked_user_id
+        event["LinkedUserID"] = linked_user_id
+        if isinstance(linked_profile, dict):
+            linked_name = str(linked_profile.get("name") or "").strip()
+            if linked_name:
+                event["LinkedUserName"] = linked_name
+
+    _ingest_history_event(hass, event)
+    try:
+        await coord.async_handle_manual_event(dict(event))
+    except Exception as err:
+        _LOGGER.debug("Open-gate manual event handling failed: %s", err)
+
+    return {
+        "ok": True,
+        "entry_id": target_entry,
+        "relay": relay_digit,
+        "triggered_by": actor_name,
+        "ha_user_id": actor_id,
+        "linked_user_id": linked_user_id,
+        "event": event,
+        "device_response": result,
+    }
+
+
 def _flag_rebooting(coord, *, triggered_by: str, duration: float = 300.0) -> None:
     """Mirror the reboot status tracking used by the service helper."""
 
@@ -3282,6 +3532,7 @@ class AkuvoxUIView(HomeAssistantView):
             "access_events": [],
             "access_event_limit": DEFAULT_ACCESS_HISTORY_LIMIT,
             "registry_users": [],
+            "home_assistant_users": [],
             "schedules": {},
             "schedule_ids": {},
             "groups": [],
@@ -3423,6 +3674,7 @@ class AkuvoxUIView(HomeAssistantView):
 
             registry_users: List[Dict[str, Any]] = []
             all_users: Dict[str, Any] = {}
+            response["home_assistant_users"] = await _home_assistant_users_payload(hass)
             if us:
                 try:
                     all_users = us.all() or {}
@@ -3475,6 +3727,12 @@ class AkuvoxUIView(HomeAssistantView):
                             "remote_enrol_pending": bool(
                                 prof.get("remote_enrol_pending")
                             ),
+                            "ha_user_id": prof.get("ha_user_id")
+                            or prof.get("home_assistant_user_id")
+                            or "",
+                            "ha_user_name": prof.get("ha_user_name")
+                            or prof.get("home_assistant_user_name")
+                            or "",
                             "license_plate": _extract_license_plates(prof),
                             "exit_permission": _normalize_exit_permission_http(
                                 prof.get("exit_permission")
@@ -3731,6 +3989,23 @@ class AkuvoxUIAction(AkuvoxUIView):
                 return web.json_response({"ok": True})
             except Exception as service_err:
                 _LOGGER.debug("Refresh-events service call failed via UI: %s", service_err)
+                return err(service_err)
+
+        if action == "open_gate":
+            try:
+                actor_id, actor_name = _request_actor_identity(hass, request, ctx)
+                result = await async_open_gate(
+                    hass,
+                    root,
+                    entry_id=entry_id,
+                    relay_number=payload.get("relay") or payload.get("relay_number") or payload.get("num"),
+                    delay=payload.get("delay"),
+                    triggered_by_id=actor_id,
+                    triggered_by_name=actor_name,
+                )
+                return web.json_response(result)
+            except Exception as service_err:
+                _LOGGER.debug("Open-gate action failed via UI: %s", service_err)
                 return err(service_err)
 
         if action == "hacs_update_check":

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -76,6 +76,7 @@ from .reboot_schedule import normalize_reboot_schedule, reboot_schedule_is_due
 from .coordinator import AkuvoxCoordinator
 from .access_history import AccessHistory
 from .http import (
+    async_open_gate,
     face_base_url,
     face_filename_from_reference,
     face_storage_dir,
@@ -730,6 +731,28 @@ def _context_user_name(hass: HomeAssistant, context) -> str:
         return default
 
     return default
+
+
+def _context_user_identity(hass: HomeAssistant, context) -> Tuple[str, str]:
+    """Best-effort Home Assistant user id/name for a service call context."""
+
+    default = "HA User"
+    if context is None:
+        return "", default
+
+    user_id = str(getattr(context, "user_id", "") or "").strip()
+    if not user_id:
+        return "", default
+
+    try:
+        user = hass.auth.async_get_user(user_id)
+        if user:
+            name = str(getattr(user, "name", "") or getattr(user, "username", "") or "").strip()
+            return user_id, name or str(getattr(user, "id", "") or user_id).strip() or default
+    except Exception:
+        pass
+
+    return user_id, user_id or default
 
 
 def _key_of_user(u: Dict[str, Any]) -> str:
@@ -2950,6 +2973,8 @@ class AkuvoxUsersStore(Store):
         paused: Optional[bool] = None,
         paused_schedule_id: Optional[str] = None,
         paused_schedule_name: Optional[str] = None,
+        ha_user_id: Optional[str] = None,
+        ha_user_name: Optional[str] = None,
     ):
         canonical = normalize_user_id(key) or str(key)
         u = self.data["users"].setdefault(canonical, {})
@@ -3106,6 +3131,19 @@ class AkuvoxUsersStore(Store):
                 u["paused_schedule_name"] = cleaned
             else:
                 u.pop("paused_schedule_name", None)
+        if ha_user_id is not None:
+            cleaned = str(ha_user_id or "").strip()
+            if cleaned:
+                u["ha_user_id"] = cleaned
+            else:
+                u.pop("ha_user_id", None)
+                u.pop("ha_user_name", None)
+        if ha_user_name is not None:
+            cleaned = str(ha_user_name or "").strip()
+            if cleaned:
+                u["ha_user_name"] = cleaned
+            else:
+                u.pop("ha_user_name", None)
         await self.async_save()
 
     async def delete(self, key: str):
@@ -7466,9 +7504,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except Exception:
             return
 
+    def _home_assistant_link_from_service(data: Mapping[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+        id_keys = ("ha_user_id", "home_assistant_user_id", "HomeAssistantUserID")
+        name_keys = ("ha_user_name", "home_assistant_user_name", "HomeAssistantUserName")
+
+        ha_user_id: Optional[str] = None
+        for key in id_keys:
+            if key in data:
+                ha_user_id = str(data.get(key) or "").strip()
+                break
+
+        ha_user_name: Optional[str] = None
+        for key in name_keys:
+            if key in data:
+                ha_user_name = str(data.get(key) or "").strip()
+                break
+
+        return ha_user_id, ha_user_name
+
     async def svc_add_user(call):
         d = call.data
         name: str = d["name"].strip()
+        ha_user_id, ha_user_name = _home_assistant_link_from_service(d)
 
         users_store: AkuvoxUsersStore = hass.data[DOMAIN]["users_store"]
         temp_id = users_store.next_free_temp_id()
@@ -7562,6 +7619,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             access_end=d.get("access_end") if "access_end" in d else None,
             source="Local",
             exit_permission=d.get("exit_permission"),
+            ha_user_id=ha_user_id,
+            ha_user_name=ha_user_name,
         )
 
         if "notify_on_access" in d or "notify_targets" in d:
@@ -7635,6 +7694,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def svc_edit_user(call):
         d = call.data
+        ha_user_id, ha_user_name = _home_assistant_link_from_service(d)
         raw_key = d.get("id")
         canonical_key = normalize_user_id(raw_key)
         key = canonical_key or str(raw_key)
@@ -7726,6 +7786,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             paused=paused_flag,
             paused_schedule_id=paused_schedule_id,
             paused_schedule_name=paused_schedule_name,
+            ha_user_id=ha_user_id,
+            ha_user_name=ha_user_name,
         )
 
         if "notify_on_access" in d or "notify_targets" in d:
@@ -7958,6 +8020,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             except Exception:
                 pass
 
+    async def svc_open_gate(call):
+        data = call.data if isinstance(call.data, Mapping) else {}
+        actor_id, actor_name = _context_user_identity(hass, getattr(call, "context", None))
+        await async_open_gate(
+            hass,
+            hass.data.get(DOMAIN, {}),
+            entry_id=data.get("entry_id"),
+            relay_number=data.get("relay") or data.get("relay_number") or data.get("num"),
+            delay=data.get("delay"),
+            triggered_by_id=actor_id,
+            triggered_by_name=actor_name,
+        )
+
     async def svc_refresh_events(call):
         entry_id = call.data.get("entry_id")
         root = hass.data[DOMAIN]
@@ -8120,6 +8195,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.services.async_register(DOMAIN, "delete_user", svc_delete_user)
     hass.services.async_register(DOMAIN, "upload_face", svc_upload_face)
     hass.services.async_register(DOMAIN, "reboot_device", svc_reboot_device)
+    hass.services.async_register(DOMAIN, "open_gate", svc_open_gate)
     hass.services.async_register(DOMAIN, "refresh_events", svc_refresh_events)
     hass.services.async_register(DOMAIN, "force_full_sync", svc_force_full_sync)
     hass.services.async_register(DOMAIN, "sync_now", svc_sync_now)

--- a/custom_components/akuvox_ac/services.yaml
+++ b/custom_components/akuvox_ac/services.yaml
@@ -36,6 +36,16 @@ add_user:
       example: ["notify.mobile_app_phone"]
       selector:
         object:
+    ha_user_id:
+      name: Home Assistant user id
+      required: false
+      selector:
+        text:
+    ha_user_name:
+      name: Home Assistant user name
+      required: false
+      selector:
+        text:
     relays:
       required: false
       example: "3"
@@ -151,6 +161,16 @@ edit_user:
       example: ["notify.mobile_app_phone"]
       selector:
         object:
+    ha_user_id:
+      name: Home Assistant user id
+      required: false
+      selector:
+        text:
+    ha_user_name:
+      name: Home Assistant user name
+      required: false
+      selector:
+        text:
     face_image_path:
       required: false
       selector:
@@ -212,6 +232,35 @@ reboot_device:
       required: false
       selector:
         text:
+
+open_gate:
+  name: Open gate
+  description: Trigger the configured door relay and record a Home Assistant access event.
+  fields:
+    entry_id:
+      name: Device entry ID
+      description: Optional when only one Akuvox device is configured.
+      required: false
+      selector:
+        text:
+    relay:
+      name: Relay
+      description: Optional; defaults to the first relay configured as door/pedestrian access.
+      required: false
+      selector:
+        select:
+          options:
+            - "1"
+            - "2"
+    delay:
+      name: Delay
+      description: Relay activation time in seconds. Defaults to 20.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 300
+          mode: box
 
 sync_now:
   name: Sync now

--- a/custom_components/akuvox_ac/tests/test_coordinator_events.py
+++ b/custom_components/akuvox_ac/tests/test_coordinator_events.py
@@ -236,6 +236,29 @@ def test_resolve_event_user_id_uses_registry_name_when_device_users_are_missing(
     assert resolved == "HA004"
 
 
+def test_resolve_event_user_id_uses_linked_home_assistant_user_id():
+    storage = _StorageStub()
+    coord = _build_coordinator(_APIStub([]), storage)
+    coord.users = []
+    coord.hass.data = {
+        DOMAIN: {
+            "users_store": _UsersStoreStub(
+                {"HA009": {"name": "Daniel", "ha_user_id": "ha-user-1"}}
+            )
+        }
+    }
+
+    resolved = coord._resolve_event_user_id(
+        {
+            "UserName": "DJGLTD",
+            "HomeAssistantUserID": "ha-user-1",
+            "Event": "Opened with Home Assistant by DJGLTD",
+        }
+    )
+
+    assert resolved == "HA009"
+
+
 def test_derive_targets_from_raw_matches_normalized_specific_user_ids():
     targets = {
         "mobile_app_lees_iphone": {

--- a/custom_components/akuvox_ac/tests/test_open_gate.py
+++ b/custom_components/akuvox_ac/tests/test_open_gate.py
@@ -1,0 +1,119 @@
+import asyncio
+from types import SimpleNamespace
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac.access_history import AccessHistory
+from custom_components.akuvox_ac.const import DOMAIN
+from custom_components.akuvox_ac.http import async_open_gate
+
+
+class _ApiStub:
+    def __init__(self):
+        self.calls = []
+
+    async def trigger_relay(self, relay_number, *, delay=20, mode=0, level=0):
+        self.calls.append(
+            {
+                "relay": relay_number,
+                "delay": delay,
+                "mode": mode,
+                "level": level,
+            }
+        )
+        return {"retcode": 0}
+
+
+class _CoordinatorStub:
+    def __init__(self):
+        self.device_name = "Gate"
+        self.health = {
+            "device_type": "Intercom",
+            "device_model": "X912",
+            "ip": "10.30.0.73",
+            "online": True,
+        }
+        self.events = []
+        self.users = []
+        self.manual_events = []
+
+    async def async_handle_manual_event(self, event):
+        self.manual_events.append(dict(event))
+
+
+class _UsersStoreStub:
+    def __init__(self, users):
+        self._users = dict(users)
+
+    def all(self):
+        return dict(self._users)
+
+
+def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
+    api = _ApiStub()
+    coordinator = _CoordinatorStub()
+    root = {
+        "access_history": AccessHistory(),
+        "users_store": _UsersStoreStub(
+            {
+                "HA001": {
+                    "name": "Daniel",
+                    "ha_user_id": "ha-user-1",
+                }
+            }
+        ),
+        "entry-1": {
+            "api": api,
+            "coordinator": coordinator,
+            "options": {
+                "relay_roles": {
+                    "relay_a": "alarm",
+                    "relay_b": "door",
+                }
+            },
+        },
+    }
+    hass = SimpleNamespace(data={DOMAIN: root})
+
+    result = asyncio.run(
+        async_open_gate(
+            hass,
+            root,
+            entry_id="entry-1",
+            triggered_by_id="ha-user-1",
+            triggered_by_name="DJGLTD",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["relay"] == 2
+    assert result["linked_user_id"] == "HA001"
+    assert api.calls == [{"relay": 2, "delay": 20, "mode": 0, "level": 0}]
+
+    assert len(coordinator.manual_events) == 1
+    event = coordinator.manual_events[0]
+    assert event["UserID"] == "HA001"
+    assert event["HomeAssistantUserName"] == "DJGLTD"
+    assert event["Event"] == "Opened with Home Assistant by DJGLTD"
+
+    history = root["access_history"].snapshot(5)
+    assert len(history) == 1
+    assert history[0]["_category"] == "access"
+    assert history[0]["LinkedUserID"] == "HA001"
+
+
+def test_open_gate_requires_entry_id_when_multiple_devices_are_configured():
+    root = {
+        "entry-1": {"api": _ApiStub(), "coordinator": _CoordinatorStub(), "options": {}},
+        "entry-2": {"api": _ApiStub(), "coordinator": _CoordinatorStub(), "options": {}},
+    }
+    hass = SimpleNamespace(data={DOMAIN: root})
+
+    try:
+        asyncio.run(async_open_gate(hass, root, triggered_by_name="DJGLTD"))
+    except RuntimeError as err:
+        assert "entry_id is required" in str(err)
+    else:
+        raise AssertionError("Expected entry_id to be required")

--- a/custom_components/akuvox_ac/www/device_management-mob.html
+++ b/custom_components/akuvox_ac/www/device_management-mob.html
@@ -652,6 +652,7 @@ function renderDevices(devices){
       </div>
       <div class="device-actions">
         <button class="btn btn-outline-light btn-sm" data-action="sync" data-id="${escapeHtml(entryId)}" ${!isOnline ? 'disabled' : ''}><i class="bi bi-arrow-repeat"></i> Sync now</button>
+        <button class="btn btn-outline-info btn-sm" data-action="open_gate" data-id="${escapeHtml(entryId)}" ${!isOnline ? 'disabled' : ''}><i class="bi bi-door-open"></i> Open gate</button>
         <button class="btn btn-outline-light btn-sm" data-manage="${escapeHtml(entryId)}"><i class="bi bi-gear"></i> Manage</button>
         <button class="btn btn-outline-danger btn-sm" data-action="reboot" data-id="${escapeHtml(entryId)}" ${!isOnline ? 'disabled' : ''}><i class="bi bi-power"></i> Reboot</button>
         <button class="btn btn-outline-danger btn-sm" data-action="remove" data-id="${escapeHtml(entryId)}" data-name="${escapeHtml(safeDeviceName(device))}"><i class="bi bi-trash"></i> Remove</button>
@@ -681,6 +682,8 @@ function renderDevices(devices){
       try {
         if (action === 'sync') {
           await apiPost(actionUrl, { action: 'sync_now', entry_id: entryId });
+        } else if (action === 'open_gate') {
+          await apiPost(actionUrl, { action: 'open_gate', entry_id: entryId });
         } else if (action === 'reboot') {
           await apiPost(actionUrl, { action: 'reboot_device', entry_id: entryId });
         } else if (action === 'remove') {
@@ -693,6 +696,8 @@ function renderDevices(devices){
           try {
             if (action === 'sync') {
               await callService('akuvox_ac', 'sync_now', { entry_id: entryId });
+            } else if (action === 'open_gate') {
+              await callService('akuvox_ac', 'open_gate', { entry_id: entryId });
             } else {
               await callService('akuvox_ac', 'reboot_device', { entry_id: entryId });
             }

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -671,6 +671,30 @@ function isCloudEvent(evt, typeLabel){
   return String(typeLabel || '').toLowerCase().includes('cloud');
 }
 
+function isHomeAssistantOpenEvent(evt, typeLabel){
+  if (!evt || typeof evt !== 'object') return false;
+  const text = [
+    evt._source,
+    evt.Source,
+    evt.source,
+    typeLabel,
+    evt.AccessMethod,
+    evt.AccessType,
+    evt.Event,
+    evt.Description,
+  ].map(value => String(value || '').toLowerCase()).join(' ');
+  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+}
+
+function getHomeAssistantOpenActor(evt){
+  const value = pickEventValue(evt, [
+    'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
+    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
+  ]);
+  const text = value === null || value === undefined ? '' : String(value).trim();
+  return text || 'HA User';
+}
+
 function getEventPinLabel(evt){
   if (!evt || typeof evt !== 'object') return '';
   const value = pickEventValue(evt, ['Pin','PIN','Passcode','Password','Credential','CardNo','CardNumber','digits']);
@@ -694,6 +718,9 @@ function getEventTitle(evt){
   const category = String(evt?._category || '').toLowerCase();
   const deviceName = resolveDeviceName(evt, evt?._device);
   const typeLabel = getEventTypeLabel(evt);
+  if (isHomeAssistantOpenEvent(evt, typeLabel)) {
+    return `${deviceName} - Opened with Home Assistant by ${getHomeAssistantOpenActor(evt)}`;
+  }
   if (category === 'call') {
     const caller = getEventUserLabel(evt);
     if (isCloudEvent(evt, typeLabel)) {

--- a/custom_components/akuvox_ac/www/event_history.html
+++ b/custom_components/akuvox_ac/www/event_history.html
@@ -585,6 +585,30 @@ function isCloudEvent(evt, typeLabel){
   return String(typeLabel || '').toLowerCase().includes('cloud');
 }
 
+function isHomeAssistantOpenEvent(evt, typeLabel){
+  if (!evt || typeof evt !== 'object') return false;
+  const text = [
+    evt._source,
+    evt.Source,
+    evt.source,
+    typeLabel,
+    evt.AccessMethod,
+    evt.AccessType,
+    evt.Event,
+    evt.Description,
+  ].map(value => String(value || '').toLowerCase()).join(' ');
+  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+}
+
+function getHomeAssistantOpenActor(evt){
+  const value = pickEventValue(evt, [
+    'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
+    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
+  ]);
+  const text = value === null || value === undefined ? '' : String(value).trim();
+  return text || 'HA User';
+}
+
 function getEventPinLabel(evt){
   if (!evt || typeof evt !== 'object') return '';
   const value = pickEventValue(evt, ['Pin','PIN','Passcode','Password','Credential','CardNo','CardNumber','digits']);
@@ -608,6 +632,9 @@ function getEventTitle(evt){
   const category = String(evt?._category || '').toLowerCase();
   const deviceName = resolveDeviceName(evt, evt?._device);
   const typeLabel = getEventTypeLabel(evt);
+  if (isHomeAssistantOpenEvent(evt, typeLabel)) {
+    return `${deviceName} - Opened with Home Assistant by ${getHomeAssistantOpenActor(evt)}`;
+  }
   if (category === 'call') {
     const caller = getEventUserLabel(evt);
     if (isCloudEvent(evt, typeLabel)) {

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1080,6 +1080,7 @@ function renderDevices(devs){
     const name   = safeDeviceName(d);
 
     const syncBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-primary" data-act="sync_now" data-id="${id}">Sync</button>`   : '';
+    const openBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-info" data-act="open_gate" data-id="${id}">Open Gate</button>` : '';
     const rebootBtn = (isOnline && id) ? `<button class="btn btn-sm btn-danger"  data-act="reboot"   data-id="${id}">Reboot</button>` : '';
     const editHref  = id ? buildHref('device-edit', { id }) : '';
     const editBtn   = (isOnline && id) ? `<a class="btn btn-sm btn-secondary" data-edit-device="${id}" href="${editHref}"><i class="bi bi-gear"></i> Edit</a>` : '';
@@ -1092,12 +1093,13 @@ function renderDevices(devs){
       <td>${syncBadge}</td>
       <td>${escapeHtml(lastChecked)}</td>
       <td>${syncBtn}</td>
+      <td>${openBtn}</td>
       <td>${editBtn}</td>
       <td>${rebootBtn}</td>
     </tr>`;
   }).join('');
 
-  $('#tblDevices').innerHTML = rows || '<tr><td colspan="9" class="text-muted">No devices</td></tr>';
+  $('#tblDevices').innerHTML = rows || '<tr><td colspan="10" class="text-muted">No devices</td></tr>';
 
   // per-device actions with UI endpoint first, HA service fallback
   $('#tblDevices').querySelectorAll('button[data-act]').forEach(b => {
@@ -1105,13 +1107,17 @@ function renderDevices(devs){
       const id = b.dataset.id;
       const act = b.dataset.act;
       try {
-        const action = act === 'sync_now' ? 'sync_now' : 'reboot_device';
+        const action = act === 'sync_now'
+          ? 'sync_now'
+          : (act === 'open_gate' ? 'open_gate' : 'reboot_device');
         await apiPost(actionUrl, { action, entry_id: id });
       } catch (e) {
         // fall back to services
         try {
           if (act === 'sync_now') {
             await callService('akuvox_ac','sync_now', { entry_id: id });
+          } else if (act === 'open_gate') {
+            await callService('akuvox_ac','open_gate', { entry_id: id });
           } else {
             await callService('akuvox_ac','reboot_device', { entry_id: id });
           }
@@ -1212,6 +1218,7 @@ const EVENT_DEVICE_KEYS = [
   '_device','device_name','device','Device','DoorName','Door','AccessPoint','Reader',
 ];
 const EVENT_CALL_USER_KEYS = [
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
   'User','UserName','user_name','user','userName','Name','NameID','UserID','user_id',
   'CallNumber','CallNum','CallNo','number','digits',
 ];
@@ -1222,7 +1229,7 @@ const EVENT_USER_ID_KEYS = [
   'UserID','user_id','UserId','userid','ID','id',
 ];
 const EVENT_USER_NAME_KEYS = [
-  'UserName','user_name','userName','Name','name','User','user',
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name','UserName','user_name','userName','Name','name','User','user',
 ];
 const EVENT_DETAIL_KEYS = {
   call: [
@@ -1283,6 +1290,28 @@ function pickFirstEventText(event, keys){
   return '';
 }
 
+function isHomeAssistantOpenEvent(event, typeLabel){
+  if (!event || typeof event !== 'object') return false;
+  const text = [
+    event._source,
+    event.Source,
+    event.source,
+    typeLabel,
+    event.AccessMethod,
+    event.AccessType,
+    event.Event,
+    event.Description,
+  ].map(value => String(value || '').toLowerCase()).join(' ');
+  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+}
+
+function homeAssistantOpenActor(event){
+  return pickFirstEventText(event, [
+    'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
+    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
+  ]) || 'HA User';
+}
+
 function userSummaryForEvent(event){
   const userId = pickFirstEventText(event, EVENT_USER_ID_KEYS);
   const userNameRaw = pickFirstEventText(event, EVENT_USER_NAME_KEYS);
@@ -1306,6 +1335,14 @@ function describeEventForDisplay(event){
   const device = pickFirstEventText(event, EVENT_DEVICE_KEYS);
   const deviceLabel = device || label;
   const typeLabel = getEventTypeLabel(event);
+  if (isHomeAssistantOpenEvent(event, typeLabel)) {
+    const actor = homeAssistantOpenActor(event);
+    return {
+      category: 'access',
+      title: `${deviceLabel} - Opened with Home Assistant by ${actor}`,
+      highlight: 'Access Granted',
+    };
+  }
   if (normalizedCategory === 'call') {
     const caller = pickFirstEventText(event, EVENT_CALL_USER_KEYS) || 'Unknown';
     const fallbackMessage = pickFirstEventText(event, EVENT_DETAIL_KEYS.default) || 'call';
@@ -2751,10 +2788,10 @@ function startNextSyncCountdown(iso, fallbackTime){
             <thead>
               <tr>
                 <th>Name</th><th>Type</th><th>IP</th><th>Status</th><th>Sync</th><th>Last Checked</th>
-                <th>Sync</th><th>Edit</th><th>Reboot</th>
+                <th>Sync</th><th>Open</th><th>Edit</th><th>Reboot</th>
               </tr>
             </thead>
-            <tbody id="tblDevices"><tr><td colspan="9" class="text-muted">Loading…</td></tr></tbody>
+            <tbody id="tblDevices"><tr><td colspan="10" class="text-muted">Loading…</td></tr></tbody>
           </table>
         </div>
       </div>

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1377,6 +1377,7 @@ function renderDevices(devs){
     const ip     = escapeHtml(d.ip || '—');
 
     const syncBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-primary" data-act="sync_now" data-id="${escapeHtml(id)}"><i class="bi bi-arrow-repeat"></i> Sync</button>`   : '';
+    const openBtn   = (isOnline && id) ? `<button class="btn btn-sm btn-outline-info" data-act="open_gate" data-id="${escapeHtml(id)}"><i class="bi bi-door-open"></i> Open Gate</button>` : '';
     const rebootBtn = (isOnline && id) ? `<button class="btn btn-sm btn-outline-danger" data-act="reboot" data-id="${escapeHtml(id)}"><i class="bi bi-power"></i> Reboot</button>` : '';
     const editHref  = id ? buildHref('device-edit', { id }) : '';
     const editBtn   = id ? `<a class="btn btn-sm btn-outline-light" data-edit-device="${escapeHtml(id)}" href="${escapeHtml(editHref)}"><i class="bi bi-pencil-square"></i> Edit</a>` : '';
@@ -1396,7 +1397,7 @@ function renderDevices(devs){
           ${syncBadge}
           <span class="device-last-sync">Last Checked: ${escapeHtml(lastChecked)}</span>
         </div>
-        <div class="device-actions">${syncBtn}${editBtn}${rebootBtn}</div>
+        <div class="device-actions">${syncBtn}${openBtn}${editBtn}${rebootBtn}</div>
       </div>
     </article>`;
   }).join('');
@@ -1409,13 +1410,17 @@ function renderDevices(devs){
       const id = b.dataset.id;
       const act = b.dataset.act;
       try {
-        const action = act === 'sync_now' ? 'sync_now' : 'reboot_device';
+        const action = act === 'sync_now'
+          ? 'sync_now'
+          : (act === 'open_gate' ? 'open_gate' : 'reboot_device');
         await apiPost(actionUrl, { action, entry_id: id });
       } catch (e) {
         // fall back to services
         try {
           if (act === 'sync_now') {
             await callService('akuvox_ac','sync_now', { entry_id: id });
+          } else if (act === 'open_gate') {
+            await callService('akuvox_ac','open_gate', { entry_id: id });
           } else {
             await callService('akuvox_ac','reboot_device', { entry_id: id });
           }
@@ -1516,6 +1521,7 @@ const EVENT_DEVICE_KEYS = [
   '_device','device_name','device','Device','DoorName','Door','AccessPoint','Reader',
 ];
 const EVENT_CALL_USER_KEYS = [
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
   'User','UserName','user_name','user','userName','Name','NameID','UserID','user_id',
   'CallNumber','CallNum','CallNo','number','digits',
 ];
@@ -1526,7 +1532,7 @@ const EVENT_USER_ID_KEYS = [
   'UserID','user_id','UserId','userid','ID','id',
 ];
 const EVENT_USER_NAME_KEYS = [
-  'UserName','user_name','userName','Name','name','User','user',
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name','UserName','user_name','userName','Name','name','User','user',
 ];
 const EVENT_DETAIL_KEYS = {
   call: [
@@ -1600,6 +1606,28 @@ function pickFirstEventText(event, keys){
   return '';
 }
 
+function isHomeAssistantOpenEvent(event, typeLabel){
+  if (!event || typeof event !== 'object') return false;
+  const text = [
+    event._source,
+    event.Source,
+    event.source,
+    typeLabel,
+    event.AccessMethod,
+    event.AccessType,
+    event.Event,
+    event.Description,
+  ].map(value => String(value || '').toLowerCase()).join(' ');
+  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+}
+
+function homeAssistantOpenActor(event){
+  return pickFirstEventText(event, [
+    'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
+    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
+  ]) || 'HA User';
+}
+
 function userSummaryForEvent(event){
   const userId = pickFirstEventText(event, EVENT_USER_ID_KEYS);
   const userNameRaw = pickFirstEventText(event, EVENT_USER_NAME_KEYS);
@@ -1623,6 +1651,14 @@ function describeEventForDisplay(event){
   const device = pickFirstEventText(event, EVENT_DEVICE_KEYS);
   const deviceLabel = device || label;
   const typeLabel = getEventTypeLabel(event);
+  if (isHomeAssistantOpenEvent(event, typeLabel)) {
+    const actor = homeAssistantOpenActor(event);
+    return {
+      category: 'access',
+      title: `${deviceLabel} - Opened with Home Assistant by ${actor}`,
+      highlight: 'Access Granted',
+    };
+  }
   if (normalizedCategory === 'call') {
     const caller = pickFirstEventText(event, EVENT_CALL_USER_KEYS) || 'Unknown';
     const fallbackMessage = pickFirstEventText(event, EVENT_DETAIL_KEYS.default) || 'call';

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -847,6 +847,7 @@ let scheduleRefreshPromise = null;
 let scheduleRefreshTimer = null;
 let PHONES = [];        // [{service, name}, ...] from /api/akuvox_ac/ui/phones
 let REGISTRY = [];      // UI list of known users from /ui/state
+let HA_USERS = [];      // Home Assistant users available for access-event linking
 let DEVICES = [];       // [{entry_id, name, users}, ...] from /ui/state
 let CURRENT = null;     // working user object
 let RESERVED_ID = null; // HA### id reserved for new-user workflow
@@ -1469,6 +1470,8 @@ function blankProfile(id = ''){
     access_end: '',
     access_expired: false,
     access_in_future: false,
+    ha_user_id: '',
+    ha_user_name: '',
     notify_targets: [],
   };
 }
@@ -1851,6 +1854,7 @@ async function load(){
     applySchedulesUpdate(state?.schedules || {}, state?.schedule_ids || {});
     syncPausedUsersFromState(state?.registry_users || []);
     REGISTRY = state.registry_users || [];
+    HA_USERS = Array.isArray(state.home_assistant_users) ? state.home_assistant_users : [];
     DEVICES = state.devices || [];
 
     // Load phones (notify services from HA mobile app)
@@ -1932,10 +1936,46 @@ function scheduleOptionsHtml(){
   return SCHED_MAP.map(it => `<option value="${it.id}">${optionLabel(it)}</option>`).join('');
 }
 
+function homeAssistantUserOptionsHtml(){
+  const options = ['<option value="">Not linked</option>'];
+  (HA_USERS || []).forEach(user => {
+    if (!user || !user.id) return;
+    const name = user.name || user.id;
+    const suffix = user.is_active === false ? ' (inactive)' : '';
+    options.push(`<option value="${escapeHtml(user.id)}" data-name="${escapeHtml(name)}">${escapeHtml(name + suffix)}</option>`);
+  });
+  return options.join('');
+}
+
+function applyHomeAssistantUserSelect(){
+  const select = document.getElementById('ha_user_id');
+  if (!select || !CURRENT) return;
+  select.innerHTML = homeAssistantUserOptionsHtml();
+  const selected = String(CURRENT.ha_user_id || CURRENT.home_assistant_user_id || '').trim();
+  if (selected && !Array.from(select.options).some(opt => opt.value === selected)){
+    const option = document.createElement('option');
+    option.value = selected;
+    option.dataset.name = CURRENT.ha_user_name || CURRENT.home_assistant_user_name || selected;
+    option.textContent = `${option.dataset.name} (saved link)`;
+    select.appendChild(option);
+  }
+  select.value = selected;
+  if (!select._bound){
+    select.addEventListener('change', () => {
+      if (!CURRENT) return;
+      const option = select.options[select.selectedIndex];
+      CURRENT.ha_user_id = select.value || '';
+      CURRENT.ha_user_name = option ? (option.dataset.name || '') : '';
+    });
+    select._bound = true;
+  }
+}
+
 function fillForm(){
   document.getElementById('name').value = CURRENT.name || '';
   document.getElementById('pin').value = CURRENT.pin || '';
   document.getElementById('phone').value = CURRENT.phone || '';
+  applyHomeAssistantUserSelect();
   CURRENT.license_plate = Array.isArray(CURRENT.license_plate) ? [...CURRENT.license_plate] : [];
   renderLicensePlateInputs();
 
@@ -2325,6 +2365,15 @@ async function save(){
     payload.notify_on_access = notifySelection.enabled;
     payload.notify_targets = notifySelection.targets;
 
+    const haUserSelect = document.getElementById('ha_user_id');
+    if (haUserSelect){
+      const option = haUserSelect.options[haUserSelect.selectedIndex];
+      payload.ha_user_id = haUserSelect.value || '';
+      payload.ha_user_name = option ? (option.dataset.name || '') : '';
+      CURRENT.ha_user_id = payload.ha_user_id;
+      CURRENT.ha_user_name = payload.ha_user_name;
+    }
+
     // Save/update the profile against the reserved ID
     const saveRes = await fetchWithAuth(API_EDIT_USER, {
       method:'POST',
@@ -2488,6 +2537,12 @@ function showPanel(which){
     <div id="faceErrorRow" class="form-text muted mt-2">Face sync errors: <span id="faceErrorCount">0</span></div>
 
     <div class="mb-3" id="phoneRow"><label class="form-label">Phone number</label><input id="phone" class="form-control"/></div>
+
+    <div class="mb-3" id="haUserLinkRow">
+      <label class="form-label">Home Assistant user link</label>
+      <select id="ha_user_id" class="form-select"></select>
+      <div class="form-text muted">Links Home Assistant gate opens to this access-control user for access notifications.</div>
+    </div>
 
     <div class="mb-3" id="anprSection">
       <label class="form-label">License Plates (ANPR)</label>

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -849,6 +849,7 @@ let scheduleRefreshPromise = null;
 let scheduleRefreshTimer = null;
 let PHONES = [];        // [{service, name}, ...] from /api/akuvox_ac/ui/phones
 let REGISTRY = [];      // UI list of known users from /ui/state
+let HA_USERS = [];      // Home Assistant users available for access-event linking
 let DEVICES = [];       // [{entry_id, name, users}, ...] from /ui/state
 let CURRENT = null;     // working user object
 let RESERVED_ID = null; // HA### id reserved for new-user workflow
@@ -1471,6 +1472,8 @@ function blankProfile(id = ''){
     access_end: '',
     access_expired: false,
     access_in_future: false,
+    ha_user_id: '',
+    ha_user_name: '',
     notify_targets: [],
   };
 }
@@ -1853,6 +1856,7 @@ async function load(){
     applySchedulesUpdate(state?.schedules || {}, state?.schedule_ids || {});
     syncPausedUsersFromState(state?.registry_users || []);
     REGISTRY = state.registry_users || [];
+    HA_USERS = Array.isArray(state.home_assistant_users) ? state.home_assistant_users : [];
     DEVICES = state.devices || [];
 
     // Load phones (notify services from HA mobile app)
@@ -1934,10 +1938,46 @@ function scheduleOptionsHtml(){
   return SCHED_MAP.map(it => `<option value="${it.id}">${optionLabel(it)}</option>`).join('');
 }
 
+function homeAssistantUserOptionsHtml(){
+  const options = ['<option value="">Not linked</option>'];
+  (HA_USERS || []).forEach(user => {
+    if (!user || !user.id) return;
+    const name = user.name || user.id;
+    const suffix = user.is_active === false ? ' (inactive)' : '';
+    options.push(`<option value="${escapeHtml(user.id)}" data-name="${escapeHtml(name)}">${escapeHtml(name + suffix)}</option>`);
+  });
+  return options.join('');
+}
+
+function applyHomeAssistantUserSelect(){
+  const select = document.getElementById('ha_user_id');
+  if (!select || !CURRENT) return;
+  select.innerHTML = homeAssistantUserOptionsHtml();
+  const selected = String(CURRENT.ha_user_id || CURRENT.home_assistant_user_id || '').trim();
+  if (selected && !Array.from(select.options).some(opt => opt.value === selected)){
+    const option = document.createElement('option');
+    option.value = selected;
+    option.dataset.name = CURRENT.ha_user_name || CURRENT.home_assistant_user_name || selected;
+    option.textContent = `${option.dataset.name} (saved link)`;
+    select.appendChild(option);
+  }
+  select.value = selected;
+  if (!select._bound){
+    select.addEventListener('change', () => {
+      if (!CURRENT) return;
+      const option = select.options[select.selectedIndex];
+      CURRENT.ha_user_id = select.value || '';
+      CURRENT.ha_user_name = option ? (option.dataset.name || '') : '';
+    });
+    select._bound = true;
+  }
+}
+
 function fillForm(){
   document.getElementById('name').value = CURRENT.name || '';
   document.getElementById('pin').value = CURRENT.pin || '';
   document.getElementById('phone').value = CURRENT.phone || '';
+  applyHomeAssistantUserSelect();
   CURRENT.license_plate = Array.isArray(CURRENT.license_plate) ? [...CURRENT.license_plate] : [];
   renderLicensePlateInputs();
 
@@ -2327,6 +2367,15 @@ async function save(){
     payload.notify_on_access = notifySelection.enabled;
     payload.notify_targets = notifySelection.targets;
 
+    const haUserSelect = document.getElementById('ha_user_id');
+    if (haUserSelect){
+      const option = haUserSelect.options[haUserSelect.selectedIndex];
+      payload.ha_user_id = haUserSelect.value || '';
+      payload.ha_user_name = option ? (option.dataset.name || '') : '';
+      CURRENT.ha_user_id = payload.ha_user_id;
+      CURRENT.ha_user_name = payload.ha_user_name;
+    }
+
     // Save/update the profile against the reserved ID
     const saveRes = await fetchWithAuth(API_EDIT_USER, {
       method:'POST',
@@ -2490,6 +2539,12 @@ function showPanel(which){
     <div id="faceErrorRow" class="form-text muted mt-2">Face sync errors: <span id="faceErrorCount">0</span></div>
 
     <div class="mb-3" id="phoneRow"><label class="form-label">Phone number</label><input id="phone" class="form-control"/></div>
+
+    <div class="mb-3" id="haUserLinkRow">
+      <label class="form-label">Home Assistant user link</label>
+      <select id="ha_user_id" class="form-select"></select>
+      <div class="form-text muted">Links Home Assistant gate opens to this access-control user for access notifications.</div>
+    </div>
 
     <div class="mb-3" id="anprSection">
       <label class="form-label">License Plates (ANPR)</label>


### PR DESCRIPTION
## Summary
- Add an authenticated `akuvox_ac.open_gate` service that triggers the configured Akuvox door relay directly from the saved device credentials.
- Add dashboard/device buttons that use the same backend path and publish `Gate - Opened with Home Assistant by <user>` access events.
- Add Home Assistant user linking on user profiles so HA-triggered opens resolve to local users for existing access notifications.

## Validation
- Python compile check passed for edited backend modules.
- Inline backend assertions passed for relay selection, linked-user event publication, and HA user resolution.
- Inline script syntax checks passed for edited dashboard HTML files.

Note: full pytest could not be run locally because the available Python runtime does not include pytest.