### PR TITLE
[codex] Resolve Home Assistant gate open actor names

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import inspect
 import json
 import logging
 import json
@@ -2634,6 +2635,7 @@ def _linked_registry_user_for_ha_actor(
         return None, None
 
     wanted_id = str(ha_user_id or "").strip()
+    wanted_id_folded = wanted_id.casefold()
     wanted_name = str(ha_user_name or "").strip().casefold()
 
     def _values_match(profile: Dict[str, Any]) -> bool:
@@ -2646,7 +2648,9 @@ def _linked_registry_user_for_ha_actor(
             raw = profile.get(key)
             if isinstance(raw, (list, tuple, set)):
                 ids.extend(raw)
-        if wanted_id and any(str(value or "").strip() == wanted_id for value in ids):
+        if wanted_id and any(
+            str(value or "").strip().casefold() == wanted_id_folded for value in ids
+        ):
             return True
 
         if wanted_name:
@@ -2666,6 +2670,32 @@ def _linked_registry_user_for_ha_actor(
             return canonical, profile
 
     return None, None
+
+
+async def _async_resolve_ha_user_name(hass: HomeAssistant, user_id: str) -> str:
+    """Resolve a Home Assistant user id to a friendly name when possible."""
+
+    user_id = str(user_id or "").strip()
+    if not user_id:
+        return ""
+
+    try:
+        user = hass.auth.async_get_user(user_id)
+        if inspect.isawaitable(user):
+            user = await user
+    except Exception:
+        return ""
+
+    if not user:
+        return ""
+
+    for attr in ("name", "username", "email", "id"):
+        value = getattr(user, attr, None)
+        if value not in (None, ""):
+            text = str(value).strip()
+            if text:
+                return text
+    return ""
 
 
 def _device_lookup_key(value: Any) -> str:
@@ -2783,16 +2813,25 @@ async def async_open_gate(
 
     actor_id = str(triggered_by_id or "").strip()
     actor_name = str(triggered_by_name or "").strip() or actor_id or "HA User"
+    if actor_id and actor_name == actor_id:
+        resolved_actor_name = await _async_resolve_ha_user_name(hass, actor_id)
+        if resolved_actor_name:
+            actor_name = resolved_actor_name
+
     linked_user_id, linked_profile = _linked_registry_user_for_ha_actor(
         root,
         ha_user_id=actor_id,
         ha_user_name=actor_name,
     )
+    linked_name = ""
+    if isinstance(linked_profile, dict):
+        linked_name = str(linked_profile.get("name") or "").strip()
+    display_actor = linked_name or actor_name or actor_id or "HA User"
 
     now = dt_util.now().replace(microsecond=0)
     timestamp = now.isoformat()
     device_name = _best_name(coord, bucket)
-    title = f"Opened with Home Assistant by {actor_name}"
+    title = f"Opened with Home Assistant by {display_actor}"
     event: Dict[str, Any] = {
         "_source": "home_assistant",
         "_category": "access",
@@ -2815,16 +2854,16 @@ async def async_open_gate(
         "Relay": str(relay_digit),
         "HomeAssistantUserID": actor_id,
         "HomeAssistantUserName": actor_name,
-        "UserName": actor_name,
-        "Name": actor_name,
+        "TriggeredBy": display_actor,
+        "User": display_actor,
+        "UserName": display_actor,
+        "Name": display_actor,
     }
     if linked_user_id:
         event["UserID"] = linked_user_id
         event["LinkedUserID"] = linked_user_id
-        if isinstance(linked_profile, dict):
-            linked_name = str(linked_profile.get("name") or "").strip()
-            if linked_name:
-                event["LinkedUserName"] = linked_name
+        if linked_name:
+            event["LinkedUserName"] = linked_name
 
     _ingest_history_event(hass, event)
     try:
@@ -2836,8 +2875,9 @@ async def async_open_gate(
         "ok": True,
         "entry_id": target_entry,
         "relay": relay_digit,
-        "triggered_by": actor_name,
+        "triggered_by": display_actor,
         "ha_user_id": actor_id,
+        "ha_user_name": actor_name,
         "linked_user_id": linked_user_id,
         "event": event,
         "device_response": result,

--- a/custom_components/akuvox_ac/tests/test_open_gate.py
+++ b/custom_components/akuvox_ac/tests/test_open_gate.py
@@ -51,6 +51,11 @@ class _UsersStoreStub:
         return dict(self._users)
 
 
+class _AuthStub:
+    async def async_get_user(self, user_id):
+        return SimpleNamespace(id=user_id, name="DJGLTD")
+
+
 def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
     api = _ApiStub()
     coordinator = _CoordinatorStub()
@@ -96,12 +101,63 @@ def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
     event = coordinator.manual_events[0]
     assert event["UserID"] == "HA001"
     assert event["HomeAssistantUserName"] == "DJGLTD"
-    assert event["Event"] == "Opened with Home Assistant by DJGLTD"
+    assert event["TriggeredBy"] == "Daniel"
+    assert event["UserName"] == "Daniel"
+    assert event["Event"] == "Opened with Home Assistant by Daniel"
 
     history = root["access_history"].snapshot(5)
     assert len(history) == 1
     assert history[0]["_category"] == "access"
     assert history[0]["LinkedUserID"] == "HA001"
+    assert history[0]["LinkedUserName"] == "Daniel"
+
+
+def test_open_gate_resolves_raw_home_assistant_context_user_id():
+    api = _ApiStub()
+    coordinator = _CoordinatorStub()
+    raw_ha_user_id = "594d0cb232264d99a62056fae5a4b597"
+    root = {
+        "access_history": AccessHistory(),
+        "users_store": _UsersStoreStub(
+            {
+                "HA001": {
+                    "name": "Sam Smith",
+                    "ha_user_id": raw_ha_user_id,
+                }
+            }
+        ),
+        "entry-1": {
+            "api": api,
+            "coordinator": coordinator,
+            "options": {
+                "relay_roles": {
+                    "relay_a": "door",
+                    "relay_b": "alarm",
+                }
+            },
+        },
+    }
+    hass = SimpleNamespace(data={DOMAIN: root}, auth=_AuthStub())
+
+    result = asyncio.run(
+        async_open_gate(
+            hass,
+            root,
+            entry_id="entry-1",
+            triggered_by_id=raw_ha_user_id,
+            triggered_by_name=raw_ha_user_id,
+        )
+    )
+
+    event = result["event"]
+    assert result["triggered_by"] == "Sam Smith"
+    assert result["ha_user_name"] == "DJGLTD"
+    assert result["linked_user_id"] == "HA001"
+    assert event["HomeAssistantUserID"] == raw_ha_user_id
+    assert event["HomeAssistantUserName"] == "DJGLTD"
+    assert event["UserID"] == "HA001"
+    assert event["LinkedUserName"] == "Sam Smith"
+    assert event["Event"] == "Opened with Home Assistant by Sam Smith"
 
 
 def test_open_gate_requires_entry_id_when_multiple_devices_are_configured():

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -688,8 +688,9 @@ function isHomeAssistantOpenEvent(evt, typeLabel){
 
 function getHomeAssistantOpenActor(evt){
   const value = pickEventValue(evt, [
+    'LinkedUserName','linked_user_name','linkedUserName',
+    '_user_name','TriggeredBy','triggered_by','User','user','UserName','user_name','Name','name',
     'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
-    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
   ]);
   const text = value === null || value === undefined ? '' : String(value).trim();
   return text || 'HA User';
@@ -706,6 +707,7 @@ function getEventPinLabel(evt){
 function hasLinkedUser(evt){
   if (!evt || typeof evt !== 'object') return false;
   const userValue = pickEventValue(evt, [
+    'LinkedUserName','linked_user_name','linkedUserName','_user_name',
     'UserID','user_id','userId',
     'User','user',
     'UserName','user_name','userName',
@@ -745,7 +747,7 @@ function getEventTitle(evt){
 
 function getEventUserLabel(evt){
   if (!evt || typeof evt !== 'object') return 'Unknown';
-  const user = evt.User || evt.user || evt.UserName || evt.user_name || evt.userName || evt.Name || evt.NameID;
+  const user = evt.LinkedUserName || evt.linked_user_name || evt.linkedUserName || evt._user_name || evt.User || evt.user || evt.UserName || evt.user_name || evt.userName || evt.Name || evt.NameID;
   if (typeof user === 'string' && user.trim()) return user.trim();
   if (user) return String(user);
   const number = evt.CallNumber || evt.CallNum || evt.CallNo || evt.number || evt.digits;
@@ -922,18 +924,30 @@ function addUserLookupEntry(map, id, name){
 function buildUserLookup(devices, registryUsers){
   const lookup = new Map();
   (registryUsers || []).forEach(entry => {
+    const label = entry.name || entry.Name || entry.user_name || entry.UserName || '';
     addUserLookupEntry(
       lookup,
       entry.id || entry.UserID || entry.UserId || entry.ID || '',
-      entry.name || entry.Name || entry.user_name || entry.UserName || ''
+      label
+    );
+    addUserLookupEntry(
+      lookup,
+      entry.ha_user_id || entry.home_assistant_user_id || entry.HomeAssistantUserID || '',
+      label
     );
   });
   (devices || []).forEach(device => {
     (device?._users || device?.users || []).forEach(user => {
+      const label = user.Name || user.name || user.user_name || user.UserName || '';
       addUserLookupEntry(
         lookup,
         user.id || user.UserID || user.UserId || user.ID || user.user_id || user.userId || '',
-        user.Name || user.name || user.user_name || user.UserName || ''
+        label
+      );
+      addUserLookupEntry(
+        lookup,
+        user.ha_user_id || user.home_assistant_user_id || user.HomeAssistantUserID || '',
+        label
       );
     });
   });
@@ -992,13 +1006,20 @@ function eventIdentity(evt){
 
 function applyUserLookup(evt, userLookup){
   if (!evt || !userLookup || userLookup.size === 0) return;
-  const userId = pickEventValue(evt, ['UserID','user_id','userId','User','user','NameID']);
+  const userId = pickEventValue(evt, [
+    'LinkedUserID','linked_user_id','linkedUserId',
+    'UserID','user_id','userId','User','user','NameID',
+    'HomeAssistantUserID','home_assistant_user_id','ha_user_id'
+  ]);
   const key = normalizeUserMatch(userId);
   if (!key) return;
   const mapped = userLookup.get(key);
   if (!mapped) return;
   if (!evt.Name && !evt.UserName && !evt.user_name && !evt.name) {
     evt.Name = mapped;
+  }
+  if (!evt.LinkedUserName && !evt.linked_user_name) {
+    evt.LinkedUserName = mapped;
   }
   evt._user_name = mapped;
 }

--- a/custom_components/akuvox_ac/www/event_history.html
+++ b/custom_components/akuvox_ac/www/event_history.html
@@ -602,8 +602,9 @@ function isHomeAssistantOpenEvent(evt, typeLabel){
 
 function getHomeAssistantOpenActor(evt){
   const value = pickEventValue(evt, [
+    'LinkedUserName','linked_user_name','linkedUserName',
+    '_user_name','TriggeredBy','triggered_by','User','user','UserName','user_name','Name','name',
     'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
-    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
   ]);
   const text = value === null || value === undefined ? '' : String(value).trim();
   return text || 'HA User';
@@ -620,6 +621,7 @@ function getEventPinLabel(evt){
 function hasLinkedUser(evt){
   if (!evt || typeof evt !== 'object') return false;
   const userValue = pickEventValue(evt, [
+    'LinkedUserName','linked_user_name','linkedUserName','_user_name',
     'UserID','user_id','userId',
     'User','user',
     'UserName','user_name','userName',
@@ -659,7 +661,7 @@ function getEventTitle(evt){
 
 function getEventUserLabel(evt){
   if (!evt || typeof evt !== 'object') return 'Unknown';
-  const user = evt.User || evt.user || evt.UserName || evt.user_name || evt.userName || evt.Name || evt.NameID;
+  const user = evt.LinkedUserName || evt.linked_user_name || evt.linkedUserName || evt._user_name || evt.User || evt.user || evt.UserName || evt.user_name || evt.userName || evt.Name || evt.NameID;
   if (typeof user === 'string' && user.trim()) return user.trim();
   if (user) return String(user);
   const number = evt.CallNumber || evt.CallNum || evt.CallNo || evt.number || evt.digits;
@@ -836,18 +838,30 @@ function addUserLookupEntry(map, id, name){
 function buildUserLookup(devices, registryUsers){
   const lookup = new Map();
   (registryUsers || []).forEach(entry => {
+    const label = entry.name || entry.Name || entry.user_name || entry.UserName || '';
     addUserLookupEntry(
       lookup,
       entry.id || entry.UserID || entry.UserId || entry.ID || '',
-      entry.name || entry.Name || entry.user_name || entry.UserName || ''
+      label
+    );
+    addUserLookupEntry(
+      lookup,
+      entry.ha_user_id || entry.home_assistant_user_id || entry.HomeAssistantUserID || '',
+      label
     );
   });
   (devices || []).forEach(device => {
     (device?._users || device?.users || []).forEach(user => {
+      const label = user.Name || user.name || user.user_name || user.UserName || '';
       addUserLookupEntry(
         lookup,
         user.id || user.UserID || user.UserId || user.ID || user.user_id || user.userId || '',
-        user.Name || user.name || user.user_name || user.UserName || ''
+        label
+      );
+      addUserLookupEntry(
+        lookup,
+        user.ha_user_id || user.home_assistant_user_id || user.HomeAssistantUserID || '',
+        label
       );
     });
   });
@@ -906,13 +920,20 @@ function eventIdentity(evt){
 
 function applyUserLookup(evt, userLookup){
   if (!evt || !userLookup || userLookup.size === 0) return;
-  const userId = pickEventValue(evt, ['UserID','user_id','userId','User','user','NameID']);
+  const userId = pickEventValue(evt, [
+    'LinkedUserID','linked_user_id','linkedUserId',
+    'UserID','user_id','userId','User','user','NameID',
+    'HomeAssistantUserID','home_assistant_user_id','ha_user_id'
+  ]);
   const key = normalizeUserMatch(userId);
   if (!key) return;
   const mapped = userLookup.get(key);
   if (!mapped) return;
   if (!evt.Name && !evt.UserName && !evt.user_name && !evt.name) {
     evt.Name = mapped;
+  }
+  if (!evt.LinkedUserName && !evt.linked_user_name) {
+    evt.LinkedUserName = mapped;
   }
   evt._user_name = mapped;
 }

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1218,8 +1218,9 @@ const EVENT_DEVICE_KEYS = [
   '_device','device_name','device','Device','DoorName','Door','AccessPoint','Reader',
 ];
 const EVENT_CALL_USER_KEYS = [
-  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
+  'LinkedUserName','linked_user_name','linkedUserName','TriggeredBy','triggered_by',
   'User','UserName','user_name','user','userName','Name','NameID','UserID','user_id',
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
   'CallNumber','CallNum','CallNo','number','digits',
 ];
 const EVENT_PIN_KEYS = [
@@ -1229,7 +1230,9 @@ const EVENT_USER_ID_KEYS = [
   'UserID','user_id','UserId','userid','ID','id',
 ];
 const EVENT_USER_NAME_KEYS = [
-  'HomeAssistantUserName','home_assistant_user_name','ha_user_name','UserName','user_name','userName','Name','name','User','user',
+  'LinkedUserName','linked_user_name','linkedUserName','TriggeredBy','triggered_by',
+  'UserName','user_name','userName','Name','name','User','user',
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
 ];
 const EVENT_DETAIL_KEYS = {
   call: [
@@ -1307,8 +1310,9 @@ function isHomeAssistantOpenEvent(event, typeLabel){
 
 function homeAssistantOpenActor(event){
   return pickFirstEventText(event, [
+    'LinkedUserName','linked_user_name','linkedUserName',
+    'TriggeredBy','triggered_by','User','user','UserName','user_name','Name','name',
     'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
-    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
   ]) || 'HA User';
 }
 

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1521,8 +1521,9 @@ const EVENT_DEVICE_KEYS = [
   '_device','device_name','device','Device','DoorName','Door','AccessPoint','Reader',
 ];
 const EVENT_CALL_USER_KEYS = [
-  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
+  'LinkedUserName','linked_user_name','linkedUserName','TriggeredBy','triggered_by',
   'User','UserName','user_name','user','userName','Name','NameID','UserID','user_id',
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
   'CallNumber','CallNum','CallNo','number','digits',
 ];
 const EVENT_PIN_KEYS = [
@@ -1532,7 +1533,9 @@ const EVENT_USER_ID_KEYS = [
   'UserID','user_id','UserId','userid','ID','id',
 ];
 const EVENT_USER_NAME_KEYS = [
-  'HomeAssistantUserName','home_assistant_user_name','ha_user_name','UserName','user_name','userName','Name','name','User','user',
+  'LinkedUserName','linked_user_name','linkedUserName','TriggeredBy','triggered_by',
+  'UserName','user_name','userName','Name','name','User','user',
+  'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
 ];
 const EVENT_DETAIL_KEYS = {
   call: [
@@ -1623,8 +1626,9 @@ function isHomeAssistantOpenEvent(event, typeLabel){
 
 function homeAssistantOpenActor(event){
   return pickFirstEventText(event, [
+    'LinkedUserName','linked_user_name','linkedUserName',
+    'TriggeredBy','triggered_by','User','user','UserName','user_name','Name','name',
     'HomeAssistantUserName','home_assistant_user_name','ha_user_name',
-    'TriggeredBy','triggered_by','UserName','user_name','Name','name',
   ]) || 'HA User';
 }
 


### PR DESCRIPTION
## Summary
- Resolve raw Home Assistant service-call user ids to friendly names when possible.
- Prefer the linked Akuvox/access-control profile name when building Home Assistant gate-open event titles.
- Update desktop and mobile dashboard/event-history rendering to prefer linked user names and to map existing events via saved Home Assistant user ids.

## Validation
- `python -m py_compile custom_components/akuvox_ac/http.py custom_components/akuvox_ac/tests/test_open_gate.py`
- Direct execution of `test_open_gate.py` assertion functions after loading HA stubs
- Node `vm.Script` syntax check for `index.html`, `index-mob.html`, `event_history.html`, and `event_history-mob.html`
- `git diff --check`