### PR TITLE
Allow open gate by device name

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -2668,11 +2668,79 @@ def _linked_registry_user_for_ha_actor(
     return None, None
 
 
+def _device_lookup_key(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip()).casefold()
+
+
+def _device_bucket_matches_lookup(
+    entry_id: str,
+    bucket: Dict[str, Any],
+    coord: Any,
+    lookup: str,
+) -> bool:
+    if not lookup:
+        return False
+
+    health = getattr(coord, "health", {}) or {}
+    opts = bucket.get("options") if isinstance(bucket.get("options"), dict) else {}
+    candidates = [
+        entry_id,
+        _best_name(coord, bucket),
+        getattr(coord, "device_name", ""),
+        health.get("name"),
+        health.get("device_name"),
+        health.get("ip"),
+        opts.get("device_name") if isinstance(opts, dict) else "",
+        opts.get("name") if isinstance(opts, dict) else "",
+    ]
+    return any(_device_lookup_key(candidate) == lookup for candidate in candidates)
+
+
+def _find_device_bucket(
+    root: Dict[str, Any],
+    *,
+    entry_id: Any = None,
+    device_name: Any = None,
+) -> Tuple[str, Dict[str, Any], Any, Dict[str, Any]]:
+    target_entry = str(entry_id or "").strip()
+    if target_entry:
+        bucket = root.get(target_entry)
+        if not isinstance(bucket, dict):
+            raise RuntimeError("device entry not found")
+        coord = bucket.get("coordinator")
+        opts = bucket.get("options") if isinstance(bucket.get("options"), dict) else {}
+        return target_entry, bucket, coord, opts
+
+    buckets = list(_iter_device_buckets(root))
+    if not buckets:
+        raise RuntimeError("no Akuvox devices are configured")
+
+    lookup = _device_lookup_key(device_name)
+    if lookup:
+        matches = [
+            item
+            for item in buckets
+            if _device_bucket_matches_lookup(item[0], item[1], item[2], lookup)
+        ]
+        if not matches:
+            raise RuntimeError("device_name did not match a configured Akuvox device")
+        if len(matches) > 1:
+            raise RuntimeError("device_name matched more than one Akuvox device")
+        return matches[0]
+
+    if len(buckets) > 1:
+        raise RuntimeError(
+            "entry_id or device_name is required when more than one device is configured"
+        )
+    return buckets[0]
+
+
 async def async_open_gate(
     hass: HomeAssistant,
     root: Dict[str, Any],
     *,
     entry_id: Any = None,
+    device_name: Any = None,
     relay_number: Any = None,
     delay: Any = None,
     triggered_by_id: str = "",
@@ -2683,21 +2751,11 @@ async def async_open_gate(
     if not isinstance(root, dict):
         raise RuntimeError("Akuvox integration is not ready")
 
-    target_entry = str(entry_id or "").strip()
-    if target_entry:
-        bucket = root.get(target_entry)
-        if not isinstance(bucket, dict):
-            raise RuntimeError("device entry not found")
-        coord = bucket.get("coordinator")
-        opts = bucket.get("options") if isinstance(bucket.get("options"), dict) else {}
-    else:
-        buckets = list(_iter_device_buckets(root))
-        if not buckets:
-            raise RuntimeError("no Akuvox devices are configured")
-        if len(buckets) > 1:
-            raise RuntimeError("entry_id is required when more than one device is configured")
-        target_entry, bucket, coord, opts = buckets[0]
-
+    target_entry, bucket, coord, opts = _find_device_bucket(
+        root,
+        entry_id=entry_id,
+        device_name=device_name,
+    )
     if not isinstance(bucket, dict):
         raise RuntimeError("device entry not found")
     api = bucket.get("api")

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -8027,6 +8027,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass,
             hass.data.get(DOMAIN, {}),
             entry_id=data.get("entry_id"),
+            device_name=data.get("device_name") or data.get("device") or data.get("name"),
             relay_number=data.get("relay") or data.get("relay_number") or data.get("num"),
             delay=data.get("delay"),
             triggered_by_id=actor_id,

--- a/custom_components/akuvox_ac/services.yaml
+++ b/custom_components/akuvox_ac/services.yaml
@@ -239,7 +239,13 @@ open_gate:
   fields:
     entry_id:
       name: Device entry ID
-      description: Optional when only one Akuvox device is configured.
+      description: Optional when only one Akuvox device is configured. You can use device name instead.
+      required: false
+      selector:
+        text:
+    device_name:
+      name: Device name
+      description: Optional friendly device name, for example Gate.
       required: false
       selector:
         text:

--- a/custom_components/akuvox_ac/tests/test_open_gate.py
+++ b/custom_components/akuvox_ac/tests/test_open_gate.py
@@ -114,6 +114,36 @@ def test_open_gate_requires_entry_id_when_multiple_devices_are_configured():
     try:
         asyncio.run(async_open_gate(hass, root, triggered_by_name="DJGLTD"))
     except RuntimeError as err:
-        assert "entry_id is required" in str(err)
+        assert "entry_id or device_name is required" in str(err)
     else:
         raise AssertionError("Expected entry_id to be required")
+
+
+def test_open_gate_can_select_device_by_friendly_name():
+    first_api = _ApiStub()
+    second_api = _ApiStub()
+    first_coord = _CoordinatorStub()
+    first_coord.device_name = "Gate"
+    second_coord = _CoordinatorStub()
+    second_coord.device_name = "Garage"
+    root = {
+        "entry-gate": {
+            "api": first_api,
+            "coordinator": first_coord,
+            "options": {"relay_roles": {"relay_a": "door", "relay_b": "alarm"}},
+        },
+        "entry-garage": {
+            "api": second_api,
+            "coordinator": second_coord,
+            "options": {"relay_roles": {"relay_a": "door", "relay_b": "alarm"}},
+        },
+    }
+    hass = SimpleNamespace(data={DOMAIN: root})
+
+    result = asyncio.run(
+        async_open_gate(hass, root, device_name="Gate", triggered_by_name="DJGLTD")
+    )
+
+    assert result["entry_id"] == "entry-gate"
+    assert first_api.calls == [{"relay": 1, "delay": 20, "mode": 0, "level": 0}]
+    assert second_api.calls == []


### PR DESCRIPTION
## Summary
- Allow `akuvox_ac.open_gate` to target devices by friendly `device_name` as well as config `entry_id`.
- Accept `device`, `name`, and device IP as matching aliases for the same lookup path.
- Update service metadata and tests for name-based targeting.

## Validation
- Python compile check passed for edited backend modules.
- Inline backend assertion passed for `device_name: Gate` selecting the correct device.
- Ran `git diff --check`.