### PR TITLE
[codex] Persist access history across restarts

### DIFF
--- a/custom_components/akuvox_ac/access_history.py
+++ b/custom_components/akuvox_ac/access_history.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List, Optional
+import asyncio
 import datetime as dt
 import re
+from typing import Any, Dict, Iterable, List, Optional
 
 
 _TYPE_KEYS = (
@@ -157,17 +158,19 @@ class AccessHistory:
         self._events.clear()
         self._seen.clear()
 
-    def ingest(self, events: Iterable[Dict[str, Any]], limit: int) -> None:
+    def ingest(self, events: Iterable[Dict[str, Any]], limit: int) -> bool:
         """Merge *events* into the history, keeping only the newest *limit* items."""
 
         limit = self._normalize_limit(limit)
         if limit <= 0:
+            changed = bool(self._events or self._seen)
             self.clear()
-            return
+            return changed
 
         # Ensure we work against a sorted baseline so we can compare against the current
         # oldest event when deciding whether to insert older entries.
         self._events.sort(key=lambda e: self._coerce_timestamp(e.get("_t")), reverse=True)
+        changed = False
 
         for event in events:
             if not isinstance(event, dict):
@@ -192,20 +195,22 @@ class AccessHistory:
 
             self._events.append(event_copy)
             self._seen.add(key)
+            changed = True
 
         if not self._events:
-            return
+            return changed
 
         self._events.sort(key=lambda e: e.get("_t", 0.0), reverse=True)
-        self.prune(limit)
+        return self.prune(limit) or changed
 
-    def prune(self, limit: int) -> None:
+    def prune(self, limit: int) -> bool:
         """Trim stored events so at most *limit* remain."""
 
         limit = self._normalize_limit(limit)
         if limit <= 0:
+            changed = bool(self._events or self._seen)
             self.clear()
-            return
+            return changed
 
         self._events.sort(key=lambda e: e.get("_t", 0.0), reverse=True)
 
@@ -215,7 +220,7 @@ class AccessHistory:
                 for evt in self._events
                 if self._coerce_key(evt.get("_key"))
             }
-            return
+            return False
 
         retained = self._events[:limit]
         self._events = retained
@@ -224,6 +229,7 @@ class AccessHistory:
             for evt in retained
             if self._coerce_key(evt.get("_key"))
         }
+        return True
 
     def snapshot(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         """Return a copy of the newest events, optionally limited to *limit* entries."""
@@ -318,4 +324,58 @@ class AccessHistory:
         return parsed.timestamp()
 
 
-__all__ = ["AccessHistory", "categorize_event"]
+def schedule_access_history_persist(
+    hass: Any,
+    root: Optional[Dict[str, Any]],
+    limit: Optional[int] = None,
+) -> bool:
+    """Persist the current access-history snapshot through the configured store."""
+
+    if not isinstance(root, dict):
+        return False
+    history = root.get("access_history")
+    store = root.get("access_history_store")
+    if history is None or store is None:
+        return False
+    if not hasattr(history, "snapshot"):
+        return False
+
+    try:
+        events = history.snapshot(limit)
+    except Exception:
+        return False
+
+    async def _save() -> None:
+        try:
+            save_events = getattr(store, "async_save_events", None)
+            if callable(save_events):
+                await save_events(events)
+                return
+
+            data = getattr(store, "data", None)
+            if isinstance(data, dict):
+                data["events"] = list(events)
+            save = getattr(store, "async_save", None)
+            if callable(save):
+                await save()
+        except Exception:
+            return
+
+    try:
+        create_task = getattr(hass, "async_create_task", None)
+        if callable(create_task):
+            create_task(_save())
+            return True
+
+        loop = getattr(hass, "loop", None)
+        if loop is not None and hasattr(loop, "create_task"):
+            loop.create_task(_save())
+            return True
+
+        asyncio.get_running_loop().create_task(_save())
+        return True
+    except RuntimeError:
+        return False
+
+
+__all__ = ["AccessHistory", "categorize_event", "schedule_access_history_persist"]

--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -26,7 +26,7 @@ from .http import (
     _match_user_by_number,
     _normalize_call_number,
 )
-from .access_history import AccessHistory, categorize_event
+from .access_history import AccessHistory, categorize_event, schedule_access_history_persist
 
 
 CALLER_LOOKBACK_SECONDS = 120
@@ -1130,7 +1130,9 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
             return
 
         try:
-            history.ingest(prepared, limit)
+            changed = history.ingest(prepared, limit)
+            if changed:
+                schedule_access_history_persist(self.hass, root, limit)
         except Exception as err:
             _LOGGER.debug(
                 "Failed to update aggregated access history for %s: %s",

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -65,7 +65,7 @@ from .relay import (
     normalize_roles as normalize_relay_roles,
 )
 from .ha_id import ha_id_from_int, is_ha_id, normalize_ha_id, normalize_user_id
-from .access_history import AccessHistory, categorize_event
+from .access_history import AccessHistory, categorize_event, schedule_access_history_persist
 from .reboot_schedule import normalize_reboot_schedule
 
 COMPONENT_ROOT = Path(__file__).parent
@@ -992,7 +992,9 @@ def _ingest_history_event(hass: HomeAssistant, event: Dict[str, Any]) -> None:
         event_copy["_category"] = categorize_event(event_copy)
 
     try:
-        history.ingest([event_copy], limit)
+        changed = history.ingest([event_copy], limit)
+        if changed:
+            schedule_access_history_persist(hass, root, limit)
     except Exception as err:
         _LOGGER.debug("Failed to ingest aggregated event: %s", err)
 
@@ -5306,7 +5308,9 @@ class AkuvoxUISettings(HomeAssistantView):
             history = root.get("access_history")
             if history and hasattr(history, "prune"):
                 try:
-                    history.prune(limit_value)
+                    changed = history.prune(limit_value)
+                    if changed:
+                        schedule_access_history_persist(hass, root, limit_value)
                 except Exception:
                     pass
 

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 import logging
@@ -2406,6 +2407,43 @@ def _log_full_sync(coord: AkuvoxCoordinator, triggered_by: str) -> None:
 
 
 # ---------------------- Persistent stores ---------------------- #
+class AkuvoxAccessHistoryStore(Store):
+    def __init__(self, hass: HomeAssistant):
+        super().__init__(hass, 1, f"{DOMAIN}_access_history.json")
+        self.data: Dict[str, Any] = {"events": []}
+
+    async def async_load(self):
+        existing = await super().async_load()
+        if isinstance(existing, dict):
+            events = existing.get("events")
+            if isinstance(events, list):
+                self.data = {"events": [dict(e) for e in events if isinstance(e, dict)]}
+                return
+        if isinstance(existing, list):
+            self.data = {"events": [dict(e) for e in existing if isinstance(e, dict)]}
+
+    async def async_save(self):
+        await super().async_save(self.data)
+
+    @staticmethod
+    def _json_safe_event(event: Mapping[str, Any]) -> Dict[str, Any]:
+        try:
+            return json.loads(json.dumps(dict(event), default=str))
+        except Exception:
+            return {str(k): str(v) for k, v in dict(event).items()}
+
+    def events(self) -> List[Dict[str, Any]]:
+        return [dict(e) for e in self.data.get("events", []) if isinstance(e, dict)]
+
+    async def async_save_events(self, events: Iterable[Mapping[str, Any]]):
+        self.data["events"] = [
+            self._json_safe_event(event)
+            for event in events or []
+            if isinstance(event, Mapping)
+        ]
+        await self.async_save()
+
+
 class AkuvoxGroupsStore(Store):
     def __init__(self, hass: HomeAssistant):
         super().__init__(hass, 1, GROUPS_STORAGE_KEY)
@@ -7290,6 +7328,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         root["settings_store"] = settings
 
     settings_store = root.get("settings_store")
+
+    if "access_history_store" not in root:
+        access_history_store = AkuvoxAccessHistoryStore(hass)
+        await access_history_store.async_load()
+        root["access_history_store"] = access_history_store
+
+    history = root.get("access_history")
+    access_history_store = root.get("access_history_store")
+    if history and access_history_store and hasattr(access_history_store, "events"):
+        try:
+            access_limit = (
+                settings_store.get_access_history_limit()
+                if settings_store and hasattr(settings_store, "get_access_history_limit")
+                else DEFAULT_ACCESS_HISTORY_LIMIT
+            )
+        except Exception:
+            access_limit = DEFAULT_ACCESS_HISTORY_LIMIT
+        try:
+            history.ingest(access_history_store.events(), access_limit)
+        except Exception:
+            pass
+
     users_store = root.get("users_store")
     if settings_store and users_store and hasattr(settings_store, "prune_stale_alert_users"):
         try:

--- a/custom_components/akuvox_ac/tests/test_open_gate.py
+++ b/custom_components/akuvox_ac/tests/test_open_gate.py
@@ -56,6 +56,27 @@ class _AuthStub:
         return SimpleNamespace(id=user_id, name="DJGLTD")
 
 
+class _HistoryStoreStub:
+    def __init__(self):
+        self.events = []
+        self.save_calls = 0
+
+    async def async_save_events(self, events):
+        self.events = [dict(event) for event in events]
+        self.save_calls += 1
+
+
+class _HassStub(SimpleNamespace):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.created_tasks = []
+
+    def async_create_task(self, coro):
+        task = asyncio.create_task(coro)
+        self.created_tasks.append(task)
+        return task
+
+
 def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
     api = _ApiStub()
     coordinator = _CoordinatorStub()
@@ -110,6 +131,59 @@ def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
     assert history[0]["_category"] == "access"
     assert history[0]["LinkedUserID"] == "HA001"
     assert history[0]["LinkedUserName"] == "Daniel"
+
+
+def test_open_gate_persists_home_assistant_event_for_restart_recovery():
+    async def _run():
+        api = _ApiStub()
+        coordinator = _CoordinatorStub()
+        history_store = _HistoryStoreStub()
+        root = {
+            "access_history": AccessHistory(),
+            "access_history_store": history_store,
+            "users_store": _UsersStoreStub(
+                {
+                    "HA001": {
+                        "name": "Daniel",
+                        "ha_user_id": "ha-user-1",
+                    }
+                }
+            ),
+            "entry-1": {
+                "api": api,
+                "coordinator": coordinator,
+                "options": {
+                    "relay_roles": {
+                        "relay_a": "door",
+                        "relay_b": "alarm",
+                    }
+                },
+            },
+        }
+        hass = _HassStub(data={DOMAIN: root})
+
+        await async_open_gate(
+            hass,
+            root,
+            entry_id="entry-1",
+            triggered_by_id="ha-user-1",
+            triggered_by_name="DJGLTD",
+        )
+        if hass.created_tasks:
+            await asyncio.gather(*hass.created_tasks)
+
+        assert history_store.save_calls == 1
+        assert len(history_store.events) == 1
+        assert history_store.events[0]["_source"] == "home_assistant"
+        assert history_store.events[0]["Event"] == "Opened with Home Assistant by Daniel"
+
+        restored = AccessHistory()
+        restored.ingest(history_store.events, 5)
+        restored_events = restored.snapshot(5)
+        assert restored_events[0]["Event"] == "Opened with Home Assistant by Daniel"
+        assert restored_events[0]["LinkedUserName"] == "Daniel"
+
+    asyncio.run(_run())
 
 
 def test_open_gate_resolves_raw_home_assistant_context_user_id():


### PR DESCRIPTION
## What changed
- Added a persistent access-history store (`akuvox_ac_access_history.json`) and hydrate the in-memory history from it during integration setup.
- Persist aggregated access-history snapshots whenever new device log entries or synthetic Home Assistant/open-gate events are merged.
- Persist history pruning when the access-event limit is changed.
- Added regression coverage proving `open_gate` writes the Home Assistant event into the persistent history and that a fresh `AccessHistory` can restore it.

## Why
`last_access` already survived restarts because it lives in each device's persistent state file. The dashboard access-event log was in memory only, so synthetic entries such as `Opened with Home Assistant by Daniel` disappeared after Home Assistant rebooted while the user table still showed the correct last-access time.

Persisting the rendered event-history source is more reliable than scraping Home Assistant logs on startup, because HA logbook/recorder retention and service-call context are not guaranteed to contain these synthetic access events.

## Validation
- Python syntax parse for the touched backend modules and test file.
- Manually invoked `test_open_gate.py` with the Home Assistant stubs because pytest is not installed in this runtime.
- Manual AccessHistory change-flag check.
- `git diff --check`.