### PR TITLE
[codex] Format last access timestamps

### DIFF
--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -192,3 +192,18 @@ def test_home_assistant_open_events_match_underscore_source():
         assert "function normalizeEventSearchText(" in page
         assert "replace(/[_-]+/g, ' ')" in page
         assert "compact.includes('homeassistant')" in page
+
+
+def test_user_last_access_formats_iso_offsets_consistently():
+    pages = {
+        "index.html": "formatLastAccess(u.last)",
+        "index-mob.html": "formatLastAccess(u.last)",
+        "user_overview-mob.html": "formatLastAccess(u.last)",
+    }
+
+    for name, usage in pages.items():
+        page = read_page(name)
+        assert "function formatLastAccess(value)" in page
+        assert r"[T\s]+" in page
+        assert r"(?:Z|[+-]\d{2}:?\d{2})?" in page
+        assert usage in page

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1681,6 +1681,21 @@ function formatScheduleDisplay(rawId, label){
   return displayId || name;
 }
 
+function formatLastAccess(value){
+  if (!value) return '—';
+  const text = String(value).trim();
+  if (!text) return '—';
+  const isoMatch = text.match(/^(\d{4}-\d{2}-\d{2})[T\s]+(\d{1,2}):(\d{2})(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?$/);
+  if (isoMatch) {
+    return `${isoMatch[1]} ${isoMatch[2].padStart(2, '0')}:${isoMatch[3]}`;
+  }
+  const match = text.match(/(\d{1,2}):(\d{2}):(\d{2})/);
+  if (!match) return text;
+  const hh = match[1].padStart(2, '0');
+  const mm = match[2];
+  return text.replace(match[0], `${hh}:${mm}`);
+}
+
 function renderUsers(devs, registryUsers, kpis){
   const devices = Array.isArray(devs) ? devs : [];
   const syncActive = !!(kpis && kpis.sync_active);
@@ -2071,7 +2086,7 @@ function renderUsers(devs, registryUsers, kpis){
       <td>${accessBadge}</td>
       <td>${faceBadge}</td>
       <td>${errorCell}</td>
-      <td>${u.last || '—'}</td>
+      <td>${escapeHtml(formatLastAccess(u.last))}</td>
       <td>${actions}</td>
     </tr>`;
   }).join('');

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -2062,6 +2062,10 @@ function formatLastAccess(value){
   if (!value) return '—';
   const text = String(value).trim();
   if (!text) return '—';
+  const isoMatch = text.match(/^(\d{4}-\d{2}-\d{2})[T\s]+(\d{1,2}):(\d{2})(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?$/);
+  if (isoMatch) {
+    return `${isoMatch[1]} ${isoMatch[2].padStart(2, '0')}:${isoMatch[3]}`;
+  }
   const match = text.match(/(\d{1,2}):(\d{2}):(\d{2})/);
   if (!match) return text;
   const hh = match[1].padStart(2, '0');

--- a/custom_components/akuvox_ac/www/user_overview-mob.html
+++ b/custom_components/akuvox_ac/www/user_overview-mob.html
@@ -1118,6 +1118,21 @@ function formatScheduleDisplay(rawId, label){
   return displayId || name;
 }
 
+function formatLastAccess(value){
+  if (!value) return '—';
+  const text = String(value).trim();
+  if (!text) return '—';
+  const isoMatch = text.match(/^(\d{4}-\d{2}-\d{2})[T\s]+(\d{1,2}):(\d{2})(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?$/);
+  if (isoMatch) {
+    return `${isoMatch[1]} ${isoMatch[2].padStart(2, '0')}:${isoMatch[3]}`;
+  }
+  const match = text.match(/(\d{1,2}):(\d{2}):(\d{2})/);
+  if (!match) return text;
+  const hh = match[1].padStart(2, '0');
+  const mm = match[2];
+  return text.replace(match[0], `${hh}:${mm}`);
+}
+
 function renderPinToggle(pin, name){
   const raw = typeof pin === 'number' ? String(pin) : String(pin || '').trim();
   if (!raw) return '<span class="text-muted">—</span>';
@@ -1572,7 +1587,7 @@ function renderUsers(list){
       </div>
       <div class="user-groups">${chips || '<span class="text-muted">No groups</span>'}</div>
       <div class="user-meta">
-        <div><i class="bi bi-clock-history"></i>Last access: ${escapeHtml(u.last || '—')}</div>
+        <div><i class="bi bi-clock-history"></i>Last access: ${escapeHtml(formatLastAccess(u.last))}</div>
         <div><i class="bi bi-key"></i>Code: ${pinToggle}</div>
         <div><i class="bi bi-calendar2-week"></i>Schedule: ${schedule}</div>
         <div><i class="bi bi-hdd-network"></i>${escapeHtml(coverageText)}${seenNote ? ` • ${escapeHtml(seenNote)}` : ''}</div>


### PR DESCRIPTION
## What changed
- Normalised user `Last Access` display on the desktop dashboard, mobile dashboard, and mobile user overview.
- ISO timestamps from Home Assistant app/button events now render as `YYYY-MM-DD HH:mm` instead of showing raw `T` separators and timezone offsets.
- Added a static regression check to keep these user-list surfaces wired through the formatter.

## Why
App-triggered access events are stored as ISO values like `2026-06-16T21:01+01:00`, while device events commonly arrive already formatted as `2026-06-16 14:26`. The table was only trimming seconds, so ISO app entries looked visually different.

## Validation
- JS syntax pass over `index.html`, `index-mob.html`, and `user_overview-mob.html`.
- Manually invoked the dashboard static test module because pytest is not installed in this runtime.
- Ran example timestamp checks matching the reported screenshot values.
- `git diff --check`.