### PR TITLE
[codex] Fix UI face upload 500

### DIFF
--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -6862,7 +6862,11 @@ class AkuvoxUIUploadFace(HomeAssistantView):
 
     async def post(self, request: web.Request):
         hass: HomeAssistant = request.app["hass"]
-        if not _request_can_access_dashboard(hass, request):
+        has_dashboard_access = _request_can_access_dashboard(hass, request)
+        self_service = (
+            None if has_dashboard_access else _request_self_service_context(hass, request)
+        )
+        if not has_dashboard_access and not self_service:
             return _dashboard_access_denied_response()
         root = hass.data.get(DOMAIN, {}) or {}
 

--- a/custom_components/akuvox_ac/tests/test_ui_upload_face.py
+++ b/custom_components/akuvox_ac/tests/test_ui_upload_face.py
@@ -1,0 +1,95 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac import http as http_module  # noqa: E402
+from custom_components.akuvox_ac.const import DOMAIN  # noqa: E402
+
+
+class _ConfigStub:
+    internal_url = "http://ha.local"
+    external_url = None
+
+    def __init__(self, root):
+        self.root = Path(root)
+
+    def path(self, *parts):
+        return str(self.root.joinpath(*parts))
+
+
+class _UsersStoreStub:
+    def __init__(self):
+        self.upserts = []
+
+    async def upsert_profile(self, user_id, **kwargs):
+        self.upserts.append((user_id, kwargs))
+
+
+class _SyncQueueStub:
+    def __init__(self):
+        self.marked = 0
+
+    def mark_change(self, *_args, **_kwargs):
+        self.marked += 1
+
+
+class _UploadRequestStub:
+    content_type = "multipart/form-data"
+
+    def __init__(self, hass, form):
+        self.app = {"hass": hass}
+        self.form = form
+        self.headers = {}
+        self.query = {}
+        self._values = {
+            http_module.KEY_HASS_USER: SimpleNamespace(
+                id="admin-user",
+                name="Admin",
+                is_admin=True,
+            )
+        }
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+    async def post(self):
+        return dict(self.form)
+
+
+def test_ui_upload_face_dashboard_request_saves_file_and_marks_profile(tmp_path):
+    users_store = _UsersStoreStub()
+    sync_queue = _SyncQueueStub()
+    hass = SimpleNamespace(
+        config=_ConfigStub(tmp_path),
+        data={DOMAIN: {"users_store": users_store, "sync_queue": sync_queue}},
+    )
+    request = _UploadRequestStub(
+        hass,
+        {
+            "id": "HA001",
+            "file": b"fake-jpeg",
+        },
+    )
+
+    response = asyncio.run(http_module.AkuvoxUIUploadFace().post(request))
+
+    assert response["args"][0]["ok"] is True
+    assert response["args"][0]["face_url"] == "http://ha.local/api/AK_AC/FaceData/HA001.jpg"
+    assert (tmp_path / DOMAIN / "FaceData" / "HA001.jpg").read_bytes() == b"fake-jpeg"
+    assert users_store.upserts == [
+        (
+            "HA001",
+            {
+                "face_url": "http://ha.local/api/AK_AC/FaceData/HA001.jpg",
+                "status": "pending",
+                "face_status": "pending",
+                "face_synced_at": "",
+                "remote_enrol_pending": False,
+            },
+        )
+    ]
+    assert sync_queue.marked == 1


### PR DESCRIPTION
## Summary

Fixes a Home Assistant-side 500 error when saving a new user with a face image from the web dashboard.

## Root Cause

`AkuvoxUIUploadFace.post()` used `self_service` and `has_dashboard_access` later in the upload flow, but the method only checked dashboard access inline and never initialized those variables. Dashboard uploads therefore crashed with a server-side `NameError` before the face file/profile update could complete.

## Changes

- Initializes `has_dashboard_access` and `self_service` at the start of the upload handler.
- Keeps dashboard users on the normal upload path while preserving the linked self-service upload guard.
- Adds a regression test for dashboard face upload that verifies the image is saved, the profile is marked pending, and sync is queued.

## Validation

- `python -m pytest custom_components\akuvox_ac\tests\test_ui_upload_face.py custom_components\akuvox_ac\tests\test_dashboard_auth.py`
- Result: `10 passed`