### PR TITLE
[codex] Add linked user self-service profile access

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -778,6 +778,7 @@ def _create_dashboard_session(hass: HomeAssistant, user: Any) -> Dict[str, Any]:
         "user_id": _ha_user_id(user),
         "user_name": _ha_user_name(user),
         "is_admin": _ha_user_is_admin(user),
+        "dashboard_access": True,
     }
     _dashboard_sessions(hass)[token] = session
     return dict(session)
@@ -799,14 +800,18 @@ def _dashboard_allowed_user_ids(settings: Any) -> Set[str]:
 def _request_can_access_dashboard(hass: HomeAssistant, request: web.Request) -> bool:
     user = _request_hass_user(request)
     if not user:
-        return _request_dashboard_session(hass, request) is not None
+        session = _request_dashboard_session(hass, request)
+        return bool(session and session.get("dashboard_access") and session.get("is_admin"))
     if _ha_user_is_admin(user):
         return True
-    user_id = _ha_user_id(user)
-    if not user_id:
-        return False
-    root = hass.data.get(DOMAIN, {}) or {}
-    return user_id in _dashboard_allowed_user_ids(root.get("settings_store"))
+    return False
+
+
+def _request_is_admin(hass: HomeAssistant, request: web.Request) -> bool:
+    if _ha_user_is_admin(_request_hass_user(request)):
+        return True
+    session = _request_dashboard_session(hass, request)
+    return bool(session and session.get("is_admin"))
 
 
 def _request_can_manage_dashboard_access(
@@ -818,6 +823,45 @@ def _request_can_manage_dashboard_access(
         return False
     session = _request_dashboard_session(hass, request)
     return bool(session and session.get("is_admin"))
+
+
+def _request_self_service_context(
+    hass: HomeAssistant,
+    request: web.Request,
+) -> Optional[Dict[str, Any]]:
+    """Return the linked local profile for a non-dashboard HA user."""
+
+    root = hass.data.get(DOMAIN, {}) or {}
+    if not isinstance(root, dict):
+        return None
+
+    actor_id, actor_name = _request_actor_identity(hass, request, None)
+    if not actor_id:
+        return None
+
+    linked_id, profile = _linked_registry_user_for_ha_actor(
+        root,
+        ha_user_id=actor_id,
+        ha_user_name=actor_name,
+    )
+    linked_id = normalize_user_id(linked_id) or str(linked_id or "").strip()
+    if not linked_id or not isinstance(profile, dict):
+        return None
+    if _profile_is_empty_reserved(profile):
+        return None
+    if str(profile.get("status") or "").strip().lower() == "deleted":
+        return None
+
+    return {
+        "user_id": linked_id,
+        "profile": profile,
+        "ha_user_id": actor_id,
+        "ha_user_name": actor_name,
+    }
+
+
+def _request_can_access_self_service(hass: HomeAssistant, request: web.Request) -> bool:
+    return _request_self_service_context(hass, request) is not None
 
 
 async def _dashboard_access_payload(
@@ -2698,6 +2742,216 @@ async def _async_resolve_ha_user_name(hass: HomeAssistant, user_id: str) -> str:
     return ""
 
 
+def _sanitize_self_service_license_plates(raw: Any) -> List[str]:
+    values: Iterable[Any]
+    if raw is None:
+        values = []
+    elif isinstance(raw, str):
+        values = re.split(r"[,;\n]+", raw)
+    elif isinstance(raw, (list, tuple, set)):
+        values = raw
+    else:
+        values = [raw]
+
+    cleaned: List[str] = []
+    seen: Set[str] = set()
+    for item in values:
+        value = ""
+        if isinstance(item, Mapping):
+            candidate = (
+                item.get("Plate")
+                or item.get("plate")
+                or item.get("value")
+                or item.get("Value")
+            )
+            if candidate is not None:
+                value = str(candidate).strip().upper()
+        else:
+            value = str(item or "").strip().upper()
+        if not value:
+            continue
+        folded = value.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        cleaned.append(value)
+        if len(cleaned) >= 5:
+            break
+    return cleaned
+
+
+def sanitize_self_service_profile_payload(
+    payload: Mapping[str, Any],
+    user_id: str,
+) -> Dict[str, Any]:
+    """Keep only fields a linked non-admin user may edit for their own profile."""
+
+    canonical = normalize_user_id(user_id) or str(user_id or "").strip()
+    cleaned: Dict[str, Any] = {"id": canonical}
+    if "name" in payload:
+        cleaned["name"] = str(payload.get("name") or "").strip()
+    if "pin" in payload:
+        raw_pin = payload.get("pin")
+        cleaned["pin"] = "" if raw_pin in (None, "") else str(raw_pin).strip()
+    if "phone" in payload:
+        cleaned["phone"] = str(payload.get("phone") or "").strip()
+    if "license_plate" in payload:
+        cleaned["license_plate"] = _sanitize_self_service_license_plates(
+            payload.get("license_plate")
+        )
+    return cleaned
+
+
+def self_service_profile_change_labels(
+    profile: Mapping[str, Any],
+    updates: Mapping[str, Any],
+) -> List[str]:
+    def _text(value: Any) -> str:
+        return str(value or "").strip()
+
+    labels: List[str] = []
+    if "name" in updates and _text(profile.get("name")) != _text(updates.get("name")):
+        labels.append("name")
+    if "pin" in updates and _text(profile.get("pin")) != _text(updates.get("pin")):
+        labels.append("PIN")
+    if "phone" in updates and _text(profile.get("phone")) != _text(updates.get("phone")):
+        labels.append("phone number")
+    if "license_plate" in updates:
+        before = _sanitize_self_service_license_plates(
+            profile.get("license_plate") or profile.get("LicensePlate")
+        )
+        after = _sanitize_self_service_license_plates(updates.get("license_plate"))
+        if before != after:
+            labels.append("license plates")
+    return labels
+
+
+async def async_send_user_profile_change_notification(
+    hass: HomeAssistant,
+    root: Dict[str, Any],
+    *,
+    user_id: str,
+    actor_name: str = "",
+    changes: Optional[Iterable[str]] = None,
+) -> None:
+    """Notify configured targets when a linked non-admin updates their own profile."""
+
+    settings = root.get("settings_store") if isinstance(root, dict) else None
+    if not settings or not hasattr(settings, "targets_for_event"):
+        return
+    try:
+        targets = list(settings.targets_for_event("user_changed", user_id=user_id))
+    except Exception as err:
+        _LOGGER.debug("Failed to resolve user profile change targets: %s", err)
+        return
+    if not targets:
+        return
+
+    users_store = root.get("users_store") if isinstance(root, dict) else None
+    profile: Any = {}
+    try:
+        if users_store:
+            profile = users_store.get(user_id) or {}
+    except Exception:
+        profile = {}
+    if not isinstance(profile, Mapping):
+        profile = {}
+
+    name = str(profile.get("name") or user_id).strip()
+    changed = [str(item).strip() for item in (changes or []) if str(item).strip()]
+    if changed:
+        message = f"{name} updated their Akuvox profile ({', '.join(changed)})."
+    else:
+        message = f"{name} updated their Akuvox profile."
+    actor = str(actor_name or "").strip()
+    if actor and actor != name:
+        message = f"{message} Changed by {actor}."
+
+    service = getattr(hass, "services", None)
+    if not service or not hasattr(service, "async_call"):
+        return
+
+    data = {
+        "event_type": "user_changed",
+        "user_id": user_id,
+        "user_name": name,
+        "changed_by": actor,
+        "changes": changed,
+    }
+    for target in targets:
+        try:
+            await service.async_call(
+                "notify",
+                target,
+                {
+                    "title": "Akuvox: User profile changed",
+                    "message": message,
+                    "data": data,
+                },
+                blocking=False,
+            )
+        except Exception as err:
+            _LOGGER.debug("Failed to notify %s about user profile change: %s", target, err)
+
+
+async def async_apply_self_service_profile_change(
+    hass: HomeAssistant,
+    root: Dict[str, Any],
+    *,
+    user_id: str,
+    payload: Mapping[str, Any],
+    actor_name: str = "",
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Apply a safe self-service profile edit and queue it for sync."""
+
+    users_store = root.get("users_store") if isinstance(root, dict) else None
+    if not users_store:
+        raise ValueError("users store unavailable")
+
+    canonical = normalize_user_id(user_id) or str(user_id or "").strip()
+    if not canonical:
+        raise ValueError("user id is required")
+
+    try:
+        existing = users_store.get(canonical) or {}
+    except Exception:
+        existing = {}
+    if not isinstance(existing, Mapping):
+        existing = {}
+
+    updates = sanitize_self_service_profile_payload(payload, canonical)
+    changes = self_service_profile_change_labels(existing, updates)
+
+    kwargs: Dict[str, Any] = {}
+    for key in ("name", "pin", "phone", "license_plate"):
+        if key in updates:
+            kwargs[key] = updates[key]
+    if changes:
+        kwargs["status"] = "pending"
+        kwargs["source"] = "Local"
+
+    if kwargs:
+        await users_store.upsert_profile(canonical, **kwargs)
+
+    queue = root.get("sync_queue") if isinstance(root, dict) else None
+    if queue and changes:
+        try:
+            queue.mark_change(None, trigger="self-service profile edit")
+        except Exception:
+            pass
+
+    if changes:
+        await async_send_user_profile_change_notification(
+            hass,
+            root,
+            user_id=canonical,
+            actor_name=actor_name,
+            changes=changes,
+        )
+
+    return updates, changes
+
+
 def _device_lookup_key(value: Any) -> str:
     return re.sub(r"\s+", " ", str(value or "").strip()).casefold()
 
@@ -3570,12 +3824,12 @@ class AkuvoxDashboardView(HomeAssistantView):
             raise web.HTTPNotFound()
 
         hass: HomeAssistant = request.app["hass"]
-        if (
-            target not in ("unauthorized", "unauthorized-mob")
-            and _request_hass_user(request) is not None
-            and not _request_can_access_dashboard(hass, request)
-        ):
-            target = "unauthorized-mob" if target.endswith("-mob") else "unauthorized"
+        if target not in ("unauthorized", "unauthorized-mob") and _request_hass_user(request) is not None:
+            if not _request_can_access_dashboard(hass, request):
+                if _request_can_access_self_service(hass, request):
+                    target = "users-mob" if target.endswith("-mob") or _request_prefers_mobile(request) else "users"
+                else:
+                    target = "unauthorized-mob" if target.endswith("-mob") else "unauthorized"
 
         asset = _resolve_dashboard_asset(target, request)
         requested_mobile = target.endswith("-mob") or _request_prefers_mobile(request)
@@ -3604,7 +3858,9 @@ class AkuvoxUIView(HomeAssistantView):
 
     async def get(self, request: web.Request):
         hass: HomeAssistant = request.app["hass"]
-        if not _request_can_access_dashboard(hass, request):
+        has_dashboard_access = _request_can_access_dashboard(hass, request)
+        self_service = None if has_dashboard_access else _request_self_service_context(hass, request)
+        if not has_dashboard_access and not self_service:
             return _dashboard_access_denied_response()
         root = hass.data.get(DOMAIN, {}) or {}
 
@@ -3643,6 +3899,11 @@ class AkuvoxUIView(HomeAssistantView):
                 "anpr": False,
                 "face": True,
                 "phone": True,
+            },
+            "dashboard_access": {
+                "can_manage": has_dashboard_access and _request_is_admin(hass, request),
+                "self_service": bool(self_service),
+                "self_user_id": (self_service or {}).get("user_id") if self_service else "",
             },
         }
 
@@ -3895,6 +4156,27 @@ class AkuvoxUIView(HomeAssistantView):
             response["groups"] = groups
             response["all_groups"] = groups
 
+            if self_service:
+                self_user_id = str(self_service.get("user_id") or "").strip()
+                response["registry_users"] = [
+                    user for user in registry_users if str(user.get("id") or "") == self_user_id
+                ]
+                response["devices"] = []
+                response["access_events"] = []
+                response["home_assistant_users"] = []
+                response["schedules"] = {}
+                response["schedule_ids"] = {}
+                response["groups"] = []
+                response["all_groups"] = []
+                response["capabilities"] = {"alarm_relay": False}
+                response["dashboard_access"] = {
+                    "can_manage": False,
+                    "self_service": True,
+                    "self_user_id": self_user_id,
+                    "current_user_id": str(self_service.get("ha_user_id") or ""),
+                    "current_user_name": str(self_service.get("ha_user_name") or ""),
+                }
+
         except Exception as err:
             _LOGGER.debug("Failed to build Akuvox state payload: %s", err)
 
@@ -3933,7 +4215,9 @@ class AkuvoxUIAction(AkuvoxUIView):
 
     async def post(self, request: web.Request):
         hass: HomeAssistant = request.app["hass"]
-        if not _request_can_access_dashboard(hass, request):
+        has_dashboard_access = _request_can_access_dashboard(hass, request)
+        self_service = None if has_dashboard_access else _request_self_service_context(hass, request)
+        if not has_dashboard_access and not self_service:
             return _dashboard_access_denied_response()
         raw_root = hass.data.get(DOMAIN, {}) or {}
         root = raw_root if isinstance(raw_root, dict) else {}
@@ -3955,6 +4239,32 @@ class AkuvoxUIAction(AkuvoxUIView):
         def err(msg: Exception | str, code: int = 400):
             text = str(msg) if isinstance(msg, str) else (str(msg) or "unknown error")
             return web.json_response({"ok": False, "error": text}, status=code)
+
+        if self_service and not has_dashboard_access:
+            self_user_id = str(self_service.get("user_id") or "").strip()
+            if action == "self_edit_profile":
+                try:
+                    _updates, changes = await async_apply_self_service_profile_change(
+                        hass,
+                        root,
+                        user_id=self_user_id,
+                        payload=payload,
+                        actor_name=str(self_service.get("ha_user_name") or ""),
+                    )
+                    return web.json_response(
+                        {"ok": True, "user_id": self_user_id, "changes": changes}
+                    )
+                except Exception as edit_err:
+                    return err(edit_err, code=400)
+            if action == "remove_face":
+                requested_id = normalize_user_id(payload.get("id") or payload.get("user_id"))
+                requested_id = requested_id or str(payload.get("id") or payload.get("user_id") or "").strip()
+                if requested_id and requested_id != self_user_id:
+                    return err("self-service users can only edit their own profile", code=403)
+                payload = dict(payload)
+                payload["id"] = self_user_id
+            else:
+                return err("action is unavailable for self-service users", code=403)
 
         if action == "call_service":
             service = str(payload.get("service") or "").strip()
@@ -4331,6 +4641,15 @@ class AkuvoxUIAction(AkuvoxUIView):
                     queue.mark_change(None)
                 except Exception:
                     pass
+
+            if self_service and not has_dashboard_access:
+                await async_send_user_profile_change_notification(
+                    hass,
+                    root,
+                    user_id=canonical,
+                    actor_name=str(self_service.get("ha_user_name") or ""),
+                    changes=["face photo removed"],
+                )
 
             return web.json_response({"ok": True})
 
@@ -6593,6 +6912,19 @@ class AkuvoxUIUploadFace(HomeAssistantView):
             else:
                 id_val_raw = str(candidate or "").strip()
 
+        if self_service and not has_dashboard_access:
+            self_user_id = str(self_service.get("user_id") or "").strip()
+            requested_id = normalize_user_id(id_val_raw) or str(id_val_raw or "").strip()
+            if requested_id and requested_id != self_user_id:
+                return web.json_response(
+                    {
+                        "ok": False,
+                        "error": "self-service users can only edit their own profile",
+                    },
+                    status=403,
+                )
+            id_val_raw = self_user_id
+
         id_val = normalize_ha_id(id_val_raw)
         if not id_val:
             return web.json_response(
@@ -6649,6 +6981,15 @@ class AkuvoxUIUploadFace(HomeAssistantView):
                 queue.mark_change(None)
             except Exception:
                 pass
+
+        if self_service and not has_dashboard_access:
+            await async_send_user_profile_change_notification(
+                hass,
+                root,
+                user_id=id_val,
+                actor_name=str(self_service.get("ha_user_name") or ""),
+                changes=["face photo uploaded"],
+            )
 
         return web.json_response({"ok": True, "face_url": face_url_public})
 

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 import logging
@@ -76,6 +77,7 @@ from .reboot_schedule import normalize_reboot_schedule, reboot_schedule_is_due
 from .coordinator import AkuvoxCoordinator
 from .access_history import AccessHistory
 from .http import (
+    async_apply_self_service_profile_change,
     async_open_gate,
     face_base_url,
     face_filename_from_reference,
@@ -83,6 +85,7 @@ from .http import (
     register_ui,
     FACE_FILE_EXTENSIONS,
     _maybe_migrate_component_folder,
+    _linked_registry_user_for_ha_actor,
 )  # provides /api/akuvox_ac/ui/* + /api/AK_AC/* assets
 from .ha_id import (
     ha_id_from_int,
@@ -753,6 +756,23 @@ def _context_user_identity(hass: HomeAssistant, context) -> Tuple[str, str]:
         pass
 
     return user_id, user_id or default
+
+
+async def _context_user_is_admin(hass: HomeAssistant, context) -> bool:
+    """Return whether the service call was made by a Home Assistant admin user."""
+
+    if context is None:
+        return False
+    user_id = str(getattr(context, "user_id", "") or "").strip()
+    if not user_id:
+        return False
+    try:
+        user = hass.auth.async_get_user(user_id)
+        if inspect.isawaitable(user):
+            user = await user
+    except Exception:
+        return False
+    return bool(user and getattr(user, "is_admin", False))
 
 
 def _key_of_user(u: Dict[str, Any]) -> str:
@@ -3599,6 +3619,7 @@ class AkuvoxSettingsStore(Store):
                     data["integrity_failed"] = bool(cfg.get("integrity_failed"))
                     data["access_expiring"] = bool(cfg.get("access_expiring"))
                     data["any_denied"] = bool(cfg.get("any_denied"))
+                    data["user_changed"] = bool(cfg.get("user_changed"))
                     granted_cfg = cfg.get("granted") if isinstance(cfg.get("granted"), dict) else {}
                     if not granted_cfg and isinstance(cfg.get("granted_users"), list):
                         granted_cfg = {
@@ -3610,6 +3631,7 @@ class AkuvoxSettingsStore(Store):
                     data["integrity_failed"] = False
                     data["access_expiring"] = False
                     data["any_denied"] = False
+                    data["user_changed"] = False
                     granted_cfg = {}
 
                 users_raw = []
@@ -3707,6 +3729,8 @@ class AkuvoxSettingsStore(Store):
             elif event_type == "access_expiring" and cfg.get("access_expiring"):
                 out.append(target)
             elif event_type == "any_denied" and cfg.get("any_denied"):
+                out.append(target)
+            elif event_type == "user_changed" and cfg.get("user_changed"):
                 out.append(target)
             elif event_type == "user_granted":
                 granted = cfg.get("granted") or {}
@@ -7693,13 +7717,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     async def svc_edit_user(call):
-        d = call.data
-        ha_user_id, ha_user_name = _home_assistant_link_from_service(d)
+        d = dict(call.data or {})
         raw_key = d.get("id")
         canonical_key = normalize_user_id(raw_key)
-        key = canonical_key or str(raw_key)
+        key = canonical_key or str(raw_key or "").strip()
         effective_id = canonical_key or key
-        users_store: AkuvoxUsersStore = hass.data[DOMAIN]["users_store"]
+        root = hass.data[DOMAIN]
+        users_store: AkuvoxUsersStore = root["users_store"]
+
+        context = getattr(call, "context", None)
+        actor_id, actor_name = _context_user_identity(hass, context)
+        if actor_id and not await _context_user_is_admin(hass, context):
+            linked_id, _linked_profile = _linked_registry_user_for_ha_actor(
+                root,
+                ha_user_id=actor_id,
+                ha_user_name=actor_name,
+            )
+            linked_id = normalize_user_id(linked_id) or str(linked_id or "").strip()
+            requested_id = normalize_user_id(effective_id) or str(effective_id or "").strip()
+            if not linked_id or (requested_id and requested_id != linked_id):
+                raise ValueError("self-service users can only edit their own profile")
+            await async_apply_self_service_profile_change(
+                hass,
+                root,
+                user_id=linked_id,
+                payload=d,
+                actor_name=actor_name,
+            )
+            return
+
+        ha_user_id, ha_user_name = _home_assistant_link_from_service(d)
         try:
             existing_profile = users_store.get(effective_id) or {}
         except Exception:

--- a/custom_components/akuvox_ac/tests/test_notify_on_access.py
+++ b/custom_components/akuvox_ac/tests/test_notify_on_access.py
@@ -88,6 +88,22 @@ def test_settings_store_targets_access_expiring_alerts():
     assert store.targets_for_event("access_expiring") == ["mobile_app_lees_iphone"]
 
 
+def test_settings_store_targets_user_profile_change_alerts():
+    store = _settings_store(
+        {
+            "mobile_app_lees_iphone": {"user_changed": True},
+            "mobile_app_verns_iphone": {"user_changed": False},
+        }
+    )
+
+    cleaned = store.get_alert_targets()
+
+    assert cleaned["mobile_app_lees_iphone"]["user_changed"] is True
+    assert store.targets_for_event("user_changed", user_id="HA012") == [
+        "mobile_app_lees_iphone"
+    ]
+
+
 def test_settings_store_tracks_expiry_reminder_sent_date():
     store = _settings_store({})
 

--- a/custom_components/akuvox_ac/www/settings-mob.html
+++ b/custom_components/akuvox_ac/www/settings-mob.html
@@ -1441,6 +1441,7 @@ function ensureTargetDefaults(target){
       integrity_failed: false,
       access_expiring: false,
       any_denied: false,
+      user_changed: false,
       granted: { any: false, specific: false, users: [] }
     };
   } else {
@@ -1449,6 +1450,7 @@ function ensureTargetDefaults(target){
     if (typeof cfg.integrity_failed !== 'boolean') cfg.integrity_failed = Boolean(cfg.integrity_failed);
     if (typeof cfg.access_expiring !== 'boolean') cfg.access_expiring = Boolean(cfg.access_expiring);
     if (typeof cfg.any_denied !== 'boolean') cfg.any_denied = Boolean(cfg.any_denied);
+    if (typeof cfg.user_changed !== 'boolean') cfg.user_changed = Boolean(cfg.user_changed);
     if (!cfg.granted || typeof cfg.granted !== 'object') cfg.granted = { any: false, specific: false, users: [] };
     if (typeof cfg.granted.any !== 'boolean') cfg.granted.any = Boolean(cfg.granted.any);
     if (!Array.isArray(cfg.granted.users)) cfg.granted.users = [];
@@ -1730,6 +1732,10 @@ function renderAlerts(){
           <label class="form-check-label">Any User Denied Access</label>
         </div>
         <div class="form-check mt-2">
+          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="user_changed" ${cfg.user_changed ? 'checked' : ''}>
+          <label class="form-check-label">User Profile Changed</label>
+        </div>
+        <div class="form-check mt-2">
           <input class="form-check-input" type="checkbox" data-target="${service}" data-field="granted_any" ${cfg.granted.any ? 'checked' : ''}>
           <label class="form-check-label">Any User Granted Access</label>
         </div>
@@ -1783,6 +1789,7 @@ function renderAlerts(){
       else if (field === 'integrity_failed') cfg.integrity_failed = checked;
       else if (field === 'access_expiring') cfg.access_expiring = checked;
       else if (field === 'any_denied') cfg.any_denied = checked;
+      else if (field === 'user_changed') cfg.user_changed = checked;
       else if (field === 'granted_any') cfg.granted.any = checked;
       else if (field === 'granted_specific') {
         cfg.granted.specific = checked;

--- a/custom_components/akuvox_ac/www/settings.html
+++ b/custom_components/akuvox_ac/www/settings.html
@@ -1443,6 +1443,7 @@ function ensureTargetDefaults(target){
       integrity_failed: false,
       access_expiring: false,
       any_denied: false,
+      user_changed: false,
       granted: { any: false, specific: false, users: [] }
     };
   } else {
@@ -1451,6 +1452,7 @@ function ensureTargetDefaults(target){
     if (typeof cfg.integrity_failed !== 'boolean') cfg.integrity_failed = Boolean(cfg.integrity_failed);
     if (typeof cfg.access_expiring !== 'boolean') cfg.access_expiring = Boolean(cfg.access_expiring);
     if (typeof cfg.any_denied !== 'boolean') cfg.any_denied = Boolean(cfg.any_denied);
+    if (typeof cfg.user_changed !== 'boolean') cfg.user_changed = Boolean(cfg.user_changed);
     if (!cfg.granted || typeof cfg.granted !== 'object') cfg.granted = { any: false, specific: false, users: [] };
     if (typeof cfg.granted.any !== 'boolean') cfg.granted.any = Boolean(cfg.granted.any);
     if (!Array.isArray(cfg.granted.users)) cfg.granted.users = [];
@@ -1732,6 +1734,10 @@ function renderAlerts(){
           <label class="form-check-label">Any User Denied Access</label>
         </div>
         <div class="form-check mt-2">
+          <input class="form-check-input" type="checkbox" data-target="${service}" data-field="user_changed" ${cfg.user_changed ? 'checked' : ''}>
+          <label class="form-check-label">User Profile Changed</label>
+        </div>
+        <div class="form-check mt-2">
           <input class="form-check-input" type="checkbox" data-target="${service}" data-field="granted_any" ${cfg.granted.any ? 'checked' : ''}>
           <label class="form-check-label">Any User Granted Access</label>
         </div>
@@ -1785,6 +1791,7 @@ function renderAlerts(){
       else if (field === 'integrity_failed') cfg.integrity_failed = checked;
       else if (field === 'access_expiring') cfg.access_expiring = checked;
       else if (field === 'any_denied') cfg.any_denied = checked;
+      else if (field === 'user_changed') cfg.user_changed = checked;
       else if (field === 'granted_any') cfg.granted.any = checked;
       else if (field === 'granted_specific') {
         cfg.granted.specific = checked;

--- a/custom_components/akuvox_ac/www/users-mob.html
+++ b/custom_components/akuvox_ac/www/users-mob.html
@@ -853,6 +853,8 @@ let CURRENT = null;     // working user object
 let RESERVED_ID = null; // HA### id reserved for new-user workflow
 let ANY_ALARM_CAPABLE = true;
 let ANY_PEDESTRIAN_CAPABLE = true;
+let SELF_SERVICE_MODE = false;
+let SELF_SERVICE_USER_ID = '';
 
 let reservationTimer = null;
 let reservationMisses = 0;
@@ -950,7 +952,7 @@ function setReservationMessage(html, tone = 'muted') {
     el.innerHTML = '';
     return;
   }
-  const cls = tone === 'error' ? 'text-danger' : tone === 'warning' ? 'text-warning' : 'muted';
+  const cls = tone === 'error' ? 'text-danger' : tone === 'warning' ? 'text-warning' : tone === 'success' ? 'text-success' : 'muted';
   el.innerHTML = `<span class="${cls}">${html}</span>`;
 }
 
@@ -1856,23 +1858,31 @@ async function load(){
     REGISTRY = state.registry_users || [];
     HA_USERS = Array.isArray(state.home_assistant_users) ? state.home_assistant_users : [];
     DEVICES = state.devices || [];
+    const dashboardAccess = state?.dashboard_access || {};
+    SELF_SERVICE_MODE = !!dashboardAccess.self_service;
+    SELF_SERVICE_USER_ID = String(dashboardAccess.self_user_id || '').trim();
 
     // Load phones (notify services from HA mobile app)
-    try {
-      const resp = await apiGet(API_PHONES);
-      PHONES = resp.phones || [];
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      console.warn('Failed to load phone list', err);
+    if (SELF_SERVICE_MODE) {
       PHONES = [];
-    }
-    try {
-      const settingsResp = await apiGet(API_SETTINGS);
-      ALERT_TARGETS = settingsResp?.alerts?.targets || {};
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      console.warn('Failed to load notification settings', err);
       ALERT_TARGETS = {};
+    } else {
+      try {
+        const resp = await apiGet(API_PHONES);
+        PHONES = resp.phones || [];
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        console.warn('Failed to load phone list', err);
+        PHONES = [];
+      }
+      try {
+        const settingsResp = await apiGet(API_SETTINGS);
+        ALERT_TARGETS = settingsResp?.alerts?.targets || {};
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        console.warn('Failed to load notification settings', err);
+        ALERT_TARGETS = {};
+      }
     }
 
     const params = new URLSearchParams(location.search);
@@ -1881,7 +1891,23 @@ async function load(){
     const startInEditMode = modeParam === 'edit';
     let handledBySelect = false;
 
-    if (id) {
+    if (SELF_SERVICE_MODE) {
+      const selfId = SELF_SERVICE_USER_ID;
+      const existing = (REGISTRY || []).find(u => String(u.id || u.UserID || u.UserId || u.ID || '').trim() === selfId);
+      if (existing) {
+        selectExistingUser(selfId, { updateUrl: false });
+        handledBySelect = true;
+      } else {
+        CURRENT = blankProfile(selfId);
+        RESERVED_ID = null;
+        stopReservationHeartbeat();
+        setReservationMessage('');
+        forgetReservationId();
+        document.getElementById('title').textContent = 'Edit Your Profile';
+        document.getElementById('idRow').style.display = 'block';
+        document.getElementById('user_id').value = CURRENT.id;
+      }
+    } else if (id) {
       const hasMatch = (REGISTRY || []).some(u => String(u.id || u.UserID || u.UserId || u.ID || '') === id);
       if (hasMatch) {
         selectExistingUser(id, { updateUrl: false });
@@ -1969,6 +1995,33 @@ function applyHomeAssistantUserSelect(){
     });
     select._bound = true;
   }
+}
+
+function applySelfServiceMode(){
+  if (!SELF_SERVICE_MODE) return;
+  const title = document.getElementById('title');
+  if (title) title.textContent = 'Edit Your Profile';
+  [
+    'haUserLinkRow',
+    'scheduleRow',
+    'pedestrianAccessRow',
+    'exitPermissionRow',
+    'accessWindow',
+    'notifyOnAccessRow',
+    'keyHolderRow',
+    'deviceIdsRow'
+  ].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.style.display = 'none';
+  });
+  const remote = document.getElementById('pRemote');
+  if (remote) remote.style.display = 'none';
+  const remoteBtn = document.getElementById('remoteEnrolButton');
+  if (remoteBtn) remoteBtn.style.display = 'none';
+  const cancelBtn = document.getElementById('cancelEditButton');
+  if (cancelBtn) cancelBtn.style.display = 'none';
+  const select = document.getElementById('ha_user_id');
+  if (select) select.disabled = true;
 }
 
 function fillForm(){
@@ -2074,6 +2127,7 @@ function fillForm(){
   }
   updateDeviceIdsDisplay();
   applyCredentialPrompts();
+  applySelfServiceMode();
   refreshNotifyState();
   if (CREDENTIAL_PROMPTS.face && hasExistingFace()) {
     showPanel('local');
@@ -2100,6 +2154,7 @@ function fillForm(){
   }
   bindFaceFileInput();
   bindRemoveFaceButton();
+  applySelfServiceMode();
   updateFacePreviewState();
 }
 
@@ -2287,7 +2342,13 @@ async function save(){
   setBusy(true);
   try{
     // Ensure we have or reserve an ID
-    if (!CURRENT.id){
+    if (SELF_SERVICE_MODE) {
+      CURRENT.id = SELF_SERVICE_USER_ID || CURRENT.id;
+      if (!CURRENT.id){
+        alert('Your linked Akuvox profile could not be found.');
+        return;
+      }
+    } else if (!CURRENT.id){
       try{
         const res = await apiGet(API_RESERVE_ID);
         if (res && res.ok && res.id) {
@@ -2361,12 +2422,16 @@ async function save(){
     CURRENT.access_start = payload.access_start;
     CURRENT.access_end = payload.access_end;
 
-    const notifySelection = collectNotifySelection();
-    payload.notify_on_access = notifySelection.enabled;
-    payload.notify_targets = notifySelection.targets;
+    const notifySelection = SELF_SERVICE_MODE
+      ? { enabled: false, targets: [] }
+      : collectNotifySelection();
+    if (!SELF_SERVICE_MODE){
+      payload.notify_on_access = notifySelection.enabled;
+      payload.notify_targets = notifySelection.targets;
+    }
 
     const haUserSelect = document.getElementById('ha_user_id');
-    if (haUserSelect){
+    if (!SELF_SERVICE_MODE && haUserSelect){
       const option = haUserSelect.options[haUserSelect.selectedIndex];
       payload.ha_user_id = haUserSelect.value || '';
       payload.ha_user_name = option ? (option.dataset.name || '') : '';
@@ -2375,21 +2440,30 @@ async function save(){
     }
 
     // Save/update the profile against the reserved ID
-    const saveRes = await fetchWithAuth(API_EDIT_USER, {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ id: CURRENT.id, ...payload })
-    });
-    if (!saveRes.ok){
-      const txt = await saveRes.text();
-      const err = buildError(saveRes, txt);
-      handleAuthError(err);
-      throw err;
+    if (SELF_SERVICE_MODE){
+      await apiPost(API_ACTION, {
+        action: 'self_edit_profile',
+        payload: { id: CURRENT.id, ...payload }
+      });
+    } else {
+      const saveRes = await fetchWithAuth(API_EDIT_USER, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ id: CURRENT.id, ...payload })
+      });
+      if (!saveRes.ok){
+        const txt = await saveRes.text();
+        const err = buildError(saveRes, txt);
+        handleAuthError(err);
+        throw err;
+      }
+      try { await saveRes.json(); } catch {}
     }
-    try { await saveRes.json(); } catch {}
 
-    applyNotifyTargetsForUser(CURRENT.id, notifySelection.targets, notifySelection.enabled);
-    CURRENT.notify_targets = notifySelection.targets;
+    if (!SELF_SERVICE_MODE){
+      applyNotifyTargetsForUser(CURRENT.id, notifySelection.targets, notifySelection.enabled);
+      CURRENT.notify_targets = notifySelection.targets;
+    }
 
     // If a photo is selected, upload it now
     const fileInput = document.getElementById('facefile');
@@ -2424,7 +2498,7 @@ async function save(){
     }
 
     // If Remote panel is visible and a phone is selected, auto-send enrolment request now
-    const remoteVisible = document.getElementById('pRemote').style.display !== 'none';
+    const remoteVisible = !SELF_SERVICE_MODE && document.getElementById('pRemote').style.display !== 'none';
     const phoneSel = document.getElementById('device');
     const phoneService = phoneSel && phoneSel.value ? phoneSel.value : '';
     if (remoteVisible && phoneService){
@@ -2443,6 +2517,14 @@ async function save(){
       }
     }
 
+    if (SELF_SERVICE_MODE){
+      stopReservationHeartbeat();
+      forgetReservationId();
+      RESERVED_ID = null;
+      setReservationMessage('Profile saved.', 'success');
+      return;
+    }
+
     // Back to list
     stopReservationHeartbeat();
     forgetReservationId();
@@ -2459,6 +2541,10 @@ async function save(){
 /* -------------------- toggle panels -------------------- */
 async function cancelEdit(evt){
   if (evt) evt.preventDefault();
+  if (SELF_SERVICE_MODE){
+    setReservationMessage('');
+    return;
+  }
   stopReservationHeartbeat();
   await releaseReservation();
   openInApp('user-overview', {}, { replaceState: true });
@@ -2503,7 +2589,7 @@ function showPanel(which){
       <label class="form-label">Face Recognition</label>
       <div class="face-options mb-2">
         <button class="btn btn-outline-light btn-toggle" onclick="showPanel('local')"><i class="bi bi-upload me-1"></i>Local enrolment</button>
-        <button class="btn btn-outline-light btn-toggle" onclick="showPanel('remote')"><i class="bi bi-wifi me-1"></i>Remote enrolment</button>
+        <button class="btn btn-outline-light btn-toggle" id="remoteEnrolButton" onclick="showPanel('remote')"><i class="bi bi-wifi me-1"></i>Remote enrolment</button>
       </div>
     </div>
 
@@ -2606,7 +2692,7 @@ function showPanel(which){
 
     <div class="action-buttons mb-3">
       <button class="btn btn-success" onclick="save()" data-busy-lock><i class="bi bi-check2-circle me-1"></i>Save</button>
-      <a class="btn btn-secondary" href="#" onclick="cancelEdit(event)"><i class="bi bi-x-circle me-1"></i>Cancel</a>
+      <a class="btn btn-secondary" href="#" id="cancelEditButton" onclick="cancelEdit(event)"><i class="bi bi-x-circle me-1"></i>Cancel</a>
     </div>
 
   </div>

--- a/custom_components/akuvox_ac/www/users.html
+++ b/custom_components/akuvox_ac/www/users.html
@@ -855,6 +855,8 @@ let CURRENT = null;     // working user object
 let RESERVED_ID = null; // HA### id reserved for new-user workflow
 let ANY_ALARM_CAPABLE = true;
 let ANY_PEDESTRIAN_CAPABLE = true;
+let SELF_SERVICE_MODE = false;
+let SELF_SERVICE_USER_ID = '';
 
 let reservationTimer = null;
 let reservationMisses = 0;
@@ -952,7 +954,7 @@ function setReservationMessage(html, tone = 'muted') {
     el.innerHTML = '';
     return;
   }
-  const cls = tone === 'error' ? 'text-danger' : tone === 'warning' ? 'text-warning' : 'muted';
+  const cls = tone === 'error' ? 'text-danger' : tone === 'warning' ? 'text-warning' : tone === 'success' ? 'text-success' : 'muted';
   el.innerHTML = `<span class="${cls}">${html}</span>`;
 }
 
@@ -1858,23 +1860,31 @@ async function load(){
     REGISTRY = state.registry_users || [];
     HA_USERS = Array.isArray(state.home_assistant_users) ? state.home_assistant_users : [];
     DEVICES = state.devices || [];
+    const dashboardAccess = state?.dashboard_access || {};
+    SELF_SERVICE_MODE = !!dashboardAccess.self_service;
+    SELF_SERVICE_USER_ID = String(dashboardAccess.self_user_id || '').trim();
 
     // Load phones (notify services from HA mobile app)
-    try {
-      const resp = await apiGet(API_PHONES);
-      PHONES = resp.phones || [];
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      console.warn('Failed to load phone list', err);
+    if (SELF_SERVICE_MODE) {
       PHONES = [];
-    }
-    try {
-      const settingsResp = await apiGet(API_SETTINGS);
-      ALERT_TARGETS = settingsResp?.alerts?.targets || {};
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      console.warn('Failed to load notification settings', err);
       ALERT_TARGETS = {};
+    } else {
+      try {
+        const resp = await apiGet(API_PHONES);
+        PHONES = resp.phones || [];
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        console.warn('Failed to load phone list', err);
+        PHONES = [];
+      }
+      try {
+        const settingsResp = await apiGet(API_SETTINGS);
+        ALERT_TARGETS = settingsResp?.alerts?.targets || {};
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        console.warn('Failed to load notification settings', err);
+        ALERT_TARGETS = {};
+      }
     }
 
     const params = new URLSearchParams(location.search);
@@ -1883,7 +1893,23 @@ async function load(){
     const startInEditMode = modeParam === 'edit';
     let handledBySelect = false;
 
-    if (id) {
+    if (SELF_SERVICE_MODE) {
+      const selfId = SELF_SERVICE_USER_ID;
+      const existing = (REGISTRY || []).find(u => String(u.id || u.UserID || u.UserId || u.ID || '').trim() === selfId);
+      if (existing) {
+        selectExistingUser(selfId, { updateUrl: false });
+        handledBySelect = true;
+      } else {
+        CURRENT = blankProfile(selfId);
+        RESERVED_ID = null;
+        stopReservationHeartbeat();
+        setReservationMessage('');
+        forgetReservationId();
+        document.getElementById('title').textContent = 'Edit Your Profile';
+        document.getElementById('idRow').style.display = 'block';
+        document.getElementById('user_id').value = CURRENT.id;
+      }
+    } else if (id) {
       const hasMatch = (REGISTRY || []).some(u => String(u.id || u.UserID || u.UserId || u.ID || '') === id);
       if (hasMatch) {
         selectExistingUser(id, { updateUrl: false });
@@ -1971,6 +1997,33 @@ function applyHomeAssistantUserSelect(){
     });
     select._bound = true;
   }
+}
+
+function applySelfServiceMode(){
+  if (!SELF_SERVICE_MODE) return;
+  const title = document.getElementById('title');
+  if (title) title.textContent = 'Edit Your Profile';
+  [
+    'haUserLinkRow',
+    'scheduleRow',
+    'pedestrianAccessRow',
+    'exitPermissionRow',
+    'accessWindow',
+    'notifyOnAccessRow',
+    'keyHolderRow',
+    'deviceIdsRow'
+  ].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.style.display = 'none';
+  });
+  const remote = document.getElementById('pRemote');
+  if (remote) remote.style.display = 'none';
+  const remoteBtn = document.getElementById('remoteEnrolButton');
+  if (remoteBtn) remoteBtn.style.display = 'none';
+  const cancelBtn = document.getElementById('cancelEditButton');
+  if (cancelBtn) cancelBtn.style.display = 'none';
+  const select = document.getElementById('ha_user_id');
+  if (select) select.disabled = true;
 }
 
 function fillForm(){
@@ -2076,6 +2129,7 @@ function fillForm(){
   }
   updateDeviceIdsDisplay();
   applyCredentialPrompts();
+  applySelfServiceMode();
   refreshNotifyState();
   if (CREDENTIAL_PROMPTS.face && hasExistingFace()) {
     showPanel('local');
@@ -2102,6 +2156,7 @@ function fillForm(){
   }
   bindFaceFileInput();
   bindRemoveFaceButton();
+  applySelfServiceMode();
   updateFacePreviewState();
 }
 
@@ -2289,7 +2344,13 @@ async function save(){
   setBusy(true);
   try{
     // Ensure we have or reserve an ID
-    if (!CURRENT.id){
+    if (SELF_SERVICE_MODE) {
+      CURRENT.id = SELF_SERVICE_USER_ID || CURRENT.id;
+      if (!CURRENT.id){
+        alert('Your linked Akuvox profile could not be found.');
+        return;
+      }
+    } else if (!CURRENT.id){
       try{
         const res = await apiGet(API_RESERVE_ID);
         if (res && res.ok && res.id) {
@@ -2363,12 +2424,16 @@ async function save(){
     CURRENT.access_start = payload.access_start;
     CURRENT.access_end = payload.access_end;
 
-    const notifySelection = collectNotifySelection();
-    payload.notify_on_access = notifySelection.enabled;
-    payload.notify_targets = notifySelection.targets;
+    const notifySelection = SELF_SERVICE_MODE
+      ? { enabled: false, targets: [] }
+      : collectNotifySelection();
+    if (!SELF_SERVICE_MODE){
+      payload.notify_on_access = notifySelection.enabled;
+      payload.notify_targets = notifySelection.targets;
+    }
 
     const haUserSelect = document.getElementById('ha_user_id');
-    if (haUserSelect){
+    if (!SELF_SERVICE_MODE && haUserSelect){
       const option = haUserSelect.options[haUserSelect.selectedIndex];
       payload.ha_user_id = haUserSelect.value || '';
       payload.ha_user_name = option ? (option.dataset.name || '') : '';
@@ -2377,21 +2442,30 @@ async function save(){
     }
 
     // Save/update the profile against the reserved ID
-    const saveRes = await fetchWithAuth(API_EDIT_USER, {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ id: CURRENT.id, ...payload })
-    });
-    if (!saveRes.ok){
-      const txt = await saveRes.text();
-      const err = buildError(saveRes, txt);
-      handleAuthError(err);
-      throw err;
+    if (SELF_SERVICE_MODE){
+      await apiPost(API_ACTION, {
+        action: 'self_edit_profile',
+        payload: { id: CURRENT.id, ...payload }
+      });
+    } else {
+      const saveRes = await fetchWithAuth(API_EDIT_USER, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ id: CURRENT.id, ...payload })
+      });
+      if (!saveRes.ok){
+        const txt = await saveRes.text();
+        const err = buildError(saveRes, txt);
+        handleAuthError(err);
+        throw err;
+      }
+      try { await saveRes.json(); } catch {}
     }
-    try { await saveRes.json(); } catch {}
 
-    applyNotifyTargetsForUser(CURRENT.id, notifySelection.targets, notifySelection.enabled);
-    CURRENT.notify_targets = notifySelection.targets;
+    if (!SELF_SERVICE_MODE){
+      applyNotifyTargetsForUser(CURRENT.id, notifySelection.targets, notifySelection.enabled);
+      CURRENT.notify_targets = notifySelection.targets;
+    }
 
     // If a photo is selected, upload it now
     const fileInput = document.getElementById('facefile');
@@ -2426,7 +2500,7 @@ async function save(){
     }
 
     // If Remote panel is visible and a phone is selected, auto-send enrolment request now
-    const remoteVisible = document.getElementById('pRemote').style.display !== 'none';
+    const remoteVisible = !SELF_SERVICE_MODE && document.getElementById('pRemote').style.display !== 'none';
     const phoneSel = document.getElementById('device');
     const phoneService = phoneSel && phoneSel.value ? phoneSel.value : '';
     if (remoteVisible && phoneService){
@@ -2445,6 +2519,14 @@ async function save(){
       }
     }
 
+    if (SELF_SERVICE_MODE){
+      stopReservationHeartbeat();
+      forgetReservationId();
+      RESERVED_ID = null;
+      setReservationMessage('Profile saved.', 'success');
+      return;
+    }
+
     // Back to list
     stopReservationHeartbeat();
     forgetReservationId();
@@ -2461,6 +2543,10 @@ async function save(){
 /* -------------------- toggle panels -------------------- */
 async function cancelEdit(evt){
   if (evt) evt.preventDefault();
+  if (SELF_SERVICE_MODE){
+    setReservationMessage('');
+    return;
+  }
   stopReservationHeartbeat();
   await releaseReservation();
   openInApp('index', { section: 'users' }, { replaceState: true });
@@ -2505,7 +2591,7 @@ function showPanel(which){
       <label class="form-label">Face Recognition</label>
       <div class="face-options mb-2">
         <button class="btn btn-outline-light btn-toggle" onclick="showPanel('local')"><i class="bi bi-upload me-1"></i>Local enrolment</button>
-        <button class="btn btn-outline-light btn-toggle" onclick="showPanel('remote')"><i class="bi bi-wifi me-1"></i>Remote enrolment</button>
+        <button class="btn btn-outline-light btn-toggle" id="remoteEnrolButton" onclick="showPanel('remote')"><i class="bi bi-wifi me-1"></i>Remote enrolment</button>
       </div>
     </div>
 
@@ -2608,7 +2694,7 @@ function showPanel(which){
 
     <div class="action-buttons mb-3">
       <button class="btn btn-success" onclick="save()" data-busy-lock><i class="bi bi-check2-circle me-1"></i>Save</button>
-      <a class="btn btn-secondary" href="#" onclick="cancelEdit(event)"><i class="bi bi-x-circle me-1"></i>Cancel</a>
+      <a class="btn btn-secondary" href="#" id="cancelEditButton" onclick="cancelEdit(event)"><i class="bi bi-x-circle me-1"></i>Cancel</a>
     </div>
 
   </div>


### PR DESCRIPTION
## What changed

- Adds a linked-user self-service mode for non-admin Home Assistant users.
- Routes linked non-admin users to their own edit-user page only, while full dashboard access remains admin-only.
- Limits self-service edits to profile/credential fields: name, PIN, phone, license plates, face upload/removal.
- Keeps Home Assistant user ID/name linking admin-only.
- Adds a notification target option for user profile changes.

## Validation

- `python -m py_compile custom_components/akuvox_ac/http.py custom_components/akuvox_ac/integration.py custom_components/akuvox_ac/tests/test_notify_on_access.py`
- Node script syntax check for `users.html`, `users-mob.html`, `settings.html`, `settings-mob.html`
- Direct notification-target test run for `test_notify_on_access.py`
- `git diff --check`