### PR TITLE
[codex] Fix Home Assistant open event labels

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -178,3 +178,17 @@ def test_cloud_open_events_use_akuvox_app_label():
         assert "Opened with Akuvox App" in page
         assert "function isCloudEvent(" in page
         assert " - Cloud - " not in page
+
+
+def test_home_assistant_open_events_match_underscore_source():
+    for name in (
+        "index.html",
+        "index-mob.html",
+        "event_history.html",
+        "event_history-mob.html",
+    ):
+        page = read_page(name)
+        assert "function isHomeAssistantOpenEvent(" in page
+        assert "function normalizeEventSearchText(" in page
+        assert "replace(/[_-]+/g, ' ')" in page
+        assert "compact.includes('homeassistant')" in page

--- a/custom_components/akuvox_ac/www/event_history-mob.html
+++ b/custom_components/akuvox_ac/www/event_history-mob.html
@@ -671,9 +671,15 @@ function isCloudEvent(evt, typeLabel){
   return String(typeLabel || '').toLowerCase().includes('cloud');
 }
 
+function normalizeEventSearchText(values){
+  return (values || [])
+    .map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' '))
+    .join(' ');
+}
+
 function isHomeAssistantOpenEvent(evt, typeLabel){
   if (!evt || typeof evt !== 'object') return false;
-  const text = [
+  const text = normalizeEventSearchText([
     evt._source,
     evt.Source,
     evt.source,
@@ -682,8 +688,10 @@ function isHomeAssistantOpenEvent(evt, typeLabel){
     evt.AccessType,
     evt.Event,
     evt.Description,
-  ].map(value => String(value || '').toLowerCase()).join(' ');
-  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+  ]);
+  const compact = text.replace(/[^a-z0-9]+/g, '');
+  return (text.includes('home assistant') || compact.includes('homeassistant'))
+    && /\b(open|opened|unlock|unlocked)\b/.test(text);
 }
 
 function getHomeAssistantOpenActor(evt){

--- a/custom_components/akuvox_ac/www/event_history.html
+++ b/custom_components/akuvox_ac/www/event_history.html
@@ -585,9 +585,15 @@ function isCloudEvent(evt, typeLabel){
   return String(typeLabel || '').toLowerCase().includes('cloud');
 }
 
+function normalizeEventSearchText(values){
+  return (values || [])
+    .map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' '))
+    .join(' ');
+}
+
 function isHomeAssistantOpenEvent(evt, typeLabel){
   if (!evt || typeof evt !== 'object') return false;
-  const text = [
+  const text = normalizeEventSearchText([
     evt._source,
     evt.Source,
     evt.source,
@@ -596,8 +602,10 @@ function isHomeAssistantOpenEvent(evt, typeLabel){
     evt.AccessType,
     evt.Event,
     evt.Description,
-  ].map(value => String(value || '').toLowerCase()).join(' ');
-  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+  ]);
+  const compact = text.replace(/[^a-z0-9]+/g, '');
+  return (text.includes('home assistant') || compact.includes('homeassistant'))
+    && /\b(open|opened|unlock|unlocked)\b/.test(text);
 }
 
 function getHomeAssistantOpenActor(evt){

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1293,9 +1293,15 @@ function pickFirstEventText(event, keys){
   return '';
 }
 
+function normalizeEventSearchText(values){
+  return (values || [])
+    .map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' '))
+    .join(' ');
+}
+
 function isHomeAssistantOpenEvent(event, typeLabel){
   if (!event || typeof event !== 'object') return false;
-  const text = [
+  const text = normalizeEventSearchText([
     event._source,
     event.Source,
     event.source,
@@ -1304,8 +1310,10 @@ function isHomeAssistantOpenEvent(event, typeLabel){
     event.AccessType,
     event.Event,
     event.Description,
-  ].map(value => String(value || '').toLowerCase()).join(' ');
-  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+  ]);
+  const compact = text.replace(/[^a-z0-9]+/g, '');
+  return (text.includes('home assistant') || compact.includes('homeassistant'))
+    && /\b(open|opened|unlock|unlocked)\b/.test(text);
 }
 
 function homeAssistantOpenActor(event){

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -1612,9 +1612,15 @@ function pickFirstEventText(event, keys){
   return '';
 }
 
+function normalizeEventSearchText(values){
+  return (values || [])
+    .map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' '))
+    .join(' ');
+}
+
 function isHomeAssistantOpenEvent(event, typeLabel){
   if (!event || typeof event !== 'object') return false;
-  const text = [
+  const text = normalizeEventSearchText([
     event._source,
     event.Source,
     event.source,
@@ -1623,8 +1629,10 @@ function isHomeAssistantOpenEvent(event, typeLabel){
     event.AccessType,
     event.Event,
     event.Description,
-  ].map(value => String(value || '').toLowerCase()).join(' ');
-  return text.includes('home assistant') && /\b(open|opened|unlock|unlocked)\b/.test(text);
+  ]);
+  const compact = text.replace(/[^a-z0-9]+/g, '');
+  return (text.includes('home assistant') || compact.includes('homeassistant'))
+    && /\b(open|opened|unlock|unlocked)\b/.test(text);
 }
 
 function homeAssistantOpenActor(event){


### PR DESCRIPTION
## What changed
- Normalised Home Assistant event-source text in the desktop and mobile dashboards/event-history pages.
- Treat `home_assistant`, `home-assistant`, and `home assistant` as the same source when formatting open/unlock events.
- Added a regression assertion so the UI keeps recognising underscore-style HA source values.

## Why
Home Assistant relay opens were published with `_source: "home_assistant"`, while the UI detector only matched the spaced phrase `home assistant`. That meant HA open events could fall through into the cloud/Akuvox App label path instead of showing `Opened with Home Assistant by ...`.

## Validation
- JS syntax pass over `index.html`, `index-mob.html`, `event_history.html`, and `event_history-mob.html`.
- Manually invoked the static dashboard control tests because pytest is not installed in this runtime.
- Manually invoked the open-gate backend tests with the Home Assistant stubs.
- `git diff --check`.