### PR TITLE
Fix event dates and relay delay handling

### DIFF
--- a/custom_components/akuvox_ac/api.py
+++ b/custom_components/akuvox_ac/api.py
@@ -74,6 +74,12 @@ def _normalize_user_source(record: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
+_RELAY_DELAY_KEYS = {
+    1: "Config.DoorSetting.RELAY.RelayADelay",
+    2: "Config.DoorSetting.RELAY.RelayBDelay",
+}
+
+
 def _truncate_string(value: str, limit: int = 800) -> str:
     """Trim very long strings so diagnostics stay manageable."""
 
@@ -666,6 +672,68 @@ class AkuvoxAPI:
         rels = (primary, *fallbacks)
         return await self._request_attempts("GET", rels, None)
 
+    @staticmethod
+    def _normalize_relay_number(relay_number: Any) -> int:
+        try:
+            relay = int(str(relay_number).strip())
+        except Exception as err:
+            raise ValueError("relay number must be 1 or 2") from err
+        if relay not in (1, 2):
+            raise ValueError("relay number must be 1 or 2")
+        return relay
+
+    @staticmethod
+    def _normalize_relay_delay(delay: Any, *, default: Optional[int] = 20) -> Optional[int]:
+        try:
+            return max(1, min(300, int(float(str(delay).strip()))))
+        except Exception:
+            return default
+
+    async def relay_config(self) -> Dict[str, Any]:
+        """Return the device relay configuration, including hold delays."""
+
+        try:
+            result = await self._get_api("/api/relay/get", "/api/relay/get/")
+            data = result.get("data") if isinstance(result, dict) else None
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            pass
+
+        payload = {
+            "target": "config",
+            "action": "get",
+            "data": {"filter": list(_RELAY_DELAY_KEYS.values())},
+        }
+        result = await self._post_api(payload, rel_paths=("/api/config/get", "/api/"))
+        data = result.get("data") if isinstance(result, dict) else None
+        return data if isinstance(data, dict) else {}
+
+    async def get_relay_delay(self, relay_number: Any = 1) -> Optional[int]:
+        """Return the configured relay hold delay in seconds, if the device exposes it."""
+
+        relay = self._normalize_relay_number(relay_number)
+        key = _RELAY_DELAY_KEYS[relay]
+        config = await self.relay_config()
+        return self._normalize_relay_delay(config.get(key), default=None)
+
+    async def set_relay_delay(self, relay_number: Any = 1, delay: Any = 20) -> Dict[str, Any]:
+        """Set the configured relay hold delay in seconds."""
+
+        relay = self._normalize_relay_number(relay_number)
+        delay_seconds = self._normalize_relay_delay(delay, default=20) or 20
+        key = _RELAY_DELAY_KEYS[relay]
+        payload = {
+            "target": "config",
+            "action": "set",
+            "data": {key: str(delay_seconds)},
+        }
+        result = await self._post_api(payload, rel_paths=("/api/config/set", "/api/"))
+        if isinstance(result, dict):
+            result.setdefault("relay", relay)
+            result.setdefault("delay", delay_seconds)
+        return result
+
     async def trigger_relay(
         self,
         relay_number: Any = 1,
@@ -676,17 +744,8 @@ class AkuvoxAPI:
     ) -> Dict[str, Any]:
         """Trigger an Akuvox relay using the device's authenticated web API."""
 
-        try:
-            relay = int(str(relay_number).strip())
-        except Exception as err:
-            raise ValueError("relay number must be 1 or 2") from err
-        if relay not in (1, 2):
-            raise ValueError("relay number must be 1 or 2")
-
-        try:
-            delay_seconds = max(1, min(300, int(float(str(delay).strip()))))
-        except Exception:
-            delay_seconds = 20
+        relay = self._normalize_relay_number(relay_number)
+        delay_seconds = self._normalize_relay_delay(delay, default=20) or 20
 
         path = (
             "/api/relay/trig"

--- a/custom_components/akuvox_ac/coordinator.py
+++ b/custom_components/akuvox_ac/coordinator.py
@@ -1056,6 +1056,8 @@ class AkuvoxCoordinator(DataUpdateCoordinator):
         if not parsed:
             return 0.0
         try:
+            if parsed.tzinfo is None:
+                return parsed.timestamp()
             return dt_util.as_utc(parsed).timestamp()
         except Exception:
             return 0.0

--- a/custom_components/akuvox_ac/http.py
+++ b/custom_components/akuvox_ac/http.py
@@ -80,6 +80,7 @@ SUPPORT_BUNDLE_VALUE_TEXT_LIMIT = 1200
 EXIT_PERMISSION_MATCH = "match"
 EXIT_PERMISSION_WORKING_DAYS = "working_days"
 EXIT_PERMISSION_ALWAYS = "always"
+_TIME_ONLY_TEXT_RE = re.compile(r"^\d{1,2}:\d{2}(?::\d{2})?(?:\.\d+)?$")
 
 
 def _component_face_dir() -> Path:
@@ -648,6 +649,7 @@ SIGNED_API_PATHS: Dict[str, str] = {
     "service_refresh_events": "/api/services/akuvox_ac/refresh_events",
     "service_reboot_device": "/api/services/akuvox_ac/reboot_device",
     "service_open_gate": "/api/services/akuvox_ac/open_gate",
+    "service_set_relay_delay": "/api/services/akuvox_ac/set_relay_delay",
     "service_delete_user": "/api/services/akuvox_ac/delete_user",
     "service_reactivate_temporary_user": "/api/services/akuvox_ac/reactivate_temporary_user",
 }
@@ -666,6 +668,7 @@ ALLOWED_DASHBOARD_SERVICE_PROXY: Set[str] = {
     "reactivate_temporary_user",
     "reboot_device",
     "refresh_events",
+    "set_relay_delay",
     "set_user_groups",
     "sync_now",
     "upload_face",
@@ -942,6 +945,39 @@ def _json_clone(value: Any) -> Any:
         return value
 
 
+def _event_timestamp_value(event: Mapping[str, Any]) -> str:
+    date_text = _normalize_user_match_value(event.get("Date")) or _normalize_user_match_value(
+        event.get("date")
+    )
+    time_text = _normalize_user_match_value(event.get("Time")) or _normalize_user_match_value(
+        event.get("time")
+    )
+    if date_text and time_text and _TIME_ONLY_TEXT_RE.match(time_text):
+        return f"{date_text} {time_text}"
+
+    for key in (
+        "timestamp",
+        "Timestamp",
+        "DateTime",
+        "datetime",
+        "DateTimeStr",
+        "dateTime",
+        "EventTime",
+        "LogTime",
+        "RecordTime",
+        "CreateTime",
+        "Time",
+        "time",
+    ):
+        text = _normalize_user_match_value(event.get(key))
+        if text:
+            return text
+
+    if date_text and time_text:
+        return f"{date_text} {time_text}"
+    return date_text or time_text
+
+
 def _ingest_history_event(hass: HomeAssistant, event: Dict[str, Any]) -> None:
     if not isinstance(event, dict):
         return
@@ -963,10 +999,10 @@ def _ingest_history_event(hass: HomeAssistant, event: Dict[str, Any]) -> None:
 
     event_copy = dict(event)
 
-    timestamp = event_copy.get("timestamp") or event_copy.get("Time")
+    timestamp = _event_timestamp_value(event_copy)
     if not timestamp:
         timestamp = dt.datetime.utcnow().isoformat() + "Z"
-        event_copy.setdefault("timestamp", timestamp)
+    event_copy.setdefault("timestamp", timestamp)
 
     event_copy["_t"] = AccessHistory._coerce_timestamp(event_copy.get("_t") or timestamp)
 
@@ -3065,7 +3101,20 @@ async def async_open_gate(
     if relay_digit not in (1, 2):
         raise RuntimeError("relay must be 1 or 2")
 
-    result = await api.trigger_relay(relay_digit, delay=delay if delay not in (None, "") else 20)
+    relay_delay = delay if delay not in (None, "") else None
+    if relay_delay is None:
+        relay_delay = 20
+        get_delay = getattr(api, "get_relay_delay", None)
+        if callable(get_delay):
+            try:
+                configured_delay = await get_delay(relay_digit)
+            except Exception as err:
+                _LOGGER.debug("Unable to read relay %s delay: %s", relay_digit, err)
+                configured_delay = None
+            if configured_delay not in (None, ""):
+                relay_delay = configured_delay
+
+    result = await api.trigger_relay(relay_digit, delay=relay_delay)
 
     actor_id = str(triggered_by_id or "").strip()
     actor_name = str(triggered_by_name or "").strip() or actor_id or "HA User"
@@ -3097,6 +3146,8 @@ async def async_open_gate(
         "entry_id": target_entry,
         "timestamp": timestamp,
         "DateTime": timestamp,
+        "Date": now.date().isoformat(),
+        "Time": now.strftime("%H:%M:%S"),
         "Device": device_name,
         "DeviceName": device_name,
         "Event": title,
@@ -3108,6 +3159,8 @@ async def async_open_gate(
         "AccessResult": "Access Granted",
         "Status": "Access Granted",
         "Relay": str(relay_digit),
+        "RelayDelay": str(relay_delay),
+        "RelayDelaySeconds": relay_delay,
         "HomeAssistantUserID": actor_id,
         "HomeAssistantUserName": actor_name,
         "TriggeredBy": display_actor,
@@ -3131,6 +3184,7 @@ async def async_open_gate(
         "ok": True,
         "entry_id": target_entry,
         "relay": relay_digit,
+        "delay": relay_delay,
         "triggered_by": display_actor,
         "ha_user_id": actor_id,
         "ha_user_name": actor_name,
@@ -3546,18 +3600,10 @@ _EVENT_USER_KEYS = (
 
 
 def _event_timestamp_text(event: Dict[str, Any]) -> str:
-    for key in ("timestamp", "Time", "DateTime", "datetime", "EventTime", "LogTime"):
-        text = _normalize_user_match_value(event.get(key))
-        if text:
-            return text
-    date_text = _normalize_user_match_value(event.get("Date")) or _normalize_user_match_value(
-        event.get("date")
-    )
-    time_text = _normalize_user_match_value(event.get("Time")) or _normalize_user_match_value(
-        event.get("time")
-    )
-    if date_text and time_text:
-        return f"{date_text} {time_text}"
+    timestamp_text = _event_timestamp_value(event)
+    if timestamp_text:
+        return timestamp_text
+
     ts_value = AccessHistory._coerce_timestamp(event.get("_t"))
     if ts_value:
         try:
@@ -3986,9 +4032,7 @@ class AkuvoxUIView(HomeAssistantView):
                     return
                 ts_value = AccessHistory._coerce_timestamp(event.get("_t"))
                 if not ts_value:
-                    ts_value = AccessHistory._coerce_timestamp(event.get("timestamp"))
-                if not ts_value:
-                    ts_value = AccessHistory._coerce_timestamp(event.get("Time"))
+                    ts_value = AccessHistory._coerce_timestamp(_event_timestamp_value(event))
                 if ts_value and ts_value > last_event_epoch:
                     last_event_epoch = ts_value
 
@@ -4801,6 +4845,52 @@ class AkuvoxUIAction(AkuvoxUIView):
                         "relay_roles": normalized,
                         "alarm_capable": relay_alarm_capable(normalized),
                         "device_alarm_any": alarm_any,
+                    }
+                )
+            except Exception as e:
+                return err(e)
+
+        if action == "get_relay_config":
+            if not entry_id:
+                return err("entry_id required")
+            try:
+                bucket = root.get(entry_id)
+                if not isinstance(bucket, dict):
+                    return err("device entry not found", code=404)
+                api = bucket.get("api")
+                if not api or not hasattr(api, "relay_config"):
+                    return err("device api is not ready", code=409)
+                config = await api.relay_config()
+                return web.json_response({"ok": True, "relay_config": config})
+            except Exception as e:
+                return err(e)
+
+        if action == "set_relay_delay":
+            if not entry_id:
+                return err("entry_id required")
+            try:
+                bucket = root.get(entry_id)
+                if not isinstance(bucket, dict):
+                    return err("device entry not found", code=404)
+                api = bucket.get("api")
+                if not api or not hasattr(api, "set_relay_delay"):
+                    return err("device api is not ready", code=409)
+                relay = payload.get("relay") or payload.get("relay_number") or payload.get("num") or 1
+                delay = payload.get("delay")
+                result = await api.set_relay_delay(relay, delay)
+                config = {}
+                if hasattr(api, "relay_config"):
+                    try:
+                        config = await api.relay_config()
+                    except Exception:
+                        config = {}
+                return web.json_response(
+                    {
+                        "ok": True,
+                        "relay": result.get("relay", relay) if isinstance(result, dict) else relay,
+                        "delay": result.get("delay", delay) if isinstance(result, dict) else delay,
+                        "relay_config": config,
+                        "device_response": result,
                     }
                 )
             except Exception as e:
@@ -5929,9 +6019,7 @@ class AkuvoxUIDiagnostics(HomeAssistantView):
                 continue
             ts_value = AccessHistory._coerce_timestamp(event.get("_t"))
             if not ts_value:
-                ts_value = AccessHistory._coerce_timestamp(event.get("timestamp"))
-            if not ts_value:
-                ts_value = AccessHistory._coerce_timestamp(event.get("Time"))
+                ts_value = AccessHistory._coerce_timestamp(_event_timestamp_value(event))
             if ts_value and ts_value > last_event_epoch:
                 last_event_epoch = ts_value
 

--- a/custom_components/akuvox_ac/integration.py
+++ b/custom_components/akuvox_ac/integration.py
@@ -8141,6 +8141,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             triggered_by_name=actor_name,
         )
 
+    async def svc_set_relay_delay(call):
+        data = call.data if isinstance(call.data, Mapping) else {}
+        root = hass.data.get(DOMAIN, {})
+        entry_id = str(data.get("entry_id") or "").strip()
+        device_name = str(data.get("device_name") or data.get("device") or data.get("name") or "").strip()
+
+        bucket = root.get(entry_id) if entry_id else None
+        if not isinstance(bucket, dict):
+            matches: List[Dict[str, Any]] = []
+            for value in root.values():
+                if not isinstance(value, dict):
+                    continue
+                api = value.get("api")
+                coord = value.get("coordinator")
+                if not api or not coord:
+                    continue
+                if device_name:
+                    friendly = str(getattr(coord, "device_name", "") or "").strip()
+                    if friendly.lower() != device_name.lower():
+                        continue
+                matches.append(value)
+            if len(matches) == 1:
+                bucket = matches[0]
+            elif device_name:
+                raise ValueError("device_name did not match a configured Akuvox device")
+            else:
+                raise ValueError("entry_id or device_name is required when more than one device is configured")
+
+        api = bucket.get("api") if isinstance(bucket, dict) else None
+        if not api or not hasattr(api, "set_relay_delay"):
+            raise RuntimeError("device API is not ready")
+
+        relay = data.get("relay") or data.get("relay_number") or data.get("num") or 1
+        delay = data.get("delay")
+        await api.set_relay_delay(relay, delay)
+
     async def svc_refresh_events(call):
         entry_id = call.data.get("entry_id")
         root = hass.data[DOMAIN]
@@ -8304,6 +8340,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.services.async_register(DOMAIN, "upload_face", svc_upload_face)
     hass.services.async_register(DOMAIN, "reboot_device", svc_reboot_device)
     hass.services.async_register(DOMAIN, "open_gate", svc_open_gate)
+    hass.services.async_register(DOMAIN, "set_relay_delay", svc_set_relay_delay)
     hass.services.async_register(DOMAIN, "refresh_events", svc_refresh_events)
     hass.services.async_register(DOMAIN, "force_full_sync", svc_force_full_sync)
     hass.services.async_register(DOMAIN, "sync_now", svc_sync_now)

--- a/custom_components/akuvox_ac/services.yaml
+++ b/custom_components/akuvox_ac/services.yaml
@@ -268,6 +268,41 @@ open_gate:
           max: 300
           mode: box
 
+set_relay_delay:
+  name: Set relay delay
+  description: Set a device relay hold time in seconds.
+  fields:
+    entry_id:
+      name: Device entry ID
+      description: Optional when only one Akuvox device is configured. You can use device name instead.
+      required: false
+      selector:
+        text:
+    device_name:
+      name: Device name
+      description: Optional friendly device name, for example Gate.
+      required: false
+      selector:
+        text:
+    relay:
+      name: Relay
+      description: Relay to update.
+      required: true
+      selector:
+        select:
+          options:
+            - "1"
+            - "2"
+    delay:
+      name: Delay
+      description: Relay hold time in seconds.
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 300
+          mode: box
+
 sync_now:
   name: Sync now
   fields:

--- a/custom_components/akuvox_ac/tests/test_api_relay.py
+++ b/custom_components/akuvox_ac/tests/test_api_relay.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from custom_components.akuvox_ac.ha_test_stubs import ensure_homeassistant_stubs
+
+ensure_homeassistant_stubs()
+
+from custom_components.akuvox_ac.api import AkuvoxAPI  # noqa: E402
+
+
+class _RelayApi(AkuvoxAPI):
+    def __init__(self):
+        pass
+
+    async def _get_api(self, *_paths):
+        return {
+            "retcode": 0,
+            "data": {
+                "Config.DoorSetting.RELAY.RelayADelay": "2",
+                "Config.DoorSetting.RELAY.RelayBDelay": "3",
+            },
+        }
+
+    async def _post_api(self, payload, *, rel_paths=None):
+        self.last_payload = payload
+        self.last_paths = tuple(rel_paths or ())
+        return {"retcode": 0}
+
+
+def test_get_relay_delay_reads_device_relay_config():
+    api = _RelayApi()
+
+    assert asyncio.run(api.get_relay_delay(1)) == 2
+    assert asyncio.run(api.get_relay_delay(2)) == 3
+
+
+def test_set_relay_delay_posts_config_set_payload():
+    api = _RelayApi()
+
+    result = asyncio.run(api.set_relay_delay(2, 9))
+
+    assert result["relay"] == 2
+    assert result["delay"] == 9
+    assert api.last_paths == ("/api/config/set", "/api/")
+    assert api.last_payload == {
+        "target": "config",
+        "action": "set",
+        "data": {"Config.DoorSetting.RELAY.RelayBDelay": "9"},
+    }

--- a/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
+++ b/custom_components/akuvox_ac/tests/test_mobile_dashboard_controls.py
@@ -207,3 +207,19 @@ def test_user_last_access_formats_iso_offsets_consistently():
         assert r"[T\s]+" in page
         assert r"(?:Z|[+-]\d{2}:?\d{2})?" in page
         assert usage in page
+
+
+def test_dashboard_event_feed_keeps_date_with_time():
+    dashboard = read_page("index.html")
+    mobile = read_page("index-mob.html")
+
+    assert "function eventTimestampValue(event)" in dashboard
+    assert "function formatEventFeedTimestamp(event)" in dashboard
+    assert "class=\"event-date\"" in dashboard
+    assert "copy.timestamp = rawTs;" in dashboard
+    assert "when.split(' ')[0]" not in dashboard
+    assert "? '' : 'Z'" not in dashboard
+
+    assert "function eventTimestampValue(event)" in mobile
+    assert "copy.timestamp = rawTs;" in mobile
+    assert "? '' : 'Z'" not in mobile

--- a/custom_components/akuvox_ac/tests/test_open_gate.py
+++ b/custom_components/akuvox_ac/tests/test_open_gate.py
@@ -7,12 +7,18 @@ ensure_homeassistant_stubs()
 
 from custom_components.akuvox_ac.access_history import AccessHistory
 from custom_components.akuvox_ac.const import DOMAIN
-from custom_components.akuvox_ac.http import async_open_gate
+from custom_components.akuvox_ac.http import _event_timestamp_text, async_open_gate
 
 
 class _ApiStub:
-    def __init__(self):
+    def __init__(self, relay_delays=None):
         self.calls = []
+        self.relay_delays = relay_delays or {}
+        self.delay_reads = []
+
+    async def get_relay_delay(self, relay_number):
+        self.delay_reads.append(relay_number)
+        return self.relay_delays.get(relay_number)
 
     async def trigger_relay(self, relay_number, *, delay=20, mode=0, level=0):
         self.calls.append(
@@ -124,6 +130,8 @@ def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
     assert event["HomeAssistantUserName"] == "DJGLTD"
     assert event["TriggeredBy"] == "Daniel"
     assert event["UserName"] == "Daniel"
+    assert event["Date"]
+    assert event["Time"]
     assert event["Event"] == "Opened with Home Assistant by Daniel"
 
     history = root["access_history"].snapshot(5)
@@ -131,6 +139,12 @@ def test_open_gate_uses_configured_door_relay_and_publishes_linked_event():
     assert history[0]["_category"] == "access"
     assert history[0]["LinkedUserID"] == "HA001"
     assert history[0]["LinkedUserName"] == "Daniel"
+
+
+def test_event_timestamp_text_combines_device_date_and_time():
+    event = {"Date": "2026-06-27", "Time": "17:57:47"}
+
+    assert _event_timestamp_text(event) == "2026-06-27 17:57:47"
 
 
 def test_open_gate_persists_home_assistant_event_for_restart_recovery():
@@ -277,3 +291,54 @@ def test_open_gate_can_select_device_by_friendly_name():
     assert result["entry_id"] == "entry-gate"
     assert first_api.calls == [{"relay": 1, "delay": 20, "mode": 0, "level": 0}]
     assert second_api.calls == []
+
+
+def test_open_gate_uses_configured_device_relay_delay_by_default():
+    api = _ApiStub(relay_delays={1: 2})
+    coordinator = _CoordinatorStub()
+    root = {
+        "access_history": AccessHistory(),
+        "entry-1": {
+            "api": api,
+            "coordinator": coordinator,
+            "options": {"relay_roles": {"relay_a": "door", "relay_b": "alarm"}},
+        },
+    }
+    hass = SimpleNamespace(data={DOMAIN: root})
+
+    result = asyncio.run(
+        async_open_gate(hass, root, entry_id="entry-1", triggered_by_name="DJGLTD")
+    )
+
+    assert result["delay"] == 2
+    assert api.delay_reads == [1]
+    assert api.calls == [{"relay": 1, "delay": 2, "mode": 0, "level": 0}]
+    assert result["event"]["RelayDelaySeconds"] == 2
+
+
+def test_open_gate_explicit_delay_overrides_device_relay_delay():
+    api = _ApiStub(relay_delays={1: 2})
+    coordinator = _CoordinatorStub()
+    root = {
+        "access_history": AccessHistory(),
+        "entry-1": {
+            "api": api,
+            "coordinator": coordinator,
+            "options": {"relay_roles": {"relay_a": "door", "relay_b": "alarm"}},
+        },
+    }
+    hass = SimpleNamespace(data={DOMAIN: root})
+
+    result = asyncio.run(
+        async_open_gate(
+            hass,
+            root,
+            entry_id="entry-1",
+            delay=7,
+            triggered_by_name="DJGLTD",
+        )
+    )
+
+    assert result["delay"] == 7
+    assert api.delay_reads == []
+    assert api.calls == [{"relay": 1, "delay": 7, "mode": 0, "level": 0}]

--- a/custom_components/akuvox_ac/www/index-mob.html
+++ b/custom_components/akuvox_ac/www/index-mob.html
@@ -1424,7 +1424,13 @@ function formatWhen(ts){
   if (!ts) return '—';
   let d = ts instanceof Date ? ts : new Date(ts);
   if (isNaN(d.getTime())) {
-    try { const clean = String(ts).split('.')[0] + 'Z'; d = new Date(clean); }
+    try {
+      const text = String(ts).trim();
+      const normalized = text.includes(' ') && !text.includes('T') ? text.replace(' ', 'T') : text;
+      const zone = (normalized.match(/(Z|[+-]\d{2}:?\d{2})$/i) || [''])[0];
+      const clean = normalized.includes('.') ? normalized.split('.')[0] + zone : normalized;
+      d = new Date(clean);
+    }
     catch { return String(ts); }
   }
   if (isNaN(d.getTime())) return String(ts);
@@ -1433,6 +1439,18 @@ function formatWhen(ts){
   const HH = pad(d.getHours()), mm = pad(d.getMinutes()), SS = pad(d.getSeconds());
   return `${HH}:${mm}:${SS} ${DD}-${MM}-${YYYY}`;
 }
+
+function eventTimestampValue(event){
+  if (!event || typeof event !== 'object') return '';
+  const direct = event._when || event.timestamp || event.Timestamp || event.DateTime || event.datetime || event.EventTime || event.LogTime || event.RecordTime || '';
+  const datePart = event.Date || event.date || event.EventDate || event.LogDate || '';
+  const timePart = event.Time || event.time || '';
+  if (datePart && timePart && /^\d{1,2}:\d{2}(?::\d{2})?$/.test(String(timePart).trim())) {
+    return `${String(datePart).trim()} ${String(timePart).trim()}`;
+  }
+  return direct || timePart || datePart || '';
+}
+
 function parseEventTimestamp(value){
   if (!value) return 0;
   if (value instanceof Date) return isNaN(value.getTime()) ? 0 : value.getTime();
@@ -1482,12 +1500,12 @@ function applyEventFilter(){
   const listEl = document.getElementById('eventList');
   if (!listEl) return;
   const html = list.map(e => {
-    const when = formatWhen(e.timestamp || e.Time || '');
+    const when = formatWhen(eventTimestampValue(e));
     const info = describeEventForDisplay(e);
     const cls = classifyEvent(e, info.highlight);
     return `<li class="event-item" data-category="${info.category}">
       <span class="event-title ${cls}">${escapeHtml(info.title)}</span>
-      <div class="event-time">${when}</div>
+      <div class="event-time">${escapeHtml(when)}</div>
     </li>`;
   }).join('');
   const emptyMessage = EVENT_EMPTY_MESSAGES[eventFilterMode] || EVENT_EMPTY_MESSAGES.all;
@@ -1509,9 +1527,10 @@ function renderEvents(devs, aggregated){
       seen.add(key);
     }
     if (typeof copy._t !== 'number') {
-      const rawTs = copy.timestamp || copy.Time || '';
+      const rawTs = eventTimestampValue(copy);
       const parsed = parseEventTimestamp(rawTs);
       copy._t = parsed || Number(copy._t) || 0;
+      if (!copy.timestamp && rawTs) copy.timestamp = rawTs;
     }
     copy._category = normalizeEventCategory(copy._category) || categorizeEvent(copy);
     copy._device = copy._device || copy.device || '';
@@ -1521,9 +1540,9 @@ function renderEvents(devs, aggregated){
   (devs || []).forEach(d => {
     const deviceName = safeDeviceName(d);
     (d.events || []).forEach(e => {
-      let ts = e.timestamp || e.Time || '';
+      let ts = eventTimestampValue(e);
       const parsed = parseEventTimestamp(ts);
-      const copy = { ...e, _device: deviceName, _t: parsed || 0 };
+      const copy = { ...e, timestamp: e.timestamp || ts, _device: deviceName, _t: parsed || 0 };
       copy._category = normalizeEventCategory(copy._category) || categorizeEvent(copy, d);
       const keyBase = copy._key || `${deviceName}|${ts || ''}|${copy.Event || copy.Result || ''}`;
       const key = keyBase ? String(keyBase) : '';

--- a/custom_components/akuvox_ac/www/index.html
+++ b/custom_components/akuvox_ac/www/index.html
@@ -117,13 +117,14 @@
     .small-mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.82rem}
     .event-list{list-style:none;padding:0;margin:0}
     .event-item{
-      display:grid;grid-template-columns:34px 70px minmax(0,1fr) auto;align-items:center;gap:10px;
+      display:grid;grid-template-columns:34px 145px minmax(0,1fr) auto;align-items:center;gap:10px;
       min-height:48px;padding:8px 14px;border-bottom:1px solid rgba(42,63,87,.66);
     }
     .event-icon{width:27px;height:27px;border-radius:7px;display:grid;place-items:center;background:#10472f;color:var(--ok)}
     .event-icon.bad{background:#4c222b;color:#ff6972}
     .event-icon.call{background:#10472f;color:var(--ok)}
-    .event-time{font-size:.75rem;color:#d1dbe6;font-variant-numeric:tabular-nums}
+    .event-time{display:flex;align-items:center;gap:22px;font-size:.75rem;color:#d1dbe6;font-variant-numeric:tabular-nums;white-space:nowrap}
+    .event-date{color:#9fb0c4}
     .event-title{font-size:.76rem;color:#eaf1f8;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .event-result{font-size:.74rem;white-space:nowrap}
     .event-result.ok{color:var(--ok)} .event-result.bad{color:var(--bad)} .event-result.dim{color:#68a9ff}
@@ -279,7 +280,7 @@
       .summary-icon{width:46px;height:46px;flex-basis:46px;font-size:1.2rem}
       .summary-value{font-size:1.25rem}
       .card-header{padding:11px 12px}
-      .event-item{grid-template-columns:30px 58px minmax(0,1fr);gap:7px;padding:8px 10px}
+      .event-item{grid-template-columns:30px 128px minmax(0,1fr);gap:7px;padding:8px 10px}
       .event-result{grid-column:3;justify-self:start}
       .device-overview-list{padding:10px}
       .device-overview-card{grid-template-columns:92px minmax(0,1fr);padding:12px;gap:12px}
@@ -1736,7 +1737,13 @@ function formatWhen(ts){
   if (!ts) return '—';
   let d = ts instanceof Date ? ts : new Date(ts);
   if (isNaN(d.getTime())) {
-    try { const clean = String(ts).split('.')[0] + 'Z'; d = new Date(clean); }
+    try {
+      const text = String(ts).trim();
+      const normalized = text.includes(' ') && !text.includes('T') ? text.replace(' ', 'T') : text;
+      const zone = (normalized.match(/(Z|[+-]\d{2}:?\d{2})$/i) || [''])[0];
+      const clean = normalized.includes('.') ? normalized.split('.')[0] + zone : normalized;
+      d = new Date(clean);
+    }
     catch { return String(ts); }
   }
   if (isNaN(d.getTime())) return String(ts);
@@ -1745,6 +1752,29 @@ function formatWhen(ts){
   const HH = pad(d.getHours()), mm = pad(d.getMinutes()), SS = pad(d.getSeconds());
   return `${HH}:${mm}:${SS} ${DD}-${MM}-${YYYY}`;
 }
+
+function eventTimestampValue(event){
+  if (!event || typeof event !== 'object') return '';
+  const direct = event._when || event.timestamp || event.Timestamp || event.DateTime || event.datetime || event.EventTime || event.LogTime || event.RecordTime || '';
+  const datePart = event.Date || event.date || event.EventDate || event.LogDate || '';
+  const timePart = event.Time || event.time || '';
+  if (datePart && timePart && /^\d{1,2}:\d{2}(?::\d{2})?$/.test(String(timePart).trim())) {
+    return `${String(datePart).trim()} ${String(timePart).trim()}`;
+  }
+  return direct || timePart || datePart || '';
+}
+
+function formatEventFeedTimestamp(event){
+  const when = formatWhen(eventTimestampValue(event));
+  const parts = String(when || '—').trim().split(/\s+/).filter(Boolean);
+  if (parts.length < 2) {
+    return `<span>${escapeHtml(when || '—')}</span>`;
+  }
+  const time = parts.shift();
+  const date = parts.join(' ');
+  return `<span>${escapeHtml(time)}</span><span class="event-date">${escapeHtml(date)}</span>`;
+}
+
 function parseEventTimestamp(value){
   if (!value) return 0;
   if (value instanceof Date) return isNaN(value.getTime()) ? 0 : value.getTime();
@@ -1787,8 +1817,7 @@ function applyEventFilter(){
   const listEl = $('#eventList');
   if (!listEl) return;
   const html = list.map(e => {
-    const when = formatWhen(e.timestamp || e.Time || '');
-    const time = when.split(' ')[0] || '—';
+    const when = formatEventFeedTimestamp(e);
     const info = describeEventForDisplay(e);
     const cls  = classifyEvent(e, info.highlight);
     const iconClass = cls === 'bad' ? 'bad' : (info.category === 'call' ? 'call' : '');
@@ -1802,7 +1831,7 @@ function applyEventFilter(){
         : (cls === 'bad' ? 'Access Denied' : cls === 'ok' ? 'Access Granted' : 'Access Event');
     return `<li class="event-item" data-category="${info.category}">
       <span class="event-icon ${iconClass}"><i class="bi ${icon}"></i></span>
-      <span class="event-time">${escapeHtml(time)}</span>
+      <span class="event-time">${when}</span>
       <span class="event-title">${escapeHtml(info.title)}</span>
       <span class="event-result ${cls}">● ${escapeHtml(result)}</span>
     </li>`;
@@ -1826,9 +1855,10 @@ function renderEvents(devs, aggregated){
       seen.add(key);
     }
     if (typeof copy._t !== 'number') {
-      const rawTs = copy.timestamp || copy.Time || '';
+      const rawTs = eventTimestampValue(copy);
       const parsed = parseEventTimestamp(rawTs);
       copy._t = parsed || Number(copy._t) || 0;
+      if (!copy.timestamp && rawTs) copy.timestamp = rawTs;
     }
     copy._category = normalizeEventCategory(copy._category) || categorizeEvent(copy);
     copy._device = copy._device || copy.device || '';
@@ -1838,10 +1868,11 @@ function renderEvents(devs, aggregated){
   (devs || []).forEach(d => {
     const deviceName = safeDeviceName(d);
     (d.events || []).forEach(e => {
-      let ts = e.timestamp || e.Time || '';
+      let ts = eventTimestampValue(e);
       const parsed = parseEventTimestamp(ts);
       const copy = {
         ...e,
+        timestamp: e.timestamp || ts,
         _device: deviceName,
         _t: parsed || 0,
         _category: categorizeEvent(e, d),


### PR DESCRIPTION
## Summary
- Show both time and date in the live access feed and preserve device `Date` + `Time` values for sorting/history.
- Normalize Home Assistant access events with full timestamps and fix local-time handling for device door-log timestamps.
- Add relay delay get/set support and use the device's configured relay delay when opening the gate from the dashboard unless a delay is explicitly supplied.

## Device check
- Read `https://10.30.0.73/api/relay/get`: Relay A delay = 2 seconds, Relay B delay = 2 seconds.
- Read the device door log: latest access rows were present for 2026-06-27, matching the dashboard feed, with separate `Date` and `Time` fields.

## Tests
- `python -m pytest custom_components/akuvox_ac/tests` passed: 191 passed, 4 existing coroutine-stub warnings.
- `git diff --check` passed with CRLF warnings only.