### PR TITLE
[codex] Use PR number release versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Follow the repository release process.
 - Do not use Git commit SHAs as user-facing release versions.
 - User-facing versions must follow Semantic Versioning: `vMAJOR.MINOR.PATCH`.
+- User-facing release versions are derived from the merged pull request number: PR `#416` becomes `v4.1.6`, PR `#500` becomes `v5.0.0`.
 - Do not manually invent or hardcode the next release number unless explicitly asked.
 - Assume release tags are created automatically by CI after merge to `main`.
 
@@ -20,10 +21,7 @@ Examples:
 - `feat!: replace legacy authentication flow`
 
 ## Pull request rules
-- In PR summaries, briefly state the expected release impact:
-  - patch
-  - minor
-  - major
+- In PR summaries, briefly state that the release version will follow the merged pull request number.
 - Keep release notes user-facing and concise.
 
 ## Version file rule

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ This integration supports **config flow** (Settings → Devices & services → A
 Follow the on‑screen steps. See the in‑integration options and services for details.
 
 ## Release Versioning
-Releases start at `v3.1.0`. The integration manifest and dashboard version label are updated by the release workflow so HACS and Home Assistant show release versions instead of commit hashes.
+Release versions are derived from the merged pull request number. The integration manifest and dashboard version label are updated by the release workflow so HACS and Home Assistant show release versions instead of commit hashes.
 
-- Small fixes and routine changes use patch versions, for example `3.1.0` → `3.1.1`.
-- Larger feature changes use minor versions, for example `3.1.x` → `3.2.0`.
-- Every merged PR or direct commit to `main` creates at least a patch release.
-- Use `feat:`, `[minor]`, `[feature]`, or `[major]` in the PR title or commit message for the next minor release.
+- PR `#416` releases as `v4.1.6`.
+- PR `#500` releases as `v5.0.0`.
+- PR `#525` releases as `v5.2.5`.
+- PR `#555` releases as `v5.5.5`.
+- Direct commits to `main` without an associated pull request do not create a release.
 
 ## Notes
 - Web assets (in `custom_components/akuvox_ac/www/`) are served via `/api/AK_AC/...` and require Home Assistant authentication (cookie session or long‑lived token).

--- a/custom_components/akuvox_ac/const.py
+++ b/custom_components/akuvox_ac/const.py
@@ -3,8 +3,8 @@ from homeassistant.const import Platform
 
 DOMAIN = "akuvox_ac"
 
-INTEGRATION_VERSION = "3.12.33"
-INTEGRATION_VERSION_LABEL = "3.12.33"
+INTEGRATION_VERSION = "4.1.7"
+INTEGRATION_VERSION_LABEL = "4.1.7"
 
 # Bump when you change stored config structure
 ENTRY_VERSION = 3

--- a/custom_components/akuvox_ac/manifest.json
+++ b/custom_components/akuvox_ac/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "akuvox_ac",
   "name": "Akuvox Access Control",
-  "version": "3.12.33",
+  "version": "4.1.7",
   "codeowners": [
     "@you"
   ],

--- a/custom_components/akuvox_ac/tests/test_release_pr_version.py
+++ b/custom_components/akuvox_ac/tests/test_release_pr_version.py
@@ -1,0 +1,41 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "release-pr-version.cjs"
+
+
+@pytest.mark.parametrize(
+    ("pr_number", "version"),
+    [
+        ("416", "4.1.6"),
+        ("500", "5.0.0"),
+        ("525", "5.2.5"),
+        ("555", "5.5.5"),
+    ],
+)
+def test_release_version_matches_pull_request_number(pr_number, version):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for release script validation")
+
+    result = subprocess.run(
+        [node, str(SCRIPT), "--version-from-pr", pr_number],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == version
+
+
+def test_release_script_uses_pull_request_number_as_source_of_truth():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "const version = versionFromPrNumber(associatedPr.number);" in source
+    assert "nextVersion(" not in source

--- a/scripts/release-pr-version.cjs
+++ b/scripts/release-pr-version.cjs
@@ -81,38 +81,6 @@ function compareVersions(left, right) {
   return 0;
 }
 
-function nextVersion(previousTag, pr) {
-  const parts = String(previousTag || "")
-    .replace(/^v/, "")
-    .split(".")
-    .map(Number);
-  if (
-    parts.length < 3
-    || parts.slice(0, 3).some((part) => !Number.isInteger(part) || part < 0)
-  ) {
-    throw new Error(`Invalid previous version tag: ${previousTag}`);
-  }
-
-  const title = String(pr?.title || "").trim();
-  const body = String(pr?.body || "");
-  const breaking = /^[a-z]+(?:\([^)]*\))?!:/i.test(title)
-    || /(^|\n)BREAKING CHANGE:/i.test(body);
-  const feature = /^feat(?:\([^)]*\))?:/i.test(title);
-
-  let [major, minor, patch] = parts;
-  if (breaking) {
-    major += 1;
-    minor = 0;
-    patch = 0;
-  } else if (feature) {
-    minor += 1;
-    patch = 0;
-  } else {
-    patch += 1;
-  }
-  return `${major}.${minor}.${patch}`;
-}
-
 async function githubJson(url) {
   const headers = {
     Accept: "application/vnd.github+json",
@@ -326,15 +294,6 @@ async function main() {
     console.log(pr?.number || "");
     return;
   }
-  if (process.argv[2] === "--next-version") {
-    console.log(
-      nextVersion(process.argv[3], {
-        title: process.argv[4] || "",
-        body: process.argv[5] || "",
-      }),
-    );
-    return;
-  }
 
   const associatedPr = await associatedPullRequest();
   if (!associatedPr?.number) {
@@ -344,9 +303,7 @@ async function main() {
 
   const pr = await pullRequestDetails(associatedPr.number);
   const previousTag = latestVersionTag();
-  const version = previousTag
-    ? nextVersion(previousTag, pr)
-    : versionFromPrNumber(associatedPr.number);
+  const version = versionFromPrNumber(associatedPr.number);
   const tag = `v${version}`;
 
   if (tagExists(tag)) {


### PR DESCRIPTION
## Summary
- force release automation to derive the version from the merged PR number every time
- correct the checked-in integration version to `4.1.7`, matching latest merged PR #417
- document the PR-number versioning scheme and add tests for the requested mappings

## Expected release
This PR should release using its merged PR number. If this is PR #418, the release workflow should publish `v4.1.8` after merge.

## Validation
- `node scripts/release-pr-version.cjs --version-from-pr 416` -> `4.1.6`
- `node scripts/release-pr-version.cjs --version-from-pr 500` -> `5.0.0`
- `node scripts/release-pr-version.cjs --version-from-pr 525` -> `5.2.5`
- `node scripts/release-pr-version.cjs --version-from-pr 555` -> `5.5.5`
- `python -m pytest custom_components\akuvox_ac\tests`
- `git diff --check`