### PR TITLE
Remove duplicate System Alerts update button

### DIFF
--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -3326,10 +3326,7 @@ function startNextSyncCountdown(iso, fallbackTime){
       </article>
 
       <article class="card" id="sectionAlerts">
-        <div class="card-header d-flex align-items-center justify-content-between">
-          <span>System Alerts</span>
-          <button id="btnHacsAutoUpdate" data-hacs-update class="btn btn-sm btn-outline-light" title="Check for updates"><i class="bi bi-cloud-arrow-down"></i></button>
-        </div>
+        <div class="card-header">System Alerts</div>
         <div class="card-body">
           <div id="systemAlerts" class="system-alerts">
             <div class="p-4 text-muted">Loading…</div>


### PR DESCRIPTION
## Summary
- Remove the duplicate update button from the desktop System Alerts header.
- Keep the top dashboard action bar as the single system update control.

## Validation
- Confirmed desktop dashboard now has one `data-hacs-update` button, in the top action bar.
- Parsed the desktop dashboard inline script with Node.
- Ran `git diff --check`.